### PR TITLE
Add CHECK_READ_ONLY env var for read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ CHECK_API_KEY=your-key uv run mcp-server-check
 |---|---|---|---|
 | `CHECK_API_KEY` | Yes | — | Your Check API key (Bearer token) |
 | `CHECK_API_BASE_URL` | No | `https://sandbox.checkhq.com` | API base URL |
+| `CHECK_READ_ONLY` | No | — | Set to `1`, `true`, or `yes` to disable all write/mutating tools |
 
 ### Sandbox vs Production
 
@@ -33,6 +34,14 @@ To point at production, set:
 
 ```bash
 CHECK_API_BASE_URL=https://api.checkhq.com
+```
+
+### Read-Only Mode
+
+Set `CHECK_READ_ONLY=1` to run the server with only read-only tools (list, get, download, preview, etc.). All create, update, delete, and other mutating tools are excluded. This is useful when you want to allow exploration of your Check data without risk of modifications.
+
+```bash
+CHECK_READ_ONLY=1 CHECK_API_KEY=your-key uvx mcp-server-check
 ```
 
 ## Usage with Claude Desktop

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -28,14 +28,18 @@ async def lifespan(server: FastMCP) -> AsyncIterator[CheckContext]:
         yield CheckContext(client=client, base_url=base_url)
 
 
+read_only = os.environ.get("CHECK_READ_ONLY", "").lower() in ("1", "true", "yes")
+
 mcp = FastMCP("Check Payroll API", lifespan=lifespan)
-register_all(mcp)
+register_all(mcp, read_only=read_only)
 
 
 def main():
     if not os.environ.get("CHECK_API_KEY"):
         print("Error: CHECK_API_KEY environment variable is required", file=sys.stderr)
         sys.exit(1)
+    if read_only:
+        print("Running in read-only mode (CHECK_READ_ONLY is set)", file=sys.stderr)
     mcp.run(transport="stdio")
 
 

--- a/src/mcp_server_check/tools/__init__.py
+++ b/src/mcp_server_check/tools/__init__.py
@@ -45,7 +45,12 @@ _MODULES = [
 ]
 
 
-def register_all(mcp: FastMCP) -> None:
-    """Register tools from every module."""
+def register_all(mcp: FastMCP, *, read_only: bool = False) -> None:
+    """Register tools from every module.
+
+    Args:
+        read_only: When True, only register read-only tools (list/get/download/preview).
+            Write, update, delete, and other mutating tools are skipped.
+    """
     for mod in _MODULES:
-        mod.register(mcp)
+        mod.register(mcp, read_only=read_only)

--- a/src/mcp_server_check/tools/bank_accounts.py
+++ b/src/mcp_server_check/tools/bank_accounts.py
@@ -126,10 +126,11 @@ async def reveal_bank_account_number(ctx: Ctx, bank_account_id: str) -> dict:
     return await check_api_get(ctx, f"/bank_accounts/{bank_account_id}/reveal")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_bank_accounts)
     mcp.add_tool(get_bank_account)
-    mcp.add_tool(create_bank_account)
-    mcp.add_tool(update_bank_account)
-    mcp.add_tool(delete_bank_account)
     mcp.add_tool(reveal_bank_account_number)
+    if not read_only:
+        mcp.add_tool(create_bank_account)
+        mcp.add_tool(update_bank_account)
+        mcp.add_tool(delete_bank_account)

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -749,12 +749,9 @@ async def request_embedded_setup(ctx: Ctx, company_id: str) -> dict:
     return await check_api_post(ctx, f"/companies/{company_id}/request_embedded_setup")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_companies)
     mcp.add_tool(get_company)
-    mcp.add_tool(create_company)
-    mcp.add_tool(update_company)
-    mcp.add_tool(onboard_company)
     mcp.add_tool(get_company_paydays)
     mcp.add_tool(list_company_tax_deposits)
     mcp.add_tool(get_company_benefit_aggregations)
@@ -769,10 +766,14 @@ def register(mcp: FastMCP) -> None:
     mcp.add_tool(list_federal_ein_verifications)
     mcp.add_tool(get_federal_ein_verification)
     mcp.add_tool(list_signatories)
-    mcp.add_tool(create_signatory)
     mcp.add_tool(get_enrollment_profile)
-    mcp.add_tool(create_enrollment_profile)
-    mcp.add_tool(update_enrollment_profile)
-    mcp.add_tool(start_implementation)
-    mcp.add_tool(cancel_implementation)
-    mcp.add_tool(request_embedded_setup)
+    if not read_only:
+        mcp.add_tool(create_company)
+        mcp.add_tool(update_company)
+        mcp.add_tool(onboard_company)
+        mcp.add_tool(create_signatory)
+        mcp.add_tool(create_enrollment_profile)
+        mcp.add_tool(update_enrollment_profile)
+        mcp.add_tool(start_implementation)
+        mcp.add_tool(cancel_implementation)
+        mcp.add_tool(request_embedded_setup)

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -895,43 +895,51 @@ async def create_net_pay_split(
     return await check_api_post(ctx, "/net_pay_splits", data=body)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Pay Schedules
     mcp.add_tool(list_pay_schedules)
     mcp.add_tool(get_pay_schedule)
-    mcp.add_tool(create_pay_schedule)
-    mcp.add_tool(update_pay_schedule)
-    mcp.add_tool(delete_pay_schedule)
     mcp.add_tool(get_pay_schedule_paydays)
     # Benefits
     mcp.add_tool(list_benefits)
     mcp.add_tool(get_benefit)
-    mcp.add_tool(create_benefit)
-    mcp.add_tool(update_benefit)
-    mcp.add_tool(delete_benefit)
     # Post-Tax Deductions
     mcp.add_tool(list_post_tax_deductions)
     mcp.add_tool(get_post_tax_deduction)
-    mcp.add_tool(create_post_tax_deduction)
-    mcp.add_tool(update_post_tax_deduction)
-    mcp.add_tool(delete_post_tax_deduction)
     # Company Benefits
     mcp.add_tool(list_company_benefits)
     mcp.add_tool(get_company_benefit)
-    mcp.add_tool(create_company_benefit)
-    mcp.add_tool(update_company_benefit)
-    mcp.add_tool(delete_company_benefit)
     # Earning Rates
     mcp.add_tool(list_earning_rates)
     mcp.add_tool(get_earning_rate)
-    mcp.add_tool(create_earning_rate)
-    mcp.add_tool(update_earning_rate)
     # Earning Codes
     mcp.add_tool(list_earning_codes)
     mcp.add_tool(get_earning_code)
-    mcp.add_tool(create_earning_code)
-    mcp.add_tool(update_earning_code)
     # Net Pay Splits
     mcp.add_tool(list_net_pay_splits)
     mcp.add_tool(get_net_pay_split)
-    mcp.add_tool(create_net_pay_split)
+    if not read_only:
+        # Pay Schedules
+        mcp.add_tool(create_pay_schedule)
+        mcp.add_tool(update_pay_schedule)
+        mcp.add_tool(delete_pay_schedule)
+        # Benefits
+        mcp.add_tool(create_benefit)
+        mcp.add_tool(update_benefit)
+        mcp.add_tool(delete_benefit)
+        # Post-Tax Deductions
+        mcp.add_tool(create_post_tax_deduction)
+        mcp.add_tool(update_post_tax_deduction)
+        mcp.add_tool(delete_post_tax_deduction)
+        # Company Benefits
+        mcp.add_tool(create_company_benefit)
+        mcp.add_tool(update_company_benefit)
+        mcp.add_tool(delete_company_benefit)
+        # Earning Rates
+        mcp.add_tool(create_earning_rate)
+        mcp.add_tool(update_earning_rate)
+        # Earning Codes
+        mcp.add_tool(create_earning_code)
+        mcp.add_tool(update_earning_code)
+        # Net Pay Splits
+        mcp.add_tool(create_net_pay_split)

--- a/src/mcp_server_check/tools/components.py
+++ b/src/mcp_server_check/tools/components.py
@@ -109,6 +109,8 @@ def _build_tools() -> list[Callable]:
 _ALL_TOOLS = _build_tools()
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
+    if read_only:
+        return
     for tool in _ALL_TOOLS:
         mcp.add_tool(tool)

--- a/src/mcp_server_check/tools/contractor_payments.py
+++ b/src/mcp_server_check/tools/contractor_payments.py
@@ -159,10 +159,11 @@ async def get_contractor_payment_paper_check(
     )
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_contractor_payments)
     mcp.add_tool(get_contractor_payment)
-    mcp.add_tool(create_contractor_payment)
-    mcp.add_tool(update_contractor_payment)
-    mcp.add_tool(delete_contractor_payment)
     mcp.add_tool(get_contractor_payment_paper_check)
+    if not read_only:
+        mcp.add_tool(create_contractor_payment)
+        mcp.add_tool(update_contractor_payment)
+        mcp.add_tool(delete_contractor_payment)

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -311,14 +311,15 @@ async def reveal_contractor_ssn(ctx: Ctx, contractor_id: str) -> dict:
     return await check_api_get(ctx, f"/contractors/{contractor_id}/reveal")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_contractors)
     mcp.add_tool(get_contractor)
-    mcp.add_tool(create_contractor)
-    mcp.add_tool(update_contractor)
-    mcp.add_tool(onboard_contractor)
     mcp.add_tool(list_contractor_payments_for_contractor)
     mcp.add_tool(get_contractor_payment_for_payroll)
     mcp.add_tool(list_contractor_forms)
-    mcp.add_tool(submit_contractor_form)
     mcp.add_tool(reveal_contractor_ssn)
+    if not read_only:
+        mcp.add_tool(create_contractor)
+        mcp.add_tool(update_contractor)
+        mcp.add_tool(onboard_contractor)
+        mcp.add_tool(submit_contractor_form)

--- a/src/mcp_server_check/tools/documents.py
+++ b/src/mcp_server_check/tools/documents.py
@@ -278,7 +278,7 @@ async def upload_company_provided_document_file(
     )
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Company Tax Documents
     mcp.add_tool(list_company_tax_documents)
     mcp.add_tool(get_company_tax_document)
@@ -302,5 +302,6 @@ def register(mcp: FastMCP) -> None:
     # Company Provided Documents
     mcp.add_tool(list_company_provided_documents)
     mcp.add_tool(get_company_provided_document)
-    mcp.add_tool(create_company_provided_document)
-    mcp.add_tool(upload_company_provided_document_file)
+    if not read_only:
+        mcp.add_tool(create_company_provided_document)
+        mcp.add_tool(upload_company_provided_document_file)

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -393,21 +393,22 @@ async def authorize_employee_partner(
     )
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_employees)
     mcp.add_tool(get_employee)
-    mcp.add_tool(create_employee)
-    mcp.add_tool(update_employee)
-    mcp.add_tool(onboard_employee)
     mcp.add_tool(list_employee_paystubs)
     mcp.add_tool(get_employee_paystub)
     mcp.add_tool(list_employee_forms)
     mcp.add_tool(get_employee_form)
-    mcp.add_tool(submit_employee_form)
-    mcp.add_tool(sign_and_submit_employee_form)
     mcp.add_tool(get_employee_company_defined_attributes)
-    mcp.add_tool(update_employee_company_defined_attributes)
     mcp.add_tool(get_employee_reciprocity_elections)
-    mcp.add_tool(update_employee_reciprocity_elections)
     mcp.add_tool(reveal_employee_ssn)
-    mcp.add_tool(authorize_employee_partner)
+    if not read_only:
+        mcp.add_tool(create_employee)
+        mcp.add_tool(update_employee)
+        mcp.add_tool(onboard_employee)
+        mcp.add_tool(submit_employee_form)
+        mcp.add_tool(sign_and_submit_employee_form)
+        mcp.add_tool(update_employee_company_defined_attributes)
+        mcp.add_tool(update_employee_reciprocity_elections)
+        mcp.add_tool(authorize_employee_partner)

--- a/src/mcp_server_check/tools/external_payrolls.py
+++ b/src/mcp_server_check/tools/external_payrolls.py
@@ -162,12 +162,13 @@ async def preview_external_payroll(ctx: Ctx, external_payroll_id: str) -> dict:
     return await check_api_get(ctx, f"/external_payrolls/{external_payroll_id}/preview")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_external_payrolls)
     mcp.add_tool(get_external_payroll)
-    mcp.add_tool(create_external_payroll)
-    mcp.add_tool(update_external_payroll)
-    mcp.add_tool(delete_external_payroll)
-    mcp.add_tool(approve_external_payroll)
-    mcp.add_tool(reopen_external_payroll)
     mcp.add_tool(preview_external_payroll)
+    if not read_only:
+        mcp.add_tool(create_external_payroll)
+        mcp.add_tool(update_external_payroll)
+        mcp.add_tool(delete_external_payroll)
+        mcp.add_tool(approve_external_payroll)
+        mcp.add_tool(reopen_external_payroll)

--- a/src/mcp_server_check/tools/forms.py
+++ b/src/mcp_server_check/tools/forms.py
@@ -69,7 +69,7 @@ async def validate_form(
     return await check_api_post(ctx, f"/forms/{form_id}/validate", data=body)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_forms)
     mcp.add_tool(get_form)
     mcp.add_tool(render_form)

--- a/src/mcp_server_check/tools/payments.py
+++ b/src/mcp_server_check/tools/payments.py
@@ -94,10 +94,11 @@ async def cancel_payment(ctx: Ctx, payment_id: str) -> dict:
     return await check_api_post(ctx, f"/payments/{payment_id}/cancel")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_payments)
     mcp.add_tool(get_payment)
     mcp.add_tool(list_payment_attempts)
-    mcp.add_tool(retry_payment)
-    mcp.add_tool(refund_payment)
-    mcp.add_tool(cancel_payment)
+    if not read_only:
+        mcp.add_tool(retry_payment)
+        mcp.add_tool(refund_payment)
+        mcp.add_tool(cancel_payment)

--- a/src/mcp_server_check/tools/payroll_items.py
+++ b/src/mcp_server_check/tools/payroll_items.py
@@ -184,12 +184,13 @@ async def get_payroll_item_paper_check(ctx: Ctx, payroll_item_id: str) -> dict:
     return await check_api_get(ctx, f"/payroll_items/{payroll_item_id}/paper_check")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_payroll_items)
     mcp.add_tool(get_payroll_item)
-    mcp.add_tool(create_payroll_item)
-    mcp.add_tool(update_payroll_item)
-    mcp.add_tool(bulk_update_payroll_items)
-    mcp.add_tool(delete_payroll_item)
-    mcp.add_tool(bulk_delete_payroll_items)
     mcp.add_tool(get_payroll_item_paper_check)
+    if not read_only:
+        mcp.add_tool(create_payroll_item)
+        mcp.add_tool(update_payroll_item)
+        mcp.add_tool(bulk_update_payroll_items)
+        mcp.add_tool(delete_payroll_item)
+        mcp.add_tool(bulk_delete_payroll_items)

--- a/src/mcp_server_check/tools/payrolls.py
+++ b/src/mcp_server_check/tools/payrolls.py
@@ -302,19 +302,20 @@ async def simulate_complete_disbursements(ctx: Ctx, payroll_id: str) -> dict:
     )
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_payrolls)
     mcp.add_tool(get_payroll)
-    mcp.add_tool(create_payroll)
-    mcp.add_tool(update_payroll)
-    mcp.add_tool(delete_payroll)
     mcp.add_tool(preview_payroll)
-    mcp.add_tool(approve_payroll)
-    mcp.add_tool(reopen_payroll)
     mcp.add_tool(get_payroll_paper_checks)
     mcp.add_tool(get_payroll_cash_requirement_report)
     mcp.add_tool(get_payroll_paper_checks_report)
-    mcp.add_tool(simulate_start_processing)
-    mcp.add_tool(simulate_complete_funding)
-    mcp.add_tool(simulate_fail_funding)
-    mcp.add_tool(simulate_complete_disbursements)
+    if not read_only:
+        mcp.add_tool(create_payroll)
+        mcp.add_tool(update_payroll)
+        mcp.add_tool(delete_payroll)
+        mcp.add_tool(approve_payroll)
+        mcp.add_tool(reopen_payroll)
+        mcp.add_tool(simulate_start_processing)
+        mcp.add_tool(simulate_complete_funding)
+        mcp.add_tool(simulate_fail_funding)
+        mcp.add_tool(simulate_complete_disbursements)

--- a/src/mcp_server_check/tools/platform.py
+++ b/src/mcp_server_check/tools/platform.py
@@ -511,36 +511,28 @@ async def get_applied_for_ids_report(ctx: Ctx) -> dict:
     return await check_api_get(ctx, "/reports/applied_for_ids")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Notifications
     mcp.add_tool(list_notifications)
     mcp.add_tool(get_notification)
     # Communications
     mcp.add_tool(list_communications)
     mcp.add_tool(get_communication)
-    mcp.add_tool(create_communication)
     # Usage
     mcp.add_tool(list_usage_summaries)
     mcp.add_tool(list_usage_records)
     # Integrations
     mcp.add_tool(list_integration_partners)
     mcp.add_tool(get_integration_partner)
-    mcp.add_tool(authorize_integration_partner)
     mcp.add_tool(list_integration_permissions)
     mcp.add_tool(get_integration_permission)
     mcp.add_tool(list_integration_accesses)
     # Accounting Integrations
     mcp.add_tool(list_accounting_accounts)
-    mcp.add_tool(refresh_accounting_accounts)
     mcp.add_tool(get_accounting_mappings)
-    mcp.add_tool(update_accounting_mappings)
-    mcp.add_tool(toggle_accounting_mappings)
-    mcp.add_tool(sync_accounting)
     mcp.add_tool(list_accounting_sync_attempts)
     # Company Groups
     mcp.add_tool(list_company_groups)
-    mcp.add_tool(create_company_group)
-    mcp.add_tool(update_company_group)
     # Addresses
     mcp.add_tool(validate_address)
     # Setups
@@ -551,3 +543,12 @@ def register(mcp: FastMCP) -> None:
     mcp.add_tool(get_requirement)
     # Reports
     mcp.add_tool(get_applied_for_ids_report)
+    if not read_only:
+        mcp.add_tool(create_communication)
+        mcp.add_tool(authorize_integration_partner)
+        mcp.add_tool(refresh_accounting_accounts)
+        mcp.add_tool(update_accounting_mappings)
+        mcp.add_tool(toggle_accounting_mappings)
+        mcp.add_tool(sync_accounting)
+        mcp.add_tool(create_company_group)
+        mcp.add_tool(update_company_group)

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -551,45 +551,46 @@ async def get_tax_package(ctx: Ctx, tax_package_id: str) -> dict:
     return await check_api_get(ctx, f"/tax_packages/{tax_package_id}")
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Company Tax Params
     mcp.add_tool(get_company_tax_params)
-    mcp.add_tool(update_company_tax_params)
     mcp.add_tool(list_company_tax_param_settings)
     mcp.add_tool(get_company_tax_param_setting)
     mcp.add_tool(list_company_jurisdictions)
     # Employee Tax Params
     mcp.add_tool(list_employee_tax_params)
     mcp.add_tool(get_employee_tax_params)
-    mcp.add_tool(update_employee_tax_params)
     mcp.add_tool(list_employee_tax_param_settings)
     mcp.add_tool(get_employee_tax_param_setting)
     mcp.add_tool(list_employee_jurisdictions)
     mcp.add_tool(bulk_get_employee_tax_param_settings)
-    mcp.add_tool(bulk_update_employee_tax_param_settings)
     # Company Tax Elections
     mcp.add_tool(list_company_tax_elections)
-    mcp.add_tool(create_company_tax_elections)
-    mcp.add_tool(update_company_tax_elections)
     # Employee Tax Elections
     mcp.add_tool(list_employee_tax_elections)
-    mcp.add_tool(update_employee_tax_elections)
     # Tax Filings
     mcp.add_tool(list_tax_filings)
     mcp.add_tool(get_tax_filing)
-    mcp.add_tool(request_tax_filing_refile)
     # Tax Filing Events
     mcp.add_tool(get_tax_filing_event)
     # Exempt Status
     mcp.add_tool(get_exempt_status)
-    mcp.add_tool(update_exempt_status)
     # Exemptible Taxes
     mcp.add_tool(list_exemptible_taxes)
-    mcp.add_tool(update_exemptible_tax)
-    mcp.add_tool(bulk_update_exemptible_taxes)
     # Employee Tax Statements
     mcp.add_tool(list_employee_tax_statements)
     mcp.add_tool(get_employee_tax_statement)
     # Tax Packages
-    mcp.add_tool(request_tax_package)
     mcp.add_tool(get_tax_package)
+    if not read_only:
+        mcp.add_tool(update_company_tax_params)
+        mcp.add_tool(update_employee_tax_params)
+        mcp.add_tool(bulk_update_employee_tax_param_settings)
+        mcp.add_tool(create_company_tax_elections)
+        mcp.add_tool(update_company_tax_elections)
+        mcp.add_tool(update_employee_tax_elections)
+        mcp.add_tool(request_tax_filing_refile)
+        mcp.add_tool(update_exempt_status)
+        mcp.add_tool(update_exemptible_tax)
+        mcp.add_tool(bulk_update_exemptible_taxes)
+        mcp.add_tool(request_tax_package)

--- a/src/mcp_server_check/tools/webhooks.py
+++ b/src/mcp_server_check/tools/webhooks.py
@@ -109,11 +109,12 @@ async def retry_webhook_events(ctx: Ctx, data: dict) -> dict:
     return await check_api_post(ctx, "/webhook_events/retry", data=data)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_webhook_configs)
     mcp.add_tool(get_webhook_config)
-    mcp.add_tool(create_webhook_config)
-    mcp.add_tool(update_webhook_config)
-    mcp.add_tool(delete_webhook_config)
-    mcp.add_tool(ping_webhook_config)
-    mcp.add_tool(retry_webhook_events)
+    if not read_only:
+        mcp.add_tool(create_webhook_config)
+        mcp.add_tool(update_webhook_config)
+        mcp.add_tool(delete_webhook_config)
+        mcp.add_tool(ping_webhook_config)
+        mcp.add_tool(retry_webhook_events)

--- a/src/mcp_server_check/tools/workplaces.py
+++ b/src/mcp_server_check/tools/workplaces.py
@@ -106,8 +106,9 @@ async def update_workplace(
     return await check_api_patch(ctx, f"/workplaces/{workplace_id}", data=body)
 
 
-def register(mcp: FastMCP) -> None:
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_workplaces)
     mcp.add_tool(get_workplace)
-    mcp.add_tool(create_workplace)
-    mcp.add_tool(update_workplace)
+    if not read_only:
+        mcp.add_tool(create_workplace)
+        mcp.add_tool(update_workplace)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -256,3 +256,54 @@ async def test_tools_registered():
     )
     # Verify we have a large number of tools registered
     assert len(tools) > 150, f"Expected 150+ tools, got {len(tools)}"
+
+
+@pytest.mark.anyio
+async def test_read_only_mode():
+    """Verify read-only mode excludes all write/mutating tools."""
+    from mcp.server.fastmcp import FastMCP
+    from mcp_server_check.tools import register_all
+
+    read_only_mcp = FastMCP("Test Read-Only")
+    register_all(read_only_mcp, read_only=True)
+    ro_tools = await read_only_mcp.list_tools()
+    ro_names = {t.name for t in ro_tools}
+
+    full_mcp = FastMCP("Test Full")
+    register_all(full_mcp, read_only=False)
+    full_tools = await full_mcp.list_tools()
+    full_names = {t.name for t in full_tools}
+
+    # Read-only should be a strict subset of full
+    assert ro_names < full_names, "Read-only tools should be a strict subset of full tools"
+
+    # Read-only should have no create/update/delete/mutating tools
+    write_prefixes = ("create_", "update_", "delete_", "bulk_update_", "bulk_delete_")
+    write_keywords = (
+        "approve_", "reopen_", "onboard_", "submit_", "sign_and_submit_",
+        "authorize_", "simulate_", "retry_", "refund_", "cancel_",
+        "start_implementation", "cancel_implementation", "request_embedded_setup",
+        "ping_", "refresh_", "toggle_", "sync_", "upload_", "request_tax_",
+    )
+    for name in ro_names:
+        assert not any(name.startswith(p) for p in write_prefixes), (
+            f"Write tool '{name}' should not be in read-only mode"
+        )
+        assert not any(name.startswith(k) for k in write_keywords), (
+            f"Mutating tool '{name}' should not be in read-only mode"
+        )
+
+    # Core read tools should still be present
+    expected_read = {
+        "list_companies", "get_company",
+        "list_employees", "get_employee",
+        "list_payrolls", "get_payroll", "preview_payroll",
+        "list_workplaces", "get_workplace",
+        "list_payments", "get_payment",
+        "list_webhook_configs", "get_webhook_config",
+        "list_forms", "get_form",
+        "validate_address",
+    }
+    assert expected_read.issubset(ro_names), (
+        f"Missing read tools in read-only mode: {expected_read - ro_names}"
+    )


### PR DESCRIPTION
When CHECK_READ_ONLY is set to 1/true/yes, only read-only tools (list, get, download, preview, validate, render, reveal) are registered. All create, update, delete, and other mutating tools are excluded, allowing safe exploration of Check data without risk of modifications.