### PR TITLE
Add missing filters to all list endpoints

### DIFF
--- a/src/mcp_server_check/tools/bank_accounts.py
+++ b/src/mcp_server_check/tools/bank_accounts.py
@@ -15,15 +15,21 @@ from mcp_server_check.helpers import (
 
 
 async def list_bank_accounts(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List bank accounts across all companies.
+    """List bank accounts, optionally filtered by company.
 
     Args:
+        company: Filter to bank accounts belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -18,15 +18,21 @@ from mcp_server_check.helpers import (
 
 
 async def list_pay_schedules(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List pay schedules across all companies.
+    """List pay schedules, optionally filtered by company.
 
     Args:
+        company: Filter to pay schedules belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -155,15 +161,25 @@ async def get_pay_schedule_paydays(
 
 
 async def list_benefits(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    employee: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List employee benefits across all companies.
+    """List employee benefits, optionally filtered by company or employee.
 
     Args:
+        company: Filter to benefits belonging to this Check company ID (e.g. "com_xxxxx").
+        employee: Filter to benefits for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
+    if employee is not None:
+        params["employee"] = employee
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -325,15 +341,25 @@ async def delete_benefit(ctx: Ctx, benefit_id: str) -> dict:
 
 
 async def list_post_tax_deductions(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    employee: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List post-tax deductions across all companies.
+    """List post-tax deductions, optionally filtered by company or employee.
 
     Args:
+        company: Filter to post-tax deductions belonging to this Check company ID (e.g. "com_xxxxx").
+        employee: Filter to post-tax deductions for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
+    if employee is not None:
+        params["employee"] = employee
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -461,15 +487,21 @@ async def delete_post_tax_deduction(ctx: Ctx, deduction_id: str) -> dict:
 
 
 async def list_company_benefits(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List company-level benefits across all companies.
+    """List company-level benefits, optionally filtered by company.
 
     Args:
+        company: Filter to company benefits belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -623,15 +655,25 @@ async def delete_company_benefit(ctx: Ctx, company_benefit_id: str) -> dict:
 
 
 async def list_earning_rates(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    employee: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List earning rates across all companies.
+    """List earning rates, optionally filtered by company or employee.
 
     Args:
+        company: Filter to earning rates belonging to this Check company ID (e.g. "com_xxxxx").
+        employee: Filter to earning rates for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
+    if employee is not None:
+        params["employee"] = employee
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -702,15 +744,21 @@ async def update_earning_rate(
 
 
 async def list_earning_codes(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List earning codes across all companies.
+    """List earning codes, optionally filtered by company.
 
     Args:
+        company: Filter to earning codes belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -783,15 +831,25 @@ async def update_earning_code(
 
 
 async def list_net_pay_splits(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    employee: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List net pay splits across all companies.
+    """List net pay splits, optionally filtered by company or employee.
 
     Args:
+        company: Filter to net pay splits belonging to this Check company ID (e.g. "com_xxxxx").
+        employee: Filter to net pay splits for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
+    if employee is not None:
+        params["employee"] = employee
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/src/mcp_server_check/tools/contractor_payments.py
+++ b/src/mcp_server_check/tools/contractor_payments.py
@@ -16,18 +16,26 @@ from mcp_server_check.helpers import (
 
 async def list_contractor_payments(
     ctx: Ctx,
+    company: str | None = None,
+    contractor: str | None = None,
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List contractor payments across all companies.
+    """List contractor payments, optionally filtered by company or contractor.
 
     Args:
+        company: Filter to contractor payments belonging to this Check company ID (e.g. "com_xxxxx").
+        contractor: Filter to payments for this Check contractor ID (e.g. "ctr_xxxxx").
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific contractor payment IDs.
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
+    if contractor is not None:
+        params["contractor"] = contractor
     if limit is not None:
         params["limit"] = limit
     if ids:

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -15,18 +15,22 @@ from mcp_server_check.helpers import (
 
 async def list_contractors(
     ctx: Ctx,
+    company: str | None = None,
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List contractors across all companies in your Check account.
+    """List contractors, optionally filtered by company.
 
     Args:
+        company: Filter to contractors belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific contractor IDs.
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if ids:

--- a/src/mcp_server_check/tools/external_payrolls.py
+++ b/src/mcp_server_check/tools/external_payrolls.py
@@ -16,18 +16,22 @@ from mcp_server_check.helpers import (
 
 async def list_external_payrolls(
     ctx: Ctx,
+    company: str | None = None,
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List external payrolls across all companies.
+    """List external payrolls, optionally filtered by company.
 
     Args:
+        company: Filter to external payrolls belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific external payroll IDs.
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if ids:

--- a/src/mcp_server_check/tools/forms.py
+++ b/src/mcp_server_check/tools/forms.py
@@ -13,15 +13,21 @@ from mcp_server_check.helpers import (
 
 
 async def list_forms(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List forms across all companies.
+    """List forms, optionally filtered by company.
 
     Args:
+        company: Filter to forms belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/src/mcp_server_check/tools/payments.py
+++ b/src/mcp_server_check/tools/payments.py
@@ -13,15 +13,21 @@ from mcp_server_check.helpers import (
 
 
 async def list_payments(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List payments across all companies.
+    """List payments, optionally filtered by company.
 
     Args:
+        company: Filter to payments belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/src/mcp_server_check/tools/payroll_items.py
+++ b/src/mcp_server_check/tools/payroll_items.py
@@ -16,18 +16,30 @@ from mcp_server_check.helpers import (
 
 async def list_payroll_items(
     ctx: Ctx,
+    company: str | None = None,
+    employee: str | None = None,
+    payroll: str | None = None,
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List payroll items across all payrolls.
+    """List payroll items, optionally filtered by company, employee, or payroll.
 
     Args:
+        company: Filter to payroll items belonging to this Check company ID (e.g. "com_xxxxx").
+        employee: Filter to payroll items for this Check employee ID (e.g. "emp_xxxxx").
+        payroll: Filter to payroll items for this Check payroll ID (e.g. "prl_xxxxx").
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific payroll item IDs.
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
+    if employee is not None:
+        params["employee"] = employee
+    if payroll is not None:
+        params["payroll"] = payroll
     if limit is not None:
         params["limit"] = limit
     if ids:

--- a/src/mcp_server_check/tools/payrolls.py
+++ b/src/mcp_server_check/tools/payrolls.py
@@ -16,18 +16,22 @@ from mcp_server_check.helpers import (
 
 async def list_payrolls(
     ctx: Ctx,
+    company: str | None = None,
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List payrolls across all companies in your Check account.
+    """List payrolls, optionally filtered by company.
 
     Args:
+        company: Filter to payrolls belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific payroll IDs.
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if ids:

--- a/src/mcp_server_check/tools/platform.py
+++ b/src/mcp_server_check/tools/platform.py
@@ -17,15 +17,21 @@ from mcp_server_check.helpers import (
 
 
 async def list_notifications(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List notifications.
+    """List notifications, optionally filtered by company.
 
     Args:
+        company: Filter to notifications belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -46,15 +52,21 @@ async def get_notification(ctx: Ctx, notification_id: str) -> dict:
 
 
 async def list_communications(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List communications.
+    """List communications, optionally filtered by company.
 
     Args:
+        company: Filter to communications belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -425,15 +437,21 @@ async def validate_address(
 
 
 async def list_setups(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List setups.
+    """List setups, optionally filtered by company.
 
     Args:
+        company: Filter to setups belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -454,15 +472,21 @@ async def get_setup(ctx: Ctx, setup_id: str) -> dict:
 
 
 async def list_requirements(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List requirements.
+    """List requirements, optionally filtered by company.
 
     Args:
+        company: Filter to requirements belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -112,15 +112,21 @@ async def list_company_jurisdictions(
 
 
 async def list_employee_tax_params(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    employee: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List employee tax parameters across all companies.
+    """List employee tax parameters, optionally filtered by employee.
 
     Args:
+        employee: Filter to tax parameters for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if employee is not None:
+        params["employee"] = employee
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -352,15 +358,21 @@ async def update_employee_tax_elections(
 
 
 async def list_tax_filings(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List tax filings across all companies.
+    """List tax filings, optionally filtered by company.
 
     Args:
+        company: Filter to tax filings belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -428,15 +440,21 @@ async def update_exempt_status(ctx: Ctx, employee_id: str, data: dict) -> dict:
 
 
 async def list_exemptible_taxes(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List exemptible taxes.
+    """List exemptible taxes, optionally filtered by company.
 
     Args:
+        company: Filter to exemptible taxes belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:
@@ -471,15 +489,21 @@ async def bulk_update_exemptible_taxes(ctx: Ctx, data: dict) -> dict:
 
 
 async def list_employee_tax_statements(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    employee: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List employee tax statements.
+    """List employee tax statements, optionally filtered by employee.
 
     Args:
+        employee: Filter to tax statements for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if employee is not None:
+        params["employee"] = employee
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/src/mcp_server_check/tools/webhooks.py
+++ b/src/mcp_server_check/tools/webhooks.py
@@ -15,15 +15,21 @@ from mcp_server_check.helpers import (
 
 
 async def list_webhook_configs(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    company: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
-    """List webhook configurations.
+    """List webhook configurations, optionally filtered by company.
 
     Args:
+        company: Filter to webhook configs belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/src/mcp_server_check/tools/workplaces.py
+++ b/src/mcp_server_check/tools/workplaces.py
@@ -15,16 +15,20 @@ from mcp_server_check.helpers import (
 
 async def list_workplaces(
     ctx: Ctx,
+    company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List workplaces across all companies in your Check account.
+    """List workplaces, optionally filtered by company.
 
     Args:
+        company: Filter to workplaces belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return (default 10, max 100).
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
+    if company is not None:
+        params["company"] = company
     if limit is not None:
         params["limit"] = limit
     if cursor:


### PR DESCRIPTION
## Summary

- Adds `company`, `employee`, `contractor`, and `payroll` query parameter filters to 25 list endpoints across 13 tool files
- Follows the same pattern established in PR #1 for `list_employees`

## Context

PR #1 fixed `list_employees` missing a `company` filter. Turns out the same problem existed across nearly every list endpoint in the MCP server — `list_contractors`, `list_payrolls`, `list_payroll_items`, `list_benefits`, `list_workplaces`, etc. all returned unscoped results with no way to filter by parent resource.

This makes it impossible for the LLM to do things like "list all payrolls for company X" or "show me all benefits for employee Y" — it just gets back a mixed bag of up to 100 results across all companies.

The Check API already supports these query parameters, so this just exposes them in the MCP tool definitions.

### Changes by filter type

**Company filter added (22 endpoints):** `list_contractors`, `list_payrolls`, `list_payroll_items`, `list_workplaces`, `list_bank_accounts`, `list_pay_schedules`, `list_benefits`, `list_post_tax_deductions`, `list_company_benefits`, `list_earning_rates`, `list_earning_codes`, `list_net_pay_splits`, `list_payments`, `list_webhook_configs`, `list_forms`, `list_notifications`, `list_communications`, `list_setups`, `list_requirements`, `list_tax_filings`, `list_exemptible_taxes`, `list_external_payrolls`, `list_contractor_payments`

**Employee filter added (7 endpoints):** `list_benefits`, `list_post_tax_deductions`, `list_earning_rates`, `list_net_pay_splits`, `list_payroll_items`, `list_employee_tax_params`, `list_employee_tax_statements`

**Contractor filter added (1 endpoint):** `list_contractor_payments`

**Payroll filter added (1 endpoint):** `list_payroll_items`

## Test plan

- [ ] Verify each updated tool accepts the new filter parameters
- [ ] Test `list_payrolls` with a company filter returns only that company's payrolls
- [ ] Test `list_benefits` with an employee filter returns only that employee's benefits
- [ ] Test `list_payroll_items` with a payroll filter returns only that payroll's items
- [ ] End-to-end: ask Claude to generate a full company report (employees, payrolls, benefits, deductions) and verify it scopes all queries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)