### PR TITLE
Update README with beta notice and correct clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mcp-server-check
 
+> **⚠️ Early Access Beta** — This MCP server is currently in beta and available to select partners. APIs, tools, and behavior may change without notice. Please share feedback with your Check point of contact.
+
 An [MCP](https://modelcontextprotocol.io/) server that wraps the [Check Payroll API](https://docs.checkhq.com/), providing 263 tools for managing companies, employees, contractors, payrolls, tax configuration, embedded components, and more.
 
 ## Quickstart
@@ -12,7 +14,7 @@ CHECK_API_KEY=your-key uvx mcp-server-check
 Or install from source:
 
 ```bash
-git clone https://github.com/ianzapolsky/mcp-server-check.git
+git clone https://github.com/check-technologies/mcp-server-check.git
 cd mcp-server-check
 uv sync
 CHECK_API_KEY=your-key uv run mcp-server-check
@@ -437,7 +439,7 @@ Generate embeddable UI component URLs via `POST /{entity_type}/{entity_id}/compo
 ## Development
 
 ```bash
-git clone https://github.com/ianzapolsky/mcp-server-check.git
+git clone https://github.com/check-technologies/mcp-server-check.git
 cd mcp-server-check
 uv sync --group dev
 uv run pytest  # 108 tests


### PR DESCRIPTION
## Summary
- Added early access beta banner at the top of the README so partners know this is beta and to expect potential breaking changes
- Fixed clone URL from `ianzapolsky/mcp-server-check` to `check-technologies/mcp-server-check` (both in Quickstart and Development sections)

## Context
Per [Slack thread](https://checkpayroll.slack.com/archives/C09NWH278R0/p1773338979138499) — prepping the repo for partner beta sharing.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm clone URL works: `git clone https://github.com/check-technologies/mcp-server-check.git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)