### PR TITLE
Add toolset-based tool filtering via headers and env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ CHECK_API_KEY=your-key uv run mcp-server-check
 |---|---|---|---|
 | `CHECK_API_KEY` | Yes | — | Your Check API key (Bearer token) |
 | `CHECK_API_BASE_URL` | No | `https://sandbox.checkhq.com` | API base URL |
+| `CHECK_TOOLSETS` | No | — | Comma-separated list of toolsets to enable (e.g. `companies,employees`) |
+| `CHECK_TOOLS` | No | — | Comma-separated allowlist of individual tool names |
+| `CHECK_EXCLUDE_TOOLS` | No | — | Comma-separated list of tool names to hide |
 | `CHECK_READ_ONLY` | No | — | Set to `1`, `true`, or `yes` to disable all write/mutating tools |
+| `CHECK_TRANSPORT` | No | `stdio` | Transport protocol: `stdio`, `sse`, or `streamable-http` |
 
 ### Sandbox vs Production
 
@@ -36,13 +40,64 @@ To point at production, set:
 CHECK_API_BASE_URL=https://api.checkhq.com
 ```
 
-### Read-Only Mode
+### Server Configuration
+
+The server supports fine-grained tool filtering, configurable via environment variables (for stdio) or HTTP headers (for SSE / streamable-http). This follows the [GitHub MCP Server configuration pattern](https://github.com/github/github-mcp-server).
+
+| Feature | Environment Variable | HTTP Header |
+|---|---|---|
+| Toolsets | `CHECK_TOOLSETS` | `X-MCP-Toolsets` |
+| Individual tools | `CHECK_TOOLS` | `X-MCP-Tools` |
+| Exclude tools | `CHECK_EXCLUDE_TOOLS` | `X-MCP-Exclude-Tools` |
+| Read-only | `CHECK_READ_ONLY` | `X-MCP-Readonly` |
+
+**Filtering precedence:** `exclude_tools` > `read_only` > `tools` > `toolsets`. Exclude always wins; if `tools` is set it acts as an allowlist independent of toolsets.
+
+#### Toolsets
+
+There are 17 toolsets, one per API module: `bank_accounts`, `companies`, `compensation`, `components`, `contractor_payments`, `contractors`, `documents`, `employees`, `external_payrolls`, `forms`, `payments`, `payroll_items`, `payrolls`, `platform`, `tax`, `webhooks`, `workplaces`.
+
+Enable only specific toolsets:
+
+```bash
+CHECK_TOOLSETS=companies,employees CHECK_API_KEY=your-key uvx mcp-server-check
+```
+
+#### Individual Tools
+
+Allow only specific tools by name:
+
+```bash
+CHECK_TOOLS=list_companies,get_company,list_employees CHECK_API_KEY=your-key uvx mcp-server-check
+```
+
+#### Excluding Tools
+
+Hide specific tools while keeping everything else:
+
+```bash
+CHECK_EXCLUDE_TOOLS=create_company,delete_company CHECK_API_KEY=your-key uvx mcp-server-check
+```
+
+#### Read-Only Mode
 
 Set `CHECK_READ_ONLY=1` to run the server with only read-only tools (list, get, download, preview, etc.). All create, update, delete, and other mutating tools are excluded. This is useful when you want to allow exploration of your Check data without risk of modifications.
 
 ```bash
 CHECK_READ_ONLY=1 CHECK_API_KEY=your-key uvx mcp-server-check
 ```
+
+#### HTTP Headers (Remote Transport)
+
+When running with `CHECK_TRANSPORT=sse` or `CHECK_TRANSPORT=streamable-http`, clients can pass configuration via HTTP headers:
+
+```
+X-MCP-Toolsets: companies,employees
+X-MCP-Readonly: true
+X-MCP-Exclude-Tools: create_company,delete_company
+```
+
+Header-based configuration takes precedence over environment variables when headers provide any filter settings.
 
 ## Usage with Claude Desktop
 
@@ -440,5 +495,5 @@ Generate embeddable UI component URLs via `POST /{entity_type}/{entity_id}/compo
 git clone https://github.com/ianzapolsky/mcp-server-check.git
 cd mcp-server-check
 uv sync --group dev
-uv run pytest  # 108 tests
+uv run pytest  # 173 tests
 ```

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
+from typing import Any
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import Tool as MCPTool
 
 from mcp_server_check.helpers import CheckContext
+from mcp_server_check.tool_filter import ToolFilter
 from mcp_server_check.tools import register_all
 
 DEFAULT_BASE_URL = "https://sandbox.checkhq.com"
@@ -28,19 +32,69 @@ async def lifespan(server: FastMCP) -> AsyncIterator[CheckContext]:
         yield CheckContext(client=client, base_url=base_url)
 
 
-read_only = os.environ.get("CHECK_READ_ONLY", "").lower() in ("1", "true", "yes")
+class CheckMCP(FastMCP):
+    """FastMCP subclass that applies toolset-based filtering at request time."""
 
-mcp = FastMCP("Check Payroll API", lifespan=lifespan)
-register_all(mcp, read_only=read_only)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._registry: dict[str, str] = {}
+        self._static_filter: ToolFilter = ToolFilter.from_env()
+
+    def _get_active_filter(self) -> ToolFilter:
+        """Return the filter for the current request.
+
+        For HTTP transports, checks request headers and merges with the
+        static (env-based) filter. For stdio, returns the static filter.
+        """
+        try:
+            request = self._mcp_server.request_context.request
+            if request is not None and hasattr(request, "headers"):
+                header_filter = ToolFilter.from_headers(request.headers)
+                # If headers provide any configuration, use it; otherwise fall back
+                if header_filter != ToolFilter():
+                    return header_filter
+        except LookupError:
+            pass
+        return self._static_filter
+
+    async def list_tools(self) -> list[MCPTool]:
+        """List tools, filtered by the active configuration."""
+        all_tools = await super().list_tools()
+        tf = self._get_active_filter()
+        return [
+            t
+            for t in all_tools
+            if tf.is_tool_allowed(t.name, self._registry.get(t.name, ""))
+        ]
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> Sequence[Any]:
+        """Call a tool, blocking if it's filtered out."""
+        tf = self._get_active_filter()
+        toolset = self._registry.get(name, "")
+        if not tf.is_tool_allowed(name, toolset):
+            raise ToolError(f"Tool '{name}' is not available in the current configuration")
+        return await super().call_tool(name, arguments)
+
+
+mcp = CheckMCP("Check Payroll API", lifespan=lifespan)
+register_all(mcp, registry=mcp._registry)
 
 
 def main():
     if not os.environ.get("CHECK_API_KEY"):
         print("Error: CHECK_API_KEY environment variable is required", file=sys.stderr)
         sys.exit(1)
-    if read_only:
+    if mcp._static_filter.read_only:
         print("Running in read-only mode (CHECK_READ_ONLY is set)", file=sys.stderr)
-    mcp.run(transport="stdio")
+    if mcp._static_filter.toolsets:
+        print(
+            f"Active toolsets: {', '.join(sorted(mcp._static_filter.toolsets))}",
+            file=sys.stderr,
+        )
+    transport = os.environ.get("CHECK_TRANSPORT", "stdio")
+    mcp.run(transport=transport)
 
 
 if __name__ == "__main__":

--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -1,0 +1,155 @@
+"""Toolset-based tool filtering for the Check MCP server.
+
+Supports filtering via HTTP headers (remote) or environment variables (local),
+following the GitHub MCP Server configuration pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+TOOLSETS: frozenset[str] = frozenset(
+    {
+        "bank_accounts",
+        "companies",
+        "compensation",
+        "components",
+        "contractor_payments",
+        "contractors",
+        "documents",
+        "employees",
+        "external_payrolls",
+        "forms",
+        "payments",
+        "payroll_items",
+        "payrolls",
+        "platform",
+        "tax",
+        "webhooks",
+        "workplaces",
+    }
+)
+
+_WRITE_PREFIXES = (
+    "create_",
+    "update_",
+    "delete_",
+    "bulk_update_",
+    "bulk_delete_",
+)
+_WRITE_KEYWORDS = (
+    "approve_",
+    "reopen_",
+    "onboard_",
+    "submit_",
+    "sign_and_submit_",
+    "authorize_",
+    "simulate_",
+    "retry_",
+    "refund_",
+    "cancel_",
+    "start_implementation",
+    "cancel_implementation",
+    "request_embedded_setup",
+    "ping_",
+    "refresh_",
+    "toggle_",
+    "sync_",
+    "upload_",
+    "request_tax_",
+)
+
+
+def is_write_tool(name: str) -> bool:
+    """Return True if the tool name matches a write/mutating pattern."""
+    return any(name.startswith(p) for p in _WRITE_PREFIXES) or any(
+        name.startswith(k) for k in _WRITE_KEYWORDS
+    )
+
+
+def _parse_comma_set(value: str | None) -> frozenset[str] | None:
+    """Parse a comma-separated string into a frozenset, or None if empty."""
+    if not value:
+        return None
+    items = frozenset(s.strip() for s in value.split(",") if s.strip())
+    return items if items else None
+
+
+def _parse_bool(value: str | None) -> bool:
+    """Parse a string as a boolean flag."""
+    return (value or "").lower() in ("1", "true", "yes")
+
+
+@dataclass(frozen=True)
+class ToolFilter:
+    """Immutable filter configuration for tool visibility.
+
+    Filtering precedence: exclude_tools > read_only > tools > toolsets.
+    - exclude_tools always wins (tool is hidden).
+    - read_only hides write/mutating tools.
+    - tools, when set, acts as an allowlist independent of toolsets.
+    - toolsets, when set, limits tools to those in the named toolsets.
+    """
+
+    toolsets: frozenset[str] | None = None
+    tools: frozenset[str] | None = None
+    exclude_tools: frozenset[str] = frozenset()
+    read_only: bool = False
+
+    def __post_init__(self) -> None:
+        if self.toolsets is not None:
+            invalid = self.toolsets - TOOLSETS
+            if invalid:
+                logger.warning("Ignoring unknown toolset(s): %s", ", ".join(sorted(invalid)))
+                object.__setattr__(self, "toolsets", self.toolsets & TOOLSETS)
+
+    def is_tool_allowed(self, tool_name: str, toolset_name: str) -> bool:
+        """Determine whether a tool should be visible given this filter."""
+        # Exclude always wins
+        if tool_name in self.exclude_tools:
+            return False
+
+        # Read-only hides write tools
+        if self.read_only and is_write_tool(tool_name):
+            return False
+
+        # Individual tool allowlist (independent of toolsets)
+        if self.tools is not None:
+            return tool_name in self.tools
+
+        # Toolset allowlist
+        if self.toolsets is not None:
+            return toolset_name in self.toolsets
+
+        return True
+
+    @classmethod
+    def from_env(cls) -> ToolFilter:
+        """Build a ToolFilter from environment variables."""
+        return cls(
+            toolsets=_parse_comma_set(os.environ.get("CHECK_TOOLSETS")),
+            tools=_parse_comma_set(os.environ.get("CHECK_TOOLS")),
+            exclude_tools=_parse_comma_set(os.environ.get("CHECK_EXCLUDE_TOOLS")) or frozenset(),
+            read_only=_parse_bool(os.environ.get("CHECK_READ_ONLY")),
+        )
+
+    @classmethod
+    def from_headers(cls, headers: dict[str, str] | object) -> ToolFilter:
+        """Build a ToolFilter from HTTP request headers.
+
+        Args:
+            headers: A dict-like object (e.g. Starlette Headers) supporting .get().
+        """
+        get = getattr(headers, "get", None)
+        if get is None:
+            return cls()
+        return cls(
+            toolsets=_parse_comma_set(get("x-mcp-toolsets")),
+            tools=_parse_comma_set(get("x-mcp-tools")),
+            exclude_tools=_parse_comma_set(get("x-mcp-exclude-tools")) or frozenset(),
+            read_only=_parse_bool(get("x-mcp-readonly")),
+        )

--- a/src/mcp_server_check/tools/__init__.py
+++ b/src/mcp_server_check/tools/__init__.py
@@ -24,33 +24,50 @@ from . import (
     workplaces,
 )
 
-_MODULES = [
-    bank_accounts,
-    companies,
-    compensation,
-    components,
-    contractor_payments,
-    contractors,
-    documents,
-    employees,
-    external_payrolls,
-    forms,
-    payroll_items,
-    payrolls,
-    payments,
-    platform,
-    tax,
-    webhooks,
-    workplaces,
-]
+_TOOLSETS = {
+    "bank_accounts": bank_accounts,
+    "companies": companies,
+    "compensation": compensation,
+    "components": components,
+    "contractor_payments": contractor_payments,
+    "contractors": contractors,
+    "documents": documents,
+    "employees": employees,
+    "external_payrolls": external_payrolls,
+    "forms": forms,
+    "payroll_items": payroll_items,
+    "payrolls": payrolls,
+    "payments": payments,
+    "platform": platform,
+    "tax": tax,
+    "webhooks": webhooks,
+    "workplaces": workplaces,
+}
 
 
-def register_all(mcp: FastMCP, *, read_only: bool = False) -> None:
-    """Register tools from every module.
+def register_all(mcp: FastMCP, registry: dict[str, str]) -> None:
+    """Register tools from every module, recording tool-to-toolset mappings.
+
+    All tools are always registered (no read_only filtering at registration time).
+    Filtering happens at request time via ToolFilter.
 
     Args:
-        read_only: When True, only register read-only tools (list/get/download/preview).
-            Write, update, delete, and other mutating tools are skipped.
+        registry: Dict to populate with tool_name -> toolset_name mappings.
     """
-    for mod in _MODULES:
-        mod.register(mcp, read_only=read_only)
+    original_add_tool = mcp.add_tool
+
+    current_toolset: list[str] = []
+
+    def tracking_add_tool(fn, **kwargs):
+        original_add_tool(fn, **kwargs)
+        tool_name = kwargs.get("name") or fn.__name__
+        registry[tool_name] = current_toolset[0]
+
+    try:
+        mcp.add_tool = tracking_add_tool  # type: ignore[assignment]
+        for toolset_name, mod in _TOOLSETS.items():
+            current_toolset.clear()
+            current_toolset.append(toolset_name)
+            mod.register(mcp, read_only=False)
+    finally:
+        mcp.add_tool = original_add_tool  # type: ignore[assignment]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,17 +4,29 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from mcp_server_check.helpers import (
-    _extract_cursor,
-    _format_list_response,
-)
-from mcp_server_check.server import mcp
+from mcp_server_check.server import CheckMCP, mcp
+from mcp_server_check.tool_filter import ToolFilter, is_write_tool
+from mcp_server_check.tools import register_all
 from mcp_server_check.tools.companies import get_company, list_companies
 from mcp_server_check.tools.employees import get_employee, list_employees
 from mcp_server_check.tools.payrolls import get_payroll, list_payrolls
 from mcp_server_check.tools.workplaces import get_workplace, list_workplaces
+from mcp_server_check.helpers import (
+    _extract_cursor,
+    _format_list_response,
+)
 
 BASE_URL = "https://sandbox.checkhq.com"
+
+
+# --- Helper to create a CheckMCP with a specific filter ---
+
+def _make_server(tool_filter: ToolFilter) -> CheckMCP:
+    """Create a CheckMCP instance with the given static filter."""
+    server = CheckMCP("Test")
+    register_all(server, registry=server._registry)
+    server._static_filter = tool_filter
+    return server
 
 
 # --- Unit tests for helpers ---
@@ -235,12 +247,14 @@ async def test_api_error_returns_error_dict(mock_api, ctx):
     assert result["status_code"] == 404
 
 
+# --- Tool registration and filtering tests ---
+
+
 @pytest.mark.anyio
 async def test_tools_registered():
-    """Verify expected tools are registered on the MCP server."""
+    """All tools are registered (263+), filtering happens at list time."""
     tools = await mcp.list_tools()
     tool_names = {t.name for t in tools}
-    # Check that core tools from the original server are present
     expected_core = {
         "list_companies",
         "get_company",
@@ -254,43 +268,36 @@ async def test_tools_registered():
     assert expected_core.issubset(tool_names), (
         f"Missing core tools: {expected_core - tool_names}"
     )
-    # Verify we have a large number of tools registered
     assert len(tools) > 150, f"Expected 150+ tools, got {len(tools)}"
+
+
+@pytest.mark.anyio
+async def test_registry_populated():
+    """The registry maps every tool to its toolset."""
+    assert len(mcp._registry) > 150
+    assert mcp._registry["list_companies"] == "companies"
+    assert mcp._registry["list_employees"] == "employees"
+    assert mcp._registry["list_bank_accounts"] == "bank_accounts"
 
 
 @pytest.mark.anyio
 async def test_read_only_mode():
     """Verify read-only mode excludes all write/mutating tools."""
-    from mcp.server.fastmcp import FastMCP
-    from mcp_server_check.tools import register_all
-
-    read_only_mcp = FastMCP("Test Read-Only")
-    register_all(read_only_mcp, read_only=True)
-    ro_tools = await read_only_mcp.list_tools()
+    server = _make_server(ToolFilter(read_only=True))
+    ro_tools = await server.list_tools()
     ro_names = {t.name for t in ro_tools}
 
-    full_mcp = FastMCP("Test Full")
-    register_all(full_mcp, read_only=False)
-    full_tools = await full_mcp.list_tools()
+    full_server = _make_server(ToolFilter())
+    full_tools = await full_server.list_tools()
     full_names = {t.name for t in full_tools}
 
     # Read-only should be a strict subset of full
     assert ro_names < full_names, "Read-only tools should be a strict subset of full tools"
 
-    # Read-only should have no create/update/delete/mutating tools
-    write_prefixes = ("create_", "update_", "delete_", "bulk_update_", "bulk_delete_")
-    write_keywords = (
-        "approve_", "reopen_", "onboard_", "submit_", "sign_and_submit_",
-        "authorize_", "simulate_", "retry_", "refund_", "cancel_",
-        "start_implementation", "cancel_implementation", "request_embedded_setup",
-        "ping_", "refresh_", "toggle_", "sync_", "upload_", "request_tax_",
-    )
+    # Read-only should have no write tools
     for name in ro_names:
-        assert not any(name.startswith(p) for p in write_prefixes), (
+        assert not is_write_tool(name), (
             f"Write tool '{name}' should not be in read-only mode"
-        )
-        assert not any(name.startswith(k) for k in write_keywords), (
-            f"Mutating tool '{name}' should not be in read-only mode"
         )
 
     # Core read tools should still be present
@@ -307,3 +314,80 @@ async def test_read_only_mode():
     assert expected_read.issubset(ro_names), (
         f"Missing read tools in read-only mode: {expected_read - ro_names}"
     )
+
+
+@pytest.mark.anyio
+async def test_toolset_filtering():
+    """Only tools from selected toolsets are listed."""
+    server = _make_server(ToolFilter(toolsets=frozenset({"companies", "employees"})))
+    tools = await server.list_tools()
+    tool_names = {t.name for t in tools}
+
+    assert "list_companies" in tool_names
+    assert "get_company" in tool_names
+    assert "list_employees" in tool_names
+    assert "get_employee" in tool_names
+
+    # Tools from other toolsets should be excluded
+    assert "list_payrolls" not in tool_names
+    assert "list_bank_accounts" not in tool_names
+    assert "list_webhook_configs" not in tool_names
+
+
+@pytest.mark.anyio
+async def test_individual_tool_filtering():
+    """Only individually named tools are listed when tools filter is set."""
+    server = _make_server(
+        ToolFilter(tools=frozenset({"list_companies", "get_company"}))
+    )
+    tools = await server.list_tools()
+    tool_names = {t.name for t in tools}
+
+    assert tool_names == {"list_companies", "get_company"}
+
+
+@pytest.mark.anyio
+async def test_exclude_tools():
+    """Excluded tools are hidden regardless of other settings."""
+    server = _make_server(
+        ToolFilter(exclude_tools=frozenset({"create_company", "delete_payroll"}))
+    )
+    tools = await server.list_tools()
+    tool_names = {t.name for t in tools}
+
+    assert "create_company" not in tool_names
+    assert "delete_payroll" not in tool_names
+    assert "list_companies" in tool_names
+    assert "get_payroll" in tool_names
+
+
+@pytest.mark.anyio
+async def test_exclude_overrides_tools_allowlist():
+    """Exclude takes precedence over the tools allowlist."""
+    server = _make_server(
+        ToolFilter(
+            tools=frozenset({"list_companies", "create_company"}),
+            exclude_tools=frozenset({"create_company"}),
+        )
+    )
+    tools = await server.list_tools()
+    tool_names = {t.name for t in tools}
+
+    assert tool_names == {"list_companies"}
+
+
+@pytest.mark.anyio
+async def test_readonly_with_toolsets():
+    """Read-only combined with toolsets filters both."""
+    server = _make_server(
+        ToolFilter(toolsets=frozenset({"companies"}), read_only=True)
+    )
+    tools = await server.list_tools()
+    tool_names = {t.name for t in tools}
+
+    assert "list_companies" in tool_names
+    assert "get_company" in tool_names
+    assert "create_company" not in tool_names
+    assert "update_company" not in tool_names
+    # Tools from other toolsets should also be excluded
+    assert "list_employees" not in tool_names

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -1,0 +1,248 @@
+"""Unit tests for ToolFilter."""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+from mcp_server_check.tool_filter import (
+    TOOLSETS,
+    ToolFilter,
+    is_write_tool,
+)
+
+
+# --- is_write_tool ---
+
+
+class TestIsWriteTool:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "create_company",
+            "update_employee",
+            "delete_payroll",
+            "bulk_update_payroll_items",
+            "bulk_delete_payroll_items",
+            "approve_payroll",
+            "reopen_payroll",
+            "onboard_company",
+            "submit_employee_form",
+            "sign_and_submit_employee_form",
+            "authorize_integration_partner",
+            "simulate_start_processing",
+            "retry_payment",
+            "refund_payment",
+            "cancel_payment",
+            "start_implementation",
+            "cancel_implementation",
+            "request_embedded_setup",
+            "ping_webhook_config",
+            "refresh_accounting_accounts",
+            "toggle_accounting_mappings",
+            "sync_accounting",
+            "upload_company_provided_document_file",
+            "request_tax_filing_refile",
+        ],
+    )
+    def test_write_tools_detected(self, name):
+        assert is_write_tool(name), f"{name} should be a write tool"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "list_companies",
+            "get_company",
+            "get_employee",
+            "list_payrolls",
+            "preview_payroll",
+            "download_company_tax_document",
+            "validate_address",
+            "list_webhook_configs",
+            "reveal_employee_ssn",
+            "get_enrollment_profile",
+        ],
+    )
+    def test_read_tools_not_detected(self, name):
+        assert not is_write_tool(name), f"{name} should NOT be a write tool"
+
+
+# --- ToolFilter.from_env ---
+
+
+class TestFromEnv:
+    def test_defaults(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            tf = ToolFilter.from_env()
+        assert tf.toolsets is None
+        assert tf.tools is None
+        assert tf.exclude_tools == frozenset()
+        assert tf.read_only is False
+
+    def test_toolsets(self):
+        with mock.patch.dict(os.environ, {"CHECK_TOOLSETS": "companies, employees"}):
+            tf = ToolFilter.from_env()
+        assert tf.toolsets == frozenset({"companies", "employees"})
+
+    def test_tools(self):
+        with mock.patch.dict(os.environ, {"CHECK_TOOLS": "list_companies,get_company"}):
+            tf = ToolFilter.from_env()
+        assert tf.tools == frozenset({"list_companies", "get_company"})
+
+    def test_exclude_tools(self):
+        with mock.patch.dict(
+            os.environ, {"CHECK_EXCLUDE_TOOLS": "create_company,delete_company"}
+        ):
+            tf = ToolFilter.from_env()
+        assert tf.exclude_tools == frozenset({"create_company", "delete_company"})
+
+    def test_read_only_true(self):
+        for val in ("1", "true", "yes", "True", "YES"):
+            with mock.patch.dict(os.environ, {"CHECK_READ_ONLY": val}):
+                tf = ToolFilter.from_env()
+            assert tf.read_only is True, f"CHECK_READ_ONLY={val} should be True"
+
+    def test_read_only_false(self):
+        for val in ("0", "false", "no", ""):
+            with mock.patch.dict(os.environ, {"CHECK_READ_ONLY": val}):
+                tf = ToolFilter.from_env()
+            assert tf.read_only is False, f"CHECK_READ_ONLY={val} should be False"
+
+    def test_empty_values_yield_none(self):
+        with mock.patch.dict(os.environ, {"CHECK_TOOLSETS": "", "CHECK_TOOLS": ""}):
+            tf = ToolFilter.from_env()
+        assert tf.toolsets is None
+        assert tf.tools is None
+
+
+# --- ToolFilter.from_headers ---
+
+
+class TestFromHeaders:
+    def test_all_headers(self):
+        headers = {
+            "x-mcp-toolsets": "companies,employees",
+            "x-mcp-tools": "list_companies",
+            "x-mcp-exclude-tools": "create_company",
+            "x-mcp-readonly": "true",
+        }
+        tf = ToolFilter.from_headers(headers)
+        assert tf.toolsets == frozenset({"companies", "employees"})
+        assert tf.tools == frozenset({"list_companies"})
+        assert tf.exclude_tools == frozenset({"create_company"})
+        assert tf.read_only is True
+
+    def test_empty_headers(self):
+        tf = ToolFilter.from_headers({})
+        assert tf == ToolFilter()
+
+    def test_no_get_method(self):
+        tf = ToolFilter.from_headers(42)  # type: ignore[arg-type]
+        assert tf == ToolFilter()
+
+    def test_case_insensitive_header_names(self):
+        """Dict keys are already lowercase, matching HTTP header convention."""
+        headers = {"x-mcp-readonly": "1"}
+        tf = ToolFilter.from_headers(headers)
+        assert tf.read_only is True
+
+
+# --- is_tool_allowed precedence ---
+
+
+class TestIsToolAllowed:
+    def test_no_filter(self):
+        tf = ToolFilter()
+        assert tf.is_tool_allowed("create_company", "companies") is True
+
+    def test_exclude_wins_over_everything(self):
+        tf = ToolFilter(
+            tools=frozenset({"create_company"}),
+            exclude_tools=frozenset({"create_company"}),
+        )
+        assert tf.is_tool_allowed("create_company", "companies") is False
+
+    def test_readonly_blocks_write(self):
+        tf = ToolFilter(read_only=True)
+        assert tf.is_tool_allowed("create_company", "companies") is False
+        assert tf.is_tool_allowed("list_companies", "companies") is True
+
+    def test_readonly_does_not_block_if_in_tools(self):
+        """Read-only takes precedence over tools allowlist."""
+        tf = ToolFilter(
+            tools=frozenset({"create_company"}),
+            read_only=True,
+        )
+        assert tf.is_tool_allowed("create_company", "companies") is False
+
+    def test_tools_allowlist(self):
+        tf = ToolFilter(tools=frozenset({"list_companies", "get_company"}))
+        assert tf.is_tool_allowed("list_companies", "companies") is True
+        assert tf.is_tool_allowed("get_company", "companies") is True
+        assert tf.is_tool_allowed("create_company", "companies") is False
+        assert tf.is_tool_allowed("list_employees", "employees") is False
+
+    def test_tools_overrides_toolsets(self):
+        """When tools is set, toolsets is ignored."""
+        tf = ToolFilter(
+            toolsets=frozenset({"employees"}),
+            tools=frozenset({"list_companies"}),
+        )
+        assert tf.is_tool_allowed("list_companies", "companies") is True
+        assert tf.is_tool_allowed("list_employees", "employees") is False
+
+    def test_toolsets_filter(self):
+        tf = ToolFilter(toolsets=frozenset({"companies"}))
+        assert tf.is_tool_allowed("list_companies", "companies") is True
+        assert tf.is_tool_allowed("create_company", "companies") is True
+        assert tf.is_tool_allowed("list_employees", "employees") is False
+
+    def test_exclude_with_toolsets(self):
+        tf = ToolFilter(
+            toolsets=frozenset({"companies"}),
+            exclude_tools=frozenset({"create_company"}),
+        )
+        assert tf.is_tool_allowed("list_companies", "companies") is True
+        assert tf.is_tool_allowed("create_company", "companies") is False
+
+    def test_readonly_with_toolsets(self):
+        tf = ToolFilter(
+            toolsets=frozenset({"companies"}),
+            read_only=True,
+        )
+        assert tf.is_tool_allowed("list_companies", "companies") is True
+        assert tf.is_tool_allowed("create_company", "companies") is False
+        assert tf.is_tool_allowed("list_employees", "employees") is False
+
+
+# --- Invalid toolset handling ---
+
+
+class TestInvalidToolsets:
+    def test_unknown_toolsets_are_stripped(self):
+        tf = ToolFilter(toolsets=frozenset({"companies", "not_a_real_one"}))
+        assert tf.toolsets == frozenset({"companies"})
+
+    def test_all_unknown_yields_empty(self):
+        tf = ToolFilter(toolsets=frozenset({"bogus"}))
+        assert tf.toolsets == frozenset()
+        # With empty toolsets, no tools should be allowed
+        assert tf.is_tool_allowed("list_companies", "companies") is False
+
+
+# --- TOOLSETS constant ---
+
+
+class TestToolsets:
+    def test_has_17_toolsets(self):
+        assert len(TOOLSETS) == 17
+
+    def test_known_toolsets(self):
+        expected = {
+            "bank_accounts", "companies", "compensation", "components",
+            "contractor_payments", "contractors", "documents", "employees",
+            "external_payrolls", "forms", "payments", "payroll_items",
+            "payrolls", "platform", "tax", "webhooks", "workplaces",
+        }
+        assert TOOLSETS == expected


### PR DESCRIPTION
Register all 263 tools at startup and filter at request time based on toolsets, individual tool allowlists, exclusions, and read-only mode. Supports configuration via env vars (stdio) or HTTP headers (remote), following the GitHub MCP Server configuration pattern.