### PR TITLE
Add company filter to list_employees tool

### DIFF
--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -15,18 +15,22 @@ from mcp_server_check.helpers import (
 
 async def list_employees(
     ctx: Ctx,
+    company: str | None = None,
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List employees across all companies in your Check account.
+    """List employees, optionally filtered by company.
 
     Args:
+        company: Filter to employees belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific employee IDs.
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if ids:


### PR DESCRIPTION
## Summary

- Adds the `company` query parameter to the `list_employees` MCP tool, allowing the LLM to filter employees by company ID

## Context

While testing the MCP server to see if it could generate a per-company employee tax withholding report (the kind of report Mason HR has been requesting from us manually), I found that `list_employees` had no way to filter by company. The tool only supported `limit`, `ids`, and `cursor`.

This meant the LLM couldn't scope employee lookups to a specific company — it would get back up to 100 employees across all companies with no way to identify which belonged to the target company. The Check API already supports `?company=com_xxxxx` on `GET /employees`, so this just exposes that existing parameter in the tool definition.

## Test plan

- [ ] Boot Claude Code with the Check MCP server configured
- [ ] Ask it to list employees for a specific company by ID
- [ ] Verify only employees from that company are returned
- [ ] Ask it to generate a per-company report (e.g. employee W-4 withholding settings) and verify it can scope the data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)