### PR TITLE
Add check CLI

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,316 @@
+# Check CLI
+
+A command-line interface for the [Check Payroll API](https://docs.checkhq.com/). The CLI exposes the same 263 endpoints as the MCP server, organized as resource-oriented commands similar to the [Stripe CLI](https://docs.stripe.com/cli).
+
+## Installation
+
+```bash
+git clone https://github.com/check-technologies/mcp-server-check.git
+cd mcp-server-check
+uv sync
+```
+
+The `check` binary is installed in the project virtualenv. Run it with `uv run`:
+
+```bash
+uv run check --help
+```
+
+To install globally (no `uv run` prefix needed):
+
+```bash
+uv tool install -e .
+check --help
+```
+
+## Authentication
+
+Set your Check API key via environment variable or flag:
+
+```bash
+# Environment variable (recommended)
+export CHECK_API_KEY=sk_test_...
+
+# Or pass directly
+uv run check --api-key sk_test_... companies list
+```
+
+## Quick Start
+
+```bash
+# List companies
+check companies list
+
+# Get a specific company
+check companies get com_xxxxx
+
+# Create a company
+check companies create --legal-name "Acme Corp"
+
+# List employees for a company
+check employees list --company com_xxxxx
+
+# Approve a payroll
+check payrolls approve prl_xxxxx
+
+# Get help for any command
+check companies create --help
+```
+
+## Command Structure
+
+Commands follow a `check <resource> <action>` pattern:
+
+```
+check <group> <command> [ARGS] [OPTIONS]
+```
+
+There are 17 resource groups, each with multiple commands:
+
+| Group | Examples |
+|---|---|
+| `companies` | `list`, `get`, `create`, `update`, `onboard`, `get-paydays` |
+| `employees` | `list`, `get`, `create`, `update`, `onboard`, `list-paystubs` |
+| `payrolls` | `list`, `get`, `create`, `approve`, `preview`, `simulate-start-processing` |
+| `contractors` | `list`, `get`, `create`, `update`, `onboard` |
+| `bank-accounts` | `list`, `get`, `create`, `delete`, `reveal-number` |
+| `compensation` | `list-pay-schedules`, `create-benefit`, `list-earning-codes` |
+| `tax` | `get-company-params`, `list-employee-elections`, `list-filings` |
+| `payments` | `list`, `get`, `retry`, `refund`, `cancel` |
+| `payroll-items` | `list`, `get`, `create`, `update`, `delete` |
+| `contractor-payments` | `list`, `get`, `create`, `delete` |
+| `external-payrolls` | `list`, `get`, `create`, `approve` |
+| `webhooks` | `list-configs`, `create-config`, `ping-config`, `retry-events` |
+| `documents` | `list-company-tax-documents`, `download-employee-tax-document` |
+| `components` | `create-company-run-payroll-component`, `create-employee-profile-component` |
+| `forms` | `list`, `get`, `render`, `validate` |
+| `platform` | `list-notifications`, `validate-address`, `sync-accounting` |
+| `workplaces` | `list`, `get`, `create`, `update` |
+
+Use `check <group> --help` to see all commands in a group.
+
+## Global Options
+
+```
+--api-key TEXT              Check API key (or CHECK_API_KEY env var)
+--env [sandbox|production]  API environment (default: sandbox; or CHECK_ENV)
+--format [json|table]       Output format (default: json)
+--read-only                 Block write operations (or CHECK_READ_ONLY)
+--verbose                   Print request details to stderr
+--version                   Show version
+--help                      Show help
+```
+
+## Output Formats
+
+**JSON (default)** — compact, pipe-friendly:
+
+```bash
+check companies get com_xxxxx
+# {"id":"com_xxxxx","legal_name":"Acme Corp","status":"active",...}
+```
+
+**Table** — human-readable columns:
+
+```bash
+check companies list --format table
+# ID         LEGAL_NAME   STATUS
+# ---------  -----------  ------
+# com_001    Acme Corp    active
+# com_002    Beta Inc     pending
+```
+
+## Piping and Composability
+
+The default JSON output is designed for piping:
+
+```bash
+# Extract employee IDs
+check employees list --company com_xxxxx | jq '.results[].id'
+
+# Count active companies
+check companies list --active | jq '.results | length'
+
+# Get details for each employee
+check employees list --company com_xxxxx | jq -r '.results[].id' | \
+  xargs -I{} check employees get {}
+```
+
+## Parameter Types
+
+| Type | Syntax | Example |
+|---|---|---|
+| ID (positional) | `<value>` | `check companies get com_xxxxx` |
+| String | `--option value` | `--legal-name "Acme Corp"` |
+| Integer | `--option N` | `--limit 10` |
+| Boolean flag | `--flag / --no-flag` | `--active` or `--no-active` |
+| JSON object | `--option '{...}'` | `--address '{"line1":"123 Main"}'` |
+| JSON from file | `--option @file.json` | `--address @addr.json` |
+| JSON from stdin | `--option @-` | `echo '{}' \| check ... --data @-` |
+| CSV list | `--option a,b,c` | `--ids com_001,com_002` |
+
+## Environment Switching
+
+By default the CLI connects to the Check **sandbox** (`https://sandbox.checkhq.com`). The sandbox supports simulation endpoints for advancing payrolls through processing states without real money movement.
+
+```bash
+# Sandbox (default)
+check payrolls list
+
+# Production
+check --env production payrolls list
+
+# Or via environment variable
+export CHECK_ENV=production
+check payrolls list
+
+# Custom base URL
+export CHECK_API_BASE_URL=https://api.checkhq.com
+check payrolls list
+```
+
+## Filtering
+
+The CLI supports the same filtering as the MCP server, via environment variables or flags.
+
+### Read-Only Mode
+
+Block all write/mutating commands:
+
+```bash
+# Via flag
+check --read-only companies list          # works
+check --read-only companies create ...    # command not found
+
+# Via environment variable
+export CHECK_READ_ONLY=1
+check companies create ...                # command not found
+```
+
+In read-only mode, write commands are hidden from `--help` output.
+
+### Toolset Filtering
+
+Restrict the CLI to specific resource groups:
+
+```bash
+export CHECK_TOOLSETS=companies,employees
+check companies list                      # works
+check payrolls list                       # "No such command"
+```
+
+### Tool-Level Filtering
+
+Allow or exclude individual commands by their tool function name:
+
+```bash
+# Allow only specific tools
+export CHECK_TOOLS=list_companies,get_company
+
+# Exclude specific tools
+export CHECK_EXCLUDE_TOOLS=delete_company,delete_employee
+```
+
+**Filtering precedence:** `CHECK_EXCLUDE_TOOLS` > `CHECK_READ_ONLY` > `CHECK_TOOLS` > `CHECK_TOOLSETS`.
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | API error (4xx/5xx response) |
+| 2 | Usage error (missing argument, unknown command) |
+| 3 | Authentication error (no API key) |
+
+Error details are printed to stderr, data to stdout, so pipes work correctly even on errors.
+
+## Examples
+
+### Payroll Workflow
+
+```bash
+# Create a payroll
+check payrolls create \
+  --company com_xxxxx \
+  --period-start 2026-01-01 \
+  --period-end 2026-01-15 \
+  --payday 2026-01-20
+
+# Add a payroll item
+check payroll-items create \
+  --payroll prl_xxxxx \
+  --employee emp_xxxxx \
+  --earnings '[{"amount":"5000.00","earning_code":"ec_xxxxx"}]'
+
+# Preview the payroll
+check payrolls preview prl_xxxxx
+
+# Approve it
+check payrolls approve prl_xxxxx
+
+# Simulate processing (sandbox only)
+check payrolls simulate-start-processing prl_xxxxx
+check payrolls simulate-complete-funding prl_xxxxx
+check payrolls simulate-complete-disbursements prl_xxxxx
+```
+
+### Employee Onboarding
+
+```bash
+# Create an employee
+check employees create \
+  --company com_xxxxx \
+  --first-name Jane \
+  --last-name Doe \
+  --email jane@example.com \
+  --start-date 2026-02-01
+
+# Onboard them
+check employees onboard emp_xxxxx
+
+# Check their forms
+check employees list-forms emp_xxxxx
+```
+
+### Reports
+
+```bash
+# Payroll journal
+check companies get-payroll-journal-report com_xxxxx \
+  --start-date 2026-01-01 --end-date 2026-03-31
+
+# Tax liabilities
+check companies get-tax-liabilities-report com_xxxxx \
+  --start-date 2026-01-01 --end-date 2026-03-31
+
+# W-2 preview
+check companies get-w2-preview-report com_xxxxx --year 2025
+```
+
+### Webhooks
+
+```bash
+# List webhook configs
+check webhooks list-configs
+
+# Create a webhook
+check webhooks create-config \
+  --url https://example.com/webhooks \
+  --environment sandbox
+
+# Test it
+check webhooks ping-config whc_xxxxx
+```
+
+## Comparison with MCP Server
+
+The CLI and MCP server share the same tool functions — adding a new API endpoint updates both interfaces in one change.
+
+| | MCP Server | CLI |
+|---|---|---|
+| **Interface** | MCP protocol (JSON-RPC) | Shell commands |
+| **Best for** | AI assistants (Claude, Cursor) | Scripts, CI/CD, debugging |
+| **Output** | Structured tool results | JSON or table to stdout |
+| **Auth** | Environment variable | Flag, env var, or config |
+| **Filtering** | Env vars + HTTP headers | Env vars + `--read-only` flag |
+| **Entry point** | `mcp-server-check` | `check` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,12 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.0.0",
     "httpx>=0.27.0",
+    "click>=8.0.0",
 ]
 
 [project.scripts]
 mcp-server-check = "mcp_server_check.server:main"
+check = "mcp_server_check.cli:main"
 
 [dependency-groups]
 dev = [

--- a/src/mcp_server_check/cli/__init__.py
+++ b/src/mcp_server_check/cli/__init__.py
@@ -1,0 +1,205 @@
+"""Check Payroll API CLI.
+
+Provides a ``check`` command that exposes the same tool functions used by
+the MCP server as a resource-oriented CLI (similar to the Stripe CLI).
+"""
+
+from __future__ import annotations
+
+import click
+
+from mcp_server_check import __version__
+from mcp_server_check.tool_filter import ToolFilter
+
+from .codegen import build_command, collect_tools
+from .context import resolve_api_key, resolve_base_url
+
+
+# ---------------------------------------------------------------------------
+# Filtered click groups
+# ---------------------------------------------------------------------------
+
+
+def _build_filter(ctx: click.Context) -> ToolFilter:
+    """Build a ToolFilter by merging env vars with the ``--read-only`` flag."""
+    root = ctx
+    while root.parent:
+        root = root.parent
+    read_only = root.params.get("read_only", False) if root.params else False
+    env_filter = ToolFilter.from_env()
+    if read_only and not env_filter.read_only:
+        return ToolFilter(
+            toolsets=env_filter.toolsets,
+            tools=env_filter.tools,
+            exclude_tools=env_filter.exclude_tools,
+            read_only=True,
+        )
+    return env_filter
+
+
+class _FilteredGroup(click.Group):
+    """Click group that hides commands rejected by :class:`ToolFilter`."""
+
+    def __init__(
+        self,
+        *args,
+        toolset_name: str = "",
+        tool_map: dict[str, str] | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.toolset_name = toolset_name
+        # command_cli_name -> tool_function_name
+        self.tool_map: dict[str, str] = tool_map if tool_map is not None else {}
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        tf = _build_filter(ctx)
+        return sorted(
+            name
+            for name in super().list_commands(ctx)
+            if name in self.tool_map
+            and tf.is_tool_allowed(self.tool_map[name], self.toolset_name)
+        )
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is None:
+            return None
+        func_name = self.tool_map.get(cmd_name)
+        if func_name is None:
+            return cmd
+        tf = _build_filter(ctx)
+        if not tf.is_tool_allowed(func_name, self.toolset_name):
+            return None
+        return cmd
+
+
+class _MainCLI(click.Group):
+    """Top-level CLI group that hides toolset groups based on ToolFilter."""
+
+    def __init__(
+        self,
+        *args,
+        toolset_names: dict[str, str] | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        # cli_group_name -> toolset_name
+        self.toolset_names: dict[str, str] = toolset_names if toolset_names is not None else {}
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        tf = _build_filter(ctx)
+        commands: list[str] = []
+        for name in super().list_commands(ctx):
+            toolset = self.toolset_names.get(name)
+            # Non-toolset commands (shouldn't exist, but be safe) always shown
+            if toolset is None:
+                commands.append(name)
+                continue
+            if tf.toolsets is None or toolset in tf.toolsets:
+                commands.append(name)
+        return commands
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is None:
+            return None
+        toolset = self.toolset_names.get(cmd_name)
+        if toolset is None:
+            return cmd
+        tf = _build_filter(ctx)
+        if tf.toolsets is not None and toolset not in tf.toolsets:
+            return None
+        return cmd
+
+
+# ---------------------------------------------------------------------------
+# CLI construction
+# ---------------------------------------------------------------------------
+
+
+def _build_cli() -> click.Group:
+    """Build the full CLI application with all auto-generated commands."""
+    toolset_names: dict[str, str] = {}
+
+    @click.group(cls=_MainCLI, toolset_names=toolset_names)
+    @click.option(
+        "--api-key",
+        envvar="CHECK_API_KEY",
+        default=None,
+        help="Check API key (or CHECK_API_KEY env var).",
+    )
+    @click.option(
+        "--env",
+        "environment",
+        type=click.Choice(["sandbox", "production"]),
+        default=None,
+        help="API environment (default: sandbox; or CHECK_ENV env var).",
+    )
+    @click.option(
+        "--format",
+        "fmt",
+        type=click.Choice(["json", "table"]),
+        default="json",
+        help="Output format (default: json).",
+    )
+    @click.option(
+        "--read-only",
+        is_flag=True,
+        default=False,
+        help="Block write operations (or CHECK_READ_ONLY env var).",
+    )
+    @click.option(
+        "--verbose",
+        is_flag=True,
+        default=False,
+        help="Print request details to stderr.",
+    )
+    @click.version_option(version=__version__, prog_name="check")
+    @click.pass_context
+    def cli(
+        ctx: click.Context,
+        api_key: str | None,
+        environment: str | None,
+        fmt: str,
+        read_only: bool,
+        verbose: bool,
+    ) -> None:
+        """Check Payroll API CLI."""
+        ctx.ensure_object(dict)
+        ctx.obj["api_key"] = resolve_api_key(api_key)
+        ctx.obj["base_url"] = resolve_base_url(environment)
+        ctx.obj["format"] = fmt
+        ctx.obj["read_only"] = read_only
+        ctx.obj["verbose"] = verbose
+
+    # Register toolset groups ------------------------------------------------
+    all_tools = collect_tools()
+    for toolset_name, functions in all_tools.items():
+        group_name = toolset_name.replace("_", "-")
+        tool_map: dict[str, str] = {}
+
+        group = _FilteredGroup(
+            name=group_name,
+            toolset_name=toolset_name,
+            tool_map=tool_map,
+            help=f"Commands for {toolset_name.replace('_', ' ')}.",
+        )
+
+        for func in functions:
+            cmd_name, cmd, func_name = build_command(func, toolset_name)
+            tool_map[cmd_name] = func_name
+            group.add_command(cmd, cmd_name)
+
+        toolset_names[group_name] = toolset_name
+        cli.add_command(group, group_name)
+
+    return cli
+
+
+cli = _build_cli()
+
+
+def main() -> None:
+    """Entry point for the ``check`` console script."""
+    cli(standalone_mode=True)

--- a/src/mcp_server_check/cli/codegen.py
+++ b/src/mcp_server_check/cli/codegen.py
@@ -1,0 +1,343 @@
+"""Auto-generate click commands from tool function signatures."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import sys
+import types
+import typing
+from typing import Any, Callable
+
+import click
+import httpx
+
+from mcp_server_check.helpers import CheckContext
+from mcp_server_check.tools import _TOOLSETS
+
+from .context import CLIContext
+from .output import output_result
+
+
+# ---------------------------------------------------------------------------
+# Custom click parameter types
+# ---------------------------------------------------------------------------
+
+
+class JSONParam(click.ParamType):
+    """Click parameter type for JSON values.
+
+    Accepts inline JSON strings or ``@filename`` (use ``@-`` for stdin).
+    """
+
+    name = "JSON"
+
+    def convert(
+        self, value: Any, param: click.Parameter | None, ctx: click.Context | None
+    ) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, str) and value.startswith("@"):
+            path = value[1:]
+            try:
+                if path == "-":
+                    content = sys.stdin.read()
+                else:
+                    with open(path) as f:
+                        content = f.read()
+                return json.loads(content)
+            except (OSError, json.JSONDecodeError) as e:
+                self.fail(f"Failed to read JSON from {path}: {e}", param, ctx)
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as e:
+            self.fail(f"Invalid JSON: {e}", param, ctx)
+
+
+class CSVList(click.ParamType):
+    """Click parameter type for comma-separated string lists."""
+
+    name = "CSV"
+
+    def convert(
+        self, value: Any, param: click.Parameter | None, ctx: click.Context | None
+    ) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return value
+        return [s.strip() for s in value.split(",") if s.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Naming helpers
+# ---------------------------------------------------------------------------
+
+
+def _singularize(word: str) -> str:
+    """Naive singularization: companies->company, accounts->account."""
+    if word.endswith("ies"):
+        return word[:-3] + "y"
+    if word.endswith("s") and not word.endswith("ss"):
+        return word[:-1]
+    return word
+
+
+def _make_command_name(func_name: str, toolset_name: str) -> str:
+    """Derive a CLI command name from a tool function name and its toolset.
+
+    Algorithm: find the toolset's plural or singular form as a contiguous
+    subsequence of the function-name parts and remove it, then join with ``-``.
+
+    Examples::
+
+        list_companies, companies   -> list
+        get_company, companies      -> get
+        get_company_paydays, companies -> get-paydays
+        list_employee_paystubs, employees -> list-paystubs
+        simulate_start_processing, payrolls -> simulate-start-processing
+        list_bank_accounts, bank_accounts -> list
+    """
+    parts = func_name.split("_")
+    ts_plural = toolset_name.split("_")
+    ts_singular = ts_plural[:-1] + [_singularize(ts_plural[-1])]
+
+    for needle in (ts_plural, ts_singular):
+        n = len(needle)
+        for i in range(len(parts) - n + 1):
+            if parts[i : i + n] == needle:
+                remaining = parts[:i] + parts[i + n :]
+                if remaining:
+                    return "-".join(remaining)
+                # Entire name was the toolset name (shouldn't happen in practice)
+                break
+
+    # No toolset component found – use the full name
+    return "-".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Type introspection
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_optional(annotation: Any) -> tuple[Any, bool]:
+    """Unwrap ``X | None`` → ``(X, True)``.  Non-optional → ``(X, False)``."""
+    if isinstance(annotation, types.UnionType):
+        args = [a for a in annotation.__args__ if a is not type(None)]
+        if len(args) == 1:
+            return args[0], True
+        return annotation, False
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union:
+        args = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0], True
+        return annotation, False
+    return annotation, False
+
+
+def _is_id_param(name: str) -> bool:
+    """Return True if a parameter name looks like a resource ID."""
+    return name.endswith("_id")
+
+
+def _get_param_help(func: Callable, param_name: str) -> str | None:
+    """Extract a parameter's help text from the function's docstring."""
+    doc = func.__doc__
+    if not doc:
+        return None
+    for line in doc.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith(f"{param_name}:"):
+            return stripped[len(param_name) + 1 :].strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Parameter builder
+# ---------------------------------------------------------------------------
+
+
+def _build_params(func: Callable) -> list[click.Parameter]:
+    """Build a list of click parameters from *func*'s signature."""
+    sig = inspect.signature(func)
+    hints = typing.get_type_hints(func)
+    params: list[click.Parameter] = []
+
+    for name, param in sig.parameters.items():
+        if name == "ctx":
+            continue
+        annotation = hints.get(name, str)
+        base_type, is_optional = _unwrap_optional(annotation)
+        has_default = param.default is not inspect.Parameter.empty
+        is_required = not is_optional and not has_default
+        cli_name = name.replace("_", "-")
+        help_text = _get_param_help(func, name)
+
+        # Positional argument for required ID strings
+        if base_type is str and _is_id_param(name) and not has_default:
+            params.append(click.Argument([name], type=click.STRING))
+            continue
+
+        # Boolean flag  (--flag / --no-flag, default None)
+        if base_type is bool:
+            params.append(
+                click.Option(
+                    [f"--{cli_name}/--no-{cli_name}"],
+                    default=None,
+                    help=help_text,
+                )
+            )
+            continue
+
+        # Common option kwargs — only set default=None for optional params
+        # (setting default on a required option prevents click from enforcing it)
+        opt_kwargs: dict[str, Any] = {"required": is_required, "help": help_text}
+        if not is_required:
+            opt_kwargs["default"] = None
+
+        # Dict or list[dict] → JSON param
+        if base_type is dict or (
+            typing.get_origin(base_type) is list
+            and typing.get_args(base_type)
+            and typing.get_args(base_type)[0] is dict
+        ):
+            params.append(
+                click.Option([f"--{cli_name}"], type=JSONParam(), **opt_kwargs)
+            )
+            continue
+
+        # list[str] → CSV list
+        if typing.get_origin(base_type) is list:
+            params.append(
+                click.Option([f"--{cli_name}"], type=CSVList(), **opt_kwargs)
+            )
+            continue
+
+        # int
+        if base_type is int:
+            params.append(
+                click.Option([f"--{cli_name}"], type=click.INT, **opt_kwargs)
+            )
+            continue
+
+        # float
+        if base_type is float:
+            params.append(
+                click.Option([f"--{cli_name}"], type=click.FLOAT, **opt_kwargs)
+            )
+            continue
+
+        # Default: string
+        params.append(
+            click.Option([f"--{cli_name}"], type=click.STRING, **opt_kwargs)
+        )
+
+    return params
+
+
+# ---------------------------------------------------------------------------
+# Callback factory
+# ---------------------------------------------------------------------------
+
+
+def _make_callback(func: Callable) -> Callable:
+    """Create a sync click callback that runs the async tool function."""
+
+    def callback(**kwargs: Any) -> None:
+        ctx = click.get_current_context()
+        api_key: str = ctx.obj["api_key"]
+        base_url: str = ctx.obj["base_url"]
+        fmt: str = ctx.obj["format"]
+
+        if not api_key:
+            click.echo(
+                "Error: CHECK_API_KEY is required. "
+                "Set it via --api-key or the CHECK_API_KEY env var.",
+                err=True,
+            )
+            ctx.exit(3)
+            return
+
+        # Strip None values so tool functions use their own defaults
+        call_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+        async def _run() -> dict:
+            async with httpx.AsyncClient(
+                base_url=base_url,
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=30.0,
+            ) as client:
+                check_ctx = CheckContext(client=client, base_url=base_url)
+                cli_ctx = CLIContext(check_ctx)
+                return await func(cli_ctx, **call_kwargs)
+
+        try:
+            result = asyncio.run(_run())
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            ctx.exit(1)
+            return
+
+        if isinstance(result, dict) and result.get("error"):
+            output_result(result, fmt, file=sys.stderr)
+            ctx.exit(1)
+        else:
+            output_result(result, fmt)
+
+    return callback
+
+
+# ---------------------------------------------------------------------------
+# Command builder
+# ---------------------------------------------------------------------------
+
+
+def build_command(
+    func: Callable, toolset_name: str
+) -> tuple[str, click.Command, str]:
+    """Build a click Command from *func*.
+
+    Returns ``(command_name, click_command, tool_function_name)``.
+    """
+    cmd_name = _make_command_name(func.__name__, toolset_name)
+    params = _build_params(func)
+    cb = _make_callback(func)
+
+    # Use first line of docstring as short help
+    help_text = None
+    if func.__doc__:
+        help_text = func.__doc__.strip().split("\n")[0]
+
+    cmd = click.Command(name=cmd_name, params=params, callback=cb, help=help_text)
+    return cmd_name, cmd, func.__name__
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery
+# ---------------------------------------------------------------------------
+
+
+def _collect_module_tools(module: Any) -> list[Callable]:
+    """Call *module*.register() with a collector to capture tool functions."""
+    functions: list[Callable] = []
+
+    class _Collector:
+        @staticmethod
+        def add_tool(fn: Callable, **kwargs: Any) -> None:
+            functions.append(fn)
+
+    module.register(_Collector(), read_only=False)
+    return functions
+
+
+def collect_tools() -> dict[str, list[Callable]]:
+    """Return ``{toolset_name: [func, ...]}`` for every registered toolset."""
+    return {
+        name: _collect_module_tools(module)
+        for name, module in _TOOLSETS.items()
+    }

--- a/src/mcp_server_check/cli/context.py
+++ b/src/mcp_server_check/cli/context.py
@@ -1,0 +1,45 @@
+"""CLI context and authentication for the Check CLI."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from mcp_server_check.helpers import CheckContext
+
+SANDBOX_URL = "https://sandbox.checkhq.com"
+PRODUCTION_URL = "https://api.checkhq.com"
+
+
+@dataclass
+class _RequestContext:
+    lifespan_context: CheckContext
+
+
+class CLIContext:
+    """Minimal context matching the interface expected by tool functions.
+
+    Mirrors the structure of ``mcp.server.fastmcp.Context`` so that existing
+    async tool functions can be called without modification:
+
+        ctx.request_context.lifespan_context -> CheckContext
+    """
+
+    def __init__(self, check_ctx: CheckContext) -> None:
+        self.request_context = _RequestContext(lifespan_context=check_ctx)
+
+
+def resolve_base_url(env: str | None = None) -> str:
+    """Resolve the API base URL from --env flag or CHECK_API_BASE_URL."""
+    explicit = os.environ.get("CHECK_API_BASE_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    env = env or os.environ.get("CHECK_ENV", "sandbox")
+    if env == "production":
+        return PRODUCTION_URL
+    return SANDBOX_URL
+
+
+def resolve_api_key(api_key: str | None = None) -> str | None:
+    """Resolve API key from --api-key flag or CHECK_API_KEY env var."""
+    return api_key or os.environ.get("CHECK_API_KEY")

--- a/src/mcp_server_check/cli/output.py
+++ b/src/mcp_server_check/cli/output.py
@@ -1,0 +1,77 @@
+"""Output formatters for the Check CLI."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def format_json(data: dict | list) -> str:
+    """Format data as compact JSON (pipe-friendly)."""
+    return json.dumps(data, separators=(",", ":"))
+
+
+def format_table(data: dict | list) -> str:
+    """Format data as a human-readable table."""
+    if isinstance(data, dict) and "results" in data:
+        rows = data["results"]
+        if not rows:
+            return "No results."
+        parts = [_format_rows(rows)]
+        if data.get("next_cursor"):
+            parts.append(f"\nNext cursor: {data['next_cursor']}")
+        return "\n".join(parts)
+
+    if isinstance(data, list):
+        if not data:
+            return "No results."
+        return _format_rows(data)
+
+    if isinstance(data, dict):
+        return _format_object(data)
+
+    return str(data)
+
+
+def _format_rows(rows: list[dict]) -> str:
+    """Format a list of dicts as aligned columns."""
+    if not rows:
+        return ""
+    columns = list(rows[0].keys())
+    widths: dict[str, int] = {}
+    for col in columns:
+        values = [str(row.get(col, "")) for row in rows]
+        widths[col] = min(max(len(col), max((len(v) for v in values), default=0)), 40)
+
+    header = "  ".join(col.upper().ljust(widths[col]) for col in columns)
+    separator = "  ".join("-" * widths[col] for col in columns)
+    lines = [header, separator]
+    for row in rows:
+        line = "  ".join(
+            str(row.get(col, ""))[:widths[col]].ljust(widths[col]) for col in columns
+        )
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _format_object(obj: dict) -> str:
+    """Format a single dict as key-value pairs."""
+    if not obj:
+        return "{}"
+    max_key_len = max(len(str(k)) for k in obj)
+    lines = []
+    for key, value in obj.items():
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, indent=2)
+        lines.append(f"{str(key).ljust(max_key_len)}  {value}")
+    return "\n".join(lines)
+
+
+def output_result(data: dict | list, fmt: str, file: object | None = None) -> None:
+    """Print formatted output to *file* (default stdout)."""
+    if file is None:
+        file = sys.stdout
+    if fmt == "table":
+        print(format_table(data), file=file)
+    else:
+        print(format_json(data), file=file)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,275 @@
+"""End-to-end tests for the Check CLI."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import respx
+from click.testing import CliRunner
+
+from mcp_server_check.cli import cli
+
+BASE_URL = "https://sandbox.checkhq.com"
+RUNNER_ENV = {"CHECK_API_KEY": "sk_test_123"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _invoke(*args: str, env: dict | None = None, **kwargs) -> object:
+    runner = CliRunner()
+    merged_env = {**RUNNER_ENV, **(env or {})}
+    return runner.invoke(cli, list(args), env=merged_env, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Basic CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "Check Payroll API CLI" in result.output
+    assert "companies" in result.output
+
+
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert "0.1.0" in result.output
+
+
+def test_help_without_api_key():
+    """--help should work without an API key."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"], env={"CHECK_API_KEY": ""})
+    assert result.exit_code == 0
+    assert "companies" in result.output
+
+
+def test_companies_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["companies", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "get" in result.output
+    assert "create" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Command execution with mocked API
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_companies_list(respx_mock):
+    respx_mock.get("/companies").mock(
+        return_value=httpx.Response(
+            200,
+            json={"results": [{"id": "com_001", "legal_name": "Acme"}], "next": None, "previous": None},
+        )
+    )
+    result = _invoke("companies", "list")
+    assert result.exit_code == 0
+    data = json.loads(result.output.strip())
+    assert data["results"][0]["id"] == "com_001"
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_companies_get(respx_mock):
+    respx_mock.get("/companies/com_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_001", "legal_name": "Acme"})
+    )
+    result = _invoke("companies", "get", "com_001")
+    assert result.exit_code == 0
+    data = json.loads(result.output.strip())
+    assert data["id"] == "com_001"
+    assert data["legal_name"] == "Acme"
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_companies_create(respx_mock):
+    respx_mock.post("/companies").mock(
+        return_value=httpx.Response(201, json={"id": "com_new", "legal_name": "New Co"})
+    )
+    result = _invoke("companies", "create", "--legal-name", "New Co")
+    assert result.exit_code == 0
+    data = json.loads(result.output.strip())
+    assert data["id"] == "com_new"
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_companies_create_with_address_json(respx_mock):
+    route = respx_mock.post("/companies").mock(
+        return_value=httpx.Response(201, json={"id": "com_addr"})
+    )
+    result = _invoke(
+        "companies",
+        "create",
+        "--legal-name",
+        "Addr Co",
+        "--address",
+        '{"line1": "123 Main St", "city": "SF", "state": "CA", "postal_code": "94105"}',
+    )
+    assert result.exit_code == 0
+    body = json.loads(route.calls[0].request.content)
+    assert body["address"]["line1"] == "123 Main St"
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_employees_list_with_options(respx_mock):
+    route = respx_mock.get("/employees").mock(
+        return_value=httpx.Response(
+            200,
+            json={"results": [{"id": "emp_001"}], "next": None, "previous": None},
+        )
+    )
+    result = _invoke("employees", "list", "--company", "com_001", "--limit", "5")
+    assert result.exit_code == 0
+    url = str(route.calls[0].request.url)
+    assert "company=com_001" in url
+    assert "limit=5" in url
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_employees_get_paystub(respx_mock):
+    """Multi-ID positional args work."""
+    respx_mock.get("/employees/emp_001/paystubs/prl_001").mock(
+        return_value=httpx.Response(200, json={"id": "emp_001", "payroll": "prl_001"})
+    )
+    result = _invoke("employees", "get-paystub", "emp_001", "prl_001")
+    assert result.exit_code == 0
+    data = json.loads(result.output.strip())
+    assert data["payroll"] == "prl_001"
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_format_table(respx_mock):
+    respx_mock.get("/companies").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "results": [{"id": "com_001", "legal_name": "Acme"}],
+                "next": None,
+                "previous": None,
+            },
+        )
+    )
+    result = _invoke("--format", "table", "companies", "list")
+    assert result.exit_code == 0
+    assert "ID" in result.output
+    assert "com_001" in result.output
+    assert "Acme" in result.output
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_format_json_compact(respx_mock):
+    respx_mock.get("/companies/com_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_001"})
+    )
+    result = _invoke("companies", "get", "com_001")
+    assert result.exit_code == 0
+    # Compact JSON has no extra spaces
+    assert result.output.strip() == '{"id":"com_001"}'
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_api_error_returns_exit_code_1(respx_mock):
+    respx_mock.get("/companies/com_bad").mock(
+        return_value=httpx.Response(404, json={"error": "not_found"})
+    )
+    result = _invoke("companies", "get", "com_bad")
+    assert result.exit_code == 1
+    # Error output goes to stderr
+    assert "error" in result.stderr
+
+
+def test_missing_api_key():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["companies", "list"], env={"CHECK_API_KEY": ""})
+    assert result.exit_code == 3
+    assert "CHECK_API_KEY" in result.stderr
+
+
+def test_missing_required_option():
+    """create requires --legal-name."""
+    result = _invoke("companies", "create")
+    assert result.exit_code == 2
+    assert "legal-name" in result.output or "legal-name" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Environment / --env switching
+# ---------------------------------------------------------------------------
+
+
+@respx.mock(base_url="https://api.checkhq.com", assert_all_called=False)
+def test_production_env(respx_mock):
+    respx_mock.get("/companies").mock(
+        return_value=httpx.Response(
+            200, json={"results": [], "next": None, "previous": None}
+        )
+    )
+    result = _invoke("--env", "production", "companies", "list")
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_hides_write_commands():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--read-only", "companies", "--help"])
+    assert result.exit_code == 0
+    assert "create" not in result.output
+    assert "update" not in result.output
+    assert "onboard" not in result.output
+    assert "list" in result.output
+    assert "get" in result.output
+
+
+def test_toolsets_env_filters_groups():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"], env={"CHECK_TOOLSETS": "companies"})
+    assert result.exit_code == 0
+    assert "companies" in result.output
+    assert "employees" not in result.output
+
+
+def test_toolsets_env_blocks_access():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["employees", "--help"], env={"CHECK_TOOLSETS": "companies"}
+    )
+    assert result.exit_code == 2
+
+
+@respx.mock(base_url=BASE_URL, assert_all_called=False)
+def test_read_only_env_blocks_write(respx_mock):
+    """CHECK_READ_ONLY=1 should block create commands at runtime."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["companies", "create", "--legal-name", "Nope"],
+        env={"CHECK_API_KEY": "sk_test_123", "CHECK_READ_ONLY": "1"},
+    )
+    # Command should not be found (hidden by filter)
+    assert result.exit_code == 2

--- a/tests/test_cli_codegen.py
+++ b/tests/test_cli_codegen.py
@@ -1,0 +1,364 @@
+"""Tests for CLI code generation (command naming, type mapping, discovery)."""
+
+from __future__ import annotations
+
+import inspect
+import types
+import typing
+
+import click
+
+from mcp_server_check.cli.codegen import (
+    CSVList,
+    JSONParam,
+    _build_params,
+    _is_id_param,
+    _make_command_name,
+    _singularize,
+    _unwrap_optional,
+    build_command,
+    collect_tools,
+)
+from mcp_server_check.helpers import Ctx
+
+
+# ---------------------------------------------------------------------------
+# _singularize
+# ---------------------------------------------------------------------------
+
+
+class TestSingularize:
+    def test_companies(self):
+        assert _singularize("companies") == "company"
+
+    def test_employees(self):
+        assert _singularize("employees") == "employee"
+
+    def test_payrolls(self):
+        assert _singularize("payrolls") == "payroll"
+
+    def test_accounts(self):
+        assert _singularize("accounts") == "account"
+
+    def test_items(self):
+        assert _singularize("items") == "item"
+
+    def test_tax(self):
+        assert _singularize("tax") == "tax"
+
+    def test_platform(self):
+        assert _singularize("platform") == "platform"
+
+    def test_no_double_strip(self):
+        """'ss' ending should not be stripped."""
+        assert _singularize("stress") == "stress"
+
+
+# ---------------------------------------------------------------------------
+# _make_command_name
+# ---------------------------------------------------------------------------
+
+
+class TestMakeCommandName:
+    def test_list_companies(self):
+        assert _make_command_name("list_companies", "companies") == "list"
+
+    def test_get_company(self):
+        assert _make_command_name("get_company", "companies") == "get"
+
+    def test_create_company(self):
+        assert _make_command_name("create_company", "companies") == "create"
+
+    def test_get_company_paydays(self):
+        assert _make_command_name("get_company_paydays", "companies") == "get-paydays"
+
+    def test_list_company_tax_deposits(self):
+        assert _make_command_name("list_company_tax_deposits", "companies") == "list-tax-deposits"
+
+    def test_list_employee_paystubs(self):
+        assert _make_command_name("list_employee_paystubs", "employees") == "list-paystubs"
+
+    def test_get_employee_paystub(self):
+        assert _make_command_name("get_employee_paystub", "employees") == "get-paystub"
+
+    def test_simulate_start_processing(self):
+        """No toolset name in function → full name preserved."""
+        assert _make_command_name("simulate_start_processing", "payrolls") == "simulate-start-processing"
+
+    def test_approve_payroll(self):
+        assert _make_command_name("approve_payroll", "payrolls") == "approve"
+
+    def test_list_bank_accounts(self):
+        assert _make_command_name("list_bank_accounts", "bank_accounts") == "list"
+
+    def test_get_bank_account(self):
+        assert _make_command_name("get_bank_account", "bank_accounts") == "get"
+
+    def test_reveal_bank_account_numbers(self):
+        assert _make_command_name("reveal_bank_account_numbers", "bank_accounts") == "reveal-numbers"
+
+    def test_list_contractor_payments(self):
+        assert _make_command_name("list_contractor_payments", "contractor_payments") == "list"
+
+    def test_get_company_tax_params(self):
+        """tax toolset — strips 'tax' from middle."""
+        assert _make_command_name("get_company_tax_params", "tax") == "get-company-params"
+
+    def test_no_match_full_name(self):
+        """When toolset name not in function name, return full name."""
+        assert _make_command_name("get_payroll_journal_report", "companies") == "get-payroll-journal-report"
+
+
+# ---------------------------------------------------------------------------
+# _unwrap_optional
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapOptional:
+    def test_plain_str(self):
+        base, opt = _unwrap_optional(str)
+        assert base is str
+        assert opt is False
+
+    def test_optional_str(self):
+        base, opt = _unwrap_optional(str | None)
+        assert base is str
+        assert opt is True
+
+    def test_optional_int(self):
+        base, opt = _unwrap_optional(int | None)
+        assert base is int
+        assert opt is True
+
+    def test_optional_dict(self):
+        base, opt = _unwrap_optional(dict | None)
+        assert base is dict
+        assert opt is True
+
+    def test_plain_dict(self):
+        base, opt = _unwrap_optional(dict)
+        assert base is dict
+        assert opt is False
+
+    def test_optional_bool(self):
+        base, opt = _unwrap_optional(bool | None)
+        assert base is bool
+        assert opt is True
+
+    def test_optional_list_str(self):
+        base, opt = _unwrap_optional(list[str] | None)
+        assert typing.get_origin(base) is list
+        assert opt is True
+
+
+# ---------------------------------------------------------------------------
+# _is_id_param
+# ---------------------------------------------------------------------------
+
+
+class TestIsIdParam:
+    def test_company_id(self):
+        assert _is_id_param("company_id") is True
+
+    def test_employee_id(self):
+        assert _is_id_param("employee_id") is True
+
+    def test_legal_name(self):
+        assert _is_id_param("legal_name") is False
+
+    def test_company(self):
+        assert _is_id_param("company") is False
+
+
+# ---------------------------------------------------------------------------
+# _build_params
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParams:
+    def test_excludes_ctx(self):
+        """The ctx parameter should never appear in click params."""
+        async def sample(ctx: Ctx, company_id: str) -> dict:
+            pass
+
+        params = _build_params(sample)
+        param_names = [p.name for p in params]
+        assert "ctx" not in param_names
+        assert "company_id" in param_names
+
+    def test_required_id_is_argument(self):
+        async def sample(ctx: Ctx, company_id: str) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert len(params) == 1
+        assert isinstance(params[0], click.Argument)
+        assert params[0].name == "company_id"
+
+    def test_required_str_is_required_option(self):
+        async def sample(ctx: Ctx, legal_name: str) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert len(params) == 1
+        assert isinstance(params[0], click.Option)
+        assert params[0].required is True
+
+    def test_optional_str(self):
+        async def sample(ctx: Ctx, trade_name: str | None = None) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert len(params) == 1
+        assert isinstance(params[0], click.Option)
+        assert params[0].required is False
+
+    def test_optional_int(self):
+        async def sample(ctx: Ctx, limit: int | None = None) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert isinstance(params[0], click.Option)
+        assert params[0].type is click.INT
+
+    def test_optional_bool(self):
+        async def sample(ctx: Ctx, active: bool | None = None) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert isinstance(params[0], click.Option)
+        assert params[0].is_flag is True
+
+    def test_dict_param(self):
+        async def sample(ctx: Ctx, address: dict | None = None) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert isinstance(params[0].type, JSONParam)
+
+    def test_required_dict(self):
+        async def sample(ctx: Ctx, data: dict) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert isinstance(params[0], click.Option)
+        assert isinstance(params[0].type, JSONParam)
+        assert params[0].required is True
+
+    def test_list_str(self):
+        async def sample(ctx: Ctx, ids: list[str] | None = None) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert isinstance(params[0].type, CSVList)
+
+    def test_list_dict(self):
+        async def sample(ctx: Ctx, parameters: list[dict] | None = None) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert isinstance(params[0].type, JSONParam)
+
+    def test_float_param(self):
+        async def sample(ctx: Ctx, amount: float | None = None) -> dict:
+            pass
+
+        params = _build_params(sample)
+        assert params[0].type is click.FLOAT
+
+
+# ---------------------------------------------------------------------------
+# build_command
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommand:
+    def test_produces_valid_command(self):
+        async def list_companies(ctx: Ctx, limit: int | None = None) -> dict:
+            """List companies."""
+            pass
+
+        cmd_name, cmd, func_name = build_command(list_companies, "companies")
+        assert cmd_name == "list"
+        assert func_name == "list_companies"
+        assert isinstance(cmd, click.Command)
+        assert cmd.help == "List companies."
+
+    def test_multiple_id_args(self):
+        async def get_employee_paystub(
+            ctx: Ctx, employee_id: str, payroll_id: str
+        ) -> dict:
+            """Get paystub."""
+            pass
+
+        cmd_name, cmd, _ = build_command(get_employee_paystub, "employees")
+        assert cmd_name == "get-paystub"
+        args = [p for p in cmd.params if isinstance(p, click.Argument)]
+        assert len(args) == 2
+        assert args[0].name == "employee_id"
+        assert args[1].name == "payroll_id"
+
+
+# ---------------------------------------------------------------------------
+# collect_tools — full discovery
+# ---------------------------------------------------------------------------
+
+
+class TestCollectTools:
+    def test_returns_all_toolsets(self):
+        tools = collect_tools()
+        assert len(tools) == 17
+        assert "companies" in tools
+        assert "employees" in tools
+        assert "payrolls" in tools
+        assert "bank_accounts" in tools
+        assert "tax" in tools
+
+    def test_all_functions_are_async(self):
+        tools = collect_tools()
+        for toolset_name, funcs in tools.items():
+            for fn in funcs:
+                assert inspect.iscoroutinefunction(fn), (
+                    f"{toolset_name}.{fn.__name__} is not async"
+                )
+
+    def test_all_functions_have_ctx_param(self):
+        tools = collect_tools()
+        for toolset_name, funcs in tools.items():
+            for fn in funcs:
+                sig = inspect.signature(fn)
+                assert "ctx" in sig.parameters, (
+                    f"{toolset_name}.{fn.__name__} missing ctx param"
+                )
+
+    def test_every_function_produces_valid_command(self):
+        """Every registered tool function should produce a valid click command."""
+        tools = collect_tools()
+        total = 0
+        for toolset_name, funcs in tools.items():
+            for fn in funcs:
+                cmd_name, cmd, func_name = build_command(fn, toolset_name)
+                assert cmd_name, f"Empty command name for {fn.__name__}"
+                assert isinstance(cmd, click.Command)
+                assert func_name == fn.__name__
+                # ctx should not appear in click params
+                param_names = [p.name for p in cmd.params]
+                assert "ctx" not in param_names, (
+                    f"ctx leaked into params for {fn.__name__}"
+                )
+                total += 1
+        # Sanity check: we should have a large number of commands
+        assert total > 200, f"Expected 200+ tools but found {total}"
+
+    def test_no_duplicate_command_names_per_toolset(self):
+        """Each toolset should have unique command names."""
+        tools = collect_tools()
+        for toolset_name, funcs in tools.items():
+            names = []
+            for fn in funcs:
+                cmd_name, _, _ = build_command(fn, toolset_name)
+                names.append(cmd_name)
+            assert len(names) == len(set(names)), (
+                f"Duplicate command names in {toolset_name}: "
+                f"{[n for n in names if names.count(n) > 1]}"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -348,6 +348,7 @@ name = "mcp-server-check"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "httpx" },
     { name = "mcp" },
 ]
@@ -361,6 +362,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
## Summary

- Adds a `check` CLI that reuses all 263 async tool functions from the MCP server with zero modifications to existing code
- Commands are auto-generated from function signatures at import time, producing a Stripe CLI-style resource-oriented interface (`check companies list`, `check payrolls approve <id>`)
- Supports all existing filtering: `--read-only`, `CHECK_TOOLSETS`, `CHECK_TOOLS`, `CHECK_EXCLUDE_TOOLS`
- JSON (compact, pipe-friendly) and table output formats
- JSON params support inline strings and `@filename` (including `@-` for stdin)
- Full documentation in `CLI.md`

## New files

| File | Purpose |
|---|---|
| `src/mcp_server_check/cli/context.py` | Duck-typed `CLIContext` matching tool function interface |
| `src/mcp_server_check/cli/codegen.py` | Introspects signatures → click commands (type mapping, naming) |
| `src/mcp_server_check/cli/output.py` | Compact JSON and table formatters |
| `src/mcp_server_check/cli/__init__.py` | Filtered click groups, global options, entry point |
| `CLI.md` | CLI documentation |
| `tests/test_cli.py` | 20 end-to-end CLI tests |
| `tests/test_cli_codegen.py` | 52 codegen unit tests |

## Modified files

- `pyproject.toml` — added `click>=8.0.0` dep, added `check` entry point

## Test plan

- [x] 245 tests pass (173 existing + 72 new, zero regressions)
- [x] `check --help` shows all 17 toolset groups
- [x] `check companies list` / `get` / `create` work end-to-end
- [x] `--format table` produces aligned columns
- [x] `--read-only` hides write commands from `--help`
- [x] `CHECK_TOOLSETS` filters groups
- [x] Exit codes: 0=success, 1=API error, 2=usage, 3=auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)