### PR TITLE
Port MCP server to TypeScript (Cloudflare Workers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist/
 build/
 .pytest_cache/
 .ruff_cache/
+
+# TypeScript / Node
+node_modules/
+ts/dist/

--- a/README.md
+++ b/README.md
@@ -491,6 +491,21 @@ Generate embeddable UI component URLs via `POST /{entity_type}/{entity_id}/compo
 **Contractor components (1):**
 `create_contractor_tax_documents_component`
 
+## TypeScript / Cloudflare Workers
+
+A TypeScript port of this server lives in the `ts/` directory, targeting Cloudflare Workers. It uses the `@modelcontextprotocol/sdk` McpServer with native `fetch` and registers the same 263 tools with identical names, parameters, and behavior.
+
+```bash
+cd ts
+npm install
+npm test          # 75 tests
+npm run typecheck # zero errors
+npm run dev       # local Cloudflare Workers dev server
+npx tsx src/stdio.ts  # stdio mode for Claude Desktop
+```
+
+See `ts/` for full details.
+
 ## Development
 
 ```bash

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,0 +1,4685 @@
+{
+  "name": "mcp-server-check",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-server-check",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "agents": "^0.0.98",
+        "zod": "^3.24.4"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250313.0",
+        "@types/node": "^25.5.0",
+        "tsx": "^4.19.4",
+        "typescript": "^5.7.3",
+        "vitest": "^3.1.1",
+        "wrangler": "^4.14.4"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
+      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
+      "dev": true,
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260312.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260312.1.tgz",
+      "integrity": "sha512-HUAtDWaqUduS6yasV6+NgsK7qBpP1qGU49ow/Wb117IHjYp+PZPUGReDYocpB4GOMRoQlvdd4L487iFxzdARpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260312.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260312.1.tgz",
+      "integrity": "sha512-DOn7TPTHSxJYfi4m4NYga/j32wOTqvJf/pY4Txz5SDKWIZHSTXFyGz2K4B+thoPWLop/KZxGoyTv7db0mk/qyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260312.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260312.1.tgz",
+      "integrity": "sha512-TdkIh3WzPXYHuvz7phAtFEEvAxvFd30tHrm4gsgpw0R0F5b8PtoM3hfL2uY7EcBBWVYUBtkY2ahDYFfufnXw/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260312.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260312.1.tgz",
+      "integrity": "sha512-kNauZhL569Iy94t844OMwa1zP6zKFiL3xiJ4tGLS+TFTEfZ3pZsRH6lWWOtkXkjTyCmBEOog0HSEKjIV4oAffw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260312.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260312.1.tgz",
+      "integrity": "sha512-5dBrlSK+nMsZy5bYQpj8t9iiQNvCRlkm9GGvswJa9vVU/1BNO4BhJMlqOLWT24EmFyApZ+kaBiPJMV8847NDTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260313.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260313.1.tgz",
+      "integrity": "sha512-jMEeX3RKfOSVqqXRKr/ulgglcTloeMzSH3FdzIfqJHtvc12/ELKd5Ldsg8ZHahKX/4eRxYdw3kbzb8jLXbq/jQ=="
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
+      "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
+      "dev": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg=="
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agents": {
+      "version": "0.0.98",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.0.98.tgz",
+      "integrity": "sha512-tl5/TMt2nheODiIc7ltbj0nLVKRZlqMEqSMehUu9unPF2H/XWBTC9owqY7iTle38yACfsJ129bJEg/CiqcIxRQ==",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.13.1",
+        "ai": "^4.3.16",
+        "cron-schedule": "^5.0.4",
+        "nanoid": "^5.1.5",
+        "partyserver": "^0.0.72",
+        "partysocket": "1.1.4",
+        "zod": "^3.25.67"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cron-schedule": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-5.0.4.tgz",
+      "integrity": "sha512-nH0a49E/kSVk6BeFgKZy4uUsy6D2A16p120h5bYD9ILBhQu7o2sJFH+WI4R731TSBQ0dB1Ik7inB/dRAB4C8QQ==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ=="
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260312.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260312.0.tgz",
+      "integrity": "sha512-pieP2rfXynPT6VRINYaiHe/tfMJ4c5OIhqRlIdLF6iZ9g5xgpEmvimvIgMpgAdDJuFlrLcwDUi8MfAo2R6dt/w==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.18.2",
+        "workerd": "1.20260312.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/partyserver": {
+      "version": "0.0.72",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.0.72.tgz",
+      "integrity": "sha512-mYkCQ6Q4KBIy4lFFuA6upmvNeD/FC+CQVTd4V3DYU6nsitKVI3NXxBrNNvmIxJLSwk3JQzYcEOPBkebB7ITVpQ==",
+      "dependencies": {
+        "nanoid": "^5.1.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20240729.0"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.4.tgz",
+      "integrity": "sha512-jXP7PFj2h5/v4UjDS8P7MZy6NJUQ7sspiFyxL4uc/+oKOL+KdtXzHnTV8INPGxBrLTXgalyG3kd12Qm7WrYc3A==",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260312.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260312.1.tgz",
+      "integrity": "sha512-nNpPkw9jaqo79B+iBCOiksx+N62xC+ETIfyzofUEdY3cSOHJg6oNnVSHm7vHevzVblfV76c8Gr0cXHEapYMBEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260312.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260312.1",
+        "@cloudflare/workerd-linux-64": "1.20260312.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260312.1",
+        "@cloudflare/workerd-windows-64": "1.20260312.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.73.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.73.0.tgz",
+      "integrity": "sha512-VJXsqKDFCp6OtFEHXITSOR5kh95JOknwPY8m7RyQuWJQguSybJy43m4vhoCSt42prutTef7eeuw7L4V4xiynGw==",
+      "dev": true,
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.15.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260312.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260312.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260312.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mcp-server-check",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "stdio": "npx tsx src/stdio.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "agents": "^0.0.98",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250313.0",
+    "@types/node": "^25.5.0",
+    "tsx": "^4.19.4",
+    "typescript": "^5.7.3",
+    "vitest": "^3.1.1",
+    "wrangler": "^4.14.4"
+  }
+}

--- a/ts/src/env.ts
+++ b/ts/src/env.ts
@@ -1,0 +1,9 @@
+/** Worker bindings / environment variables. */
+export interface Env {
+  CHECK_API_KEY: string;
+  CHECK_API_BASE_URL?: string;
+  CHECK_TOOLSETS?: string;
+  CHECK_TOOLS?: string;
+  CHECK_EXCLUDE_TOOLS?: string;
+  CHECK_READ_ONLY?: string;
+}

--- a/ts/src/helpers.ts
+++ b/ts/src/helpers.ts
@@ -1,0 +1,152 @@
+/** Shared helpers for the Check MCP server. */
+
+export interface CheckApiOptions {
+  apiKey: string;
+  baseUrl: string;
+}
+
+const DEFAULT_BASE_URL = "https://sandbox.checkhq.com";
+
+export function buildApiOptions(apiKey: string, baseUrl?: string): CheckApiOptions {
+  return {
+    apiKey,
+    baseUrl: (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, ""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pagination helpers
+// ---------------------------------------------------------------------------
+
+export function extractCursor(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    return parsed.searchParams.get("cursor") ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatListResponse(data: Record<string, unknown>): Record<string, unknown> {
+  return {
+    results: data.results ?? [],
+    next_cursor: extractCursor(data.next as string | undefined),
+    previous_cursor: extractCursor(data.previous as string | undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core request function — never throws
+// ---------------------------------------------------------------------------
+
+export async function checkApiRequest(
+  api: CheckApiOptions,
+  method: string,
+  path: string,
+  options?: {
+    params?: Record<string, unknown>;
+    data?: unknown;
+  },
+): Promise<Record<string, unknown>> {
+  const url = new URL(`${api.baseUrl}${path}`);
+  if (options?.params) {
+    for (const [k, v] of Object.entries(options.params)) {
+      if (v !== undefined && v !== null) {
+        url.searchParams.set(k, String(v));
+      }
+    }
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${api.apiKey}`,
+    Accept: "application/json",
+  };
+
+  const init: RequestInit = { method, headers };
+
+  if (options?.data !== undefined) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(options.data);
+  }
+
+  try {
+    const response = await fetch(url.toString(), init);
+
+    if (!response.ok) {
+      let errorBody: unknown;
+      try {
+        errorBody = await response.json();
+      } catch {
+        errorBody = await response.text();
+      }
+      return {
+        error: true,
+        status_code: response.status,
+        detail: errorBody,
+      };
+    }
+
+    if (response.status === 204) {
+      return { success: true };
+    }
+
+    return (await response.json()) as Record<string, unknown>;
+  } catch (e: unknown) {
+    return { error: true, detail: String(e) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrappers
+// ---------------------------------------------------------------------------
+
+export function checkApiGet(
+  api: CheckApiOptions,
+  path: string,
+  params?: Record<string, unknown>,
+) {
+  return checkApiRequest(api, "GET", path, { params });
+}
+
+export function checkApiPost(
+  api: CheckApiOptions,
+  path: string,
+  data?: unknown,
+) {
+  return checkApiRequest(api, "POST", path, { data });
+}
+
+export function checkApiPatch(
+  api: CheckApiOptions,
+  path: string,
+  data: unknown,
+) {
+  return checkApiRequest(api, "PATCH", path, { data });
+}
+
+export function checkApiPut(
+  api: CheckApiOptions,
+  path: string,
+  data: unknown,
+) {
+  return checkApiRequest(api, "PUT", path, { data });
+}
+
+export function checkApiDelete(
+  api: CheckApiOptions,
+  path: string,
+  params?: Record<string, unknown>,
+) {
+  return checkApiRequest(api, "DELETE", path, { params });
+}
+
+export async function checkApiList(
+  api: CheckApiOptions,
+  path: string,
+  params?: Record<string, unknown>,
+) {
+  const data = await checkApiGet(api, path, params);
+  if ("error" in data) return data;
+  return formatListResponse(data);
+}

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,0 +1,40 @@
+/** Cloudflare Worker entrypoint — Streamable HTTP MCP transport. */
+
+import { McpAgent } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Env } from "./env.js";
+import { buildApiOptions } from "./helpers.js";
+import { ToolFilter } from "./tool-filter.js";
+import { registerAll } from "./tools/index.js";
+
+export class CheckMcpAgent extends McpAgent<Env> {
+  server = new McpServer({
+    name: "Check Payroll API",
+    version: "0.1.0",
+  });
+
+  async init() {
+    const staticFilter = ToolFilter.fromEnv(this.env);
+    // TODO: when agents package supports per-request headers, merge header filter
+    const api = buildApiOptions(this.env.CHECK_API_KEY, this.env.CHECK_API_BASE_URL);
+    registerAll(this.server, api, staticFilter);
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/sse" || url.pathname === "/sse/message") {
+      // @ts-expect-error — McpAgent.fetch typing
+      return CheckMcpAgent.fetch(request, env, ctx);
+    }
+
+    if (url.pathname === "/mcp") {
+      // @ts-expect-error — McpAgent.fetch typing
+      return CheckMcpAgent.fetch(request, env, ctx);
+    }
+
+    return new Response("Check Payroll MCP Server", { status: 200 });
+  },
+};

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -1,0 +1,19 @@
+/** Factory: create a configured McpServer with filtered tools registered. */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Env } from "./env.js";
+import { buildApiOptions } from "./helpers.js";
+import { ToolFilter } from "./tool-filter.js";
+import { registerAll } from "./tools/index.js";
+
+export function createServer(env: Env, filter: ToolFilter): McpServer {
+  const server = new McpServer({
+    name: "Check Payroll API",
+    version: "0.1.0",
+  });
+
+  const api = buildApiOptions(env.CHECK_API_KEY, env.CHECK_API_BASE_URL);
+  registerAll(server, api, filter);
+
+  return server;
+}

--- a/ts/src/stdio.ts
+++ b/ts/src/stdio.ts
@@ -1,0 +1,41 @@
+/** Node.js stdio entrypoint for local dev with Claude Desktop. */
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Env } from "./env.js";
+import { createServer } from "./server.js";
+import { ToolFilter } from "./tool-filter.js";
+
+async function main() {
+  const apiKey = process.env.CHECK_API_KEY;
+  if (!apiKey) {
+    console.error("Error: CHECK_API_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  const env: Env = {
+    CHECK_API_KEY: apiKey,
+    CHECK_API_BASE_URL: process.env.CHECK_API_BASE_URL,
+    CHECK_TOOLSETS: process.env.CHECK_TOOLSETS,
+    CHECK_TOOLS: process.env.CHECK_TOOLS,
+    CHECK_EXCLUDE_TOOLS: process.env.CHECK_EXCLUDE_TOOLS,
+    CHECK_READ_ONLY: process.env.CHECK_READ_ONLY,
+  };
+
+  const filter = ToolFilter.fromEnv(env);
+
+  if (filter.readOnly) {
+    console.error("Running in read-only mode (CHECK_READ_ONLY is set)");
+  }
+  if (filter.toolsets) {
+    console.error(`Active toolsets: ${[...filter.toolsets].sort().join(", ")}`);
+  }
+
+  const server = createServer(env, filter);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/ts/src/tool-filter.ts
+++ b/ts/src/tool-filter.ts
@@ -1,0 +1,135 @@
+/** Toolset-based tool filtering for the Check MCP server. */
+
+import type { Env } from "./env.js";
+
+export const TOOLSETS: ReadonlySet<string> = new Set([
+  "bank_accounts",
+  "companies",
+  "compensation",
+  "components",
+  "contractor_payments",
+  "contractors",
+  "documents",
+  "employees",
+  "external_payrolls",
+  "forms",
+  "payments",
+  "payroll_items",
+  "payrolls",
+  "platform",
+  "tax",
+  "webhooks",
+  "workplaces",
+]);
+
+const WRITE_PREFIXES = [
+  "create_",
+  "update_",
+  "delete_",
+  "bulk_update_",
+  "bulk_delete_",
+];
+
+const WRITE_KEYWORDS = [
+  "approve_",
+  "reopen_",
+  "onboard_",
+  "submit_",
+  "sign_and_submit_",
+  "authorize_",
+  "simulate_",
+  "retry_",
+  "refund_",
+  "cancel_",
+  "start_implementation",
+  "cancel_implementation",
+  "request_embedded_setup",
+  "ping_",
+  "refresh_",
+  "toggle_",
+  "sync_",
+  "upload_",
+  "request_tax_",
+];
+
+export function isWriteTool(name: string): boolean {
+  return (
+    WRITE_PREFIXES.some((p) => name.startsWith(p)) ||
+    WRITE_KEYWORDS.some((k) => name.startsWith(k))
+  );
+}
+
+function parseCommaSet(value: string | undefined | null): ReadonlySet<string> | null {
+  if (!value) return null;
+  const items = new Set(
+    value
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  return items.size > 0 ? items : null;
+}
+
+function parseBool(value: string | undefined | null): boolean {
+  return ["1", "true", "yes"].includes((value ?? "").toLowerCase());
+}
+
+export class ToolFilter {
+  readonly toolsets: ReadonlySet<string> | null;
+  readonly tools: ReadonlySet<string> | null;
+  readonly excludeTools: ReadonlySet<string>;
+  readonly readOnly: boolean;
+
+  constructor(opts?: {
+    toolsets?: ReadonlySet<string> | null;
+    tools?: ReadonlySet<string> | null;
+    excludeTools?: ReadonlySet<string>;
+    readOnly?: boolean;
+  }) {
+    let toolsets = opts?.toolsets ?? null;
+    if (toolsets !== null) {
+      const valid = new Set([...toolsets].filter((t) => TOOLSETS.has(t)));
+      toolsets = valid;
+    }
+    this.toolsets = toolsets;
+    this.tools = opts?.tools ?? null;
+    this.excludeTools = opts?.excludeTools ?? new Set();
+    this.readOnly = opts?.readOnly ?? false;
+  }
+
+  isToolAllowed(toolName: string, toolsetName: string): boolean {
+    if (this.excludeTools.has(toolName)) return false;
+    if (this.readOnly && isWriteTool(toolName)) return false;
+    if (this.tools !== null) return this.tools.has(toolName);
+    if (this.toolsets !== null) return this.toolsets.has(toolsetName);
+    return true;
+  }
+
+  /** True when no filtering is configured (default state). */
+  isDefault(): boolean {
+    return (
+      this.toolsets === null &&
+      this.tools === null &&
+      this.excludeTools.size === 0 &&
+      !this.readOnly
+    );
+  }
+
+  static fromEnv(env: Env): ToolFilter {
+    return new ToolFilter({
+      toolsets: parseCommaSet(env.CHECK_TOOLSETS),
+      tools: parseCommaSet(env.CHECK_TOOLS),
+      excludeTools: parseCommaSet(env.CHECK_EXCLUDE_TOOLS) ?? new Set(),
+      readOnly: parseBool(env.CHECK_READ_ONLY),
+    });
+  }
+
+  static fromHeaders(headers: Headers): ToolFilter {
+    return new ToolFilter({
+      toolsets: parseCommaSet(headers.get("x-mcp-toolsets")),
+      tools: parseCommaSet(headers.get("x-mcp-tools")),
+      excludeTools: parseCommaSet(headers.get("x-mcp-exclude-tools")) ?? new Set(),
+      readOnly: parseBool(headers.get("x-mcp-readonly")),
+    });
+  }
+}

--- a/ts/src/tools/_register.ts
+++ b/ts/src/tools/_register.ts
@@ -1,0 +1,25 @@
+/** Shared tool registration helper. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolFilter } from "../tool-filter.js";
+
+/**
+ * Register a single tool on the server if the filter allows it.
+ * Wraps `server.tool()` to avoid TypeScript overload-resolution issues
+ * when using spread args.
+ */
+export function tool(
+  server: McpServer,
+  filter: ToolFilter,
+  toolsetName: string,
+  name: string,
+  description: string,
+  schema: Record<string, z.ZodTypeAny>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (args: any, extra: any) => any,
+) {
+  if (filter.isToolAllowed(name, toolsetName)) {
+    server.tool(name, description, schema, handler);
+  }
+}

--- a/ts/src/tools/bank-accounts.ts
+++ b/ts/src/tools/bank-accounts.ts
@@ -1,0 +1,136 @@
+/** Bank account tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiDelete,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_bank_accounts",
+    "List bank accounts, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to bank accounts belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/bank_accounts", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_bank_account",
+    "Get details for a specific bank account.",
+    {
+      bank_account_id: z.string().describe("The Check bank account ID."),
+    },
+    async ({ bank_account_id }) => {
+      const result = await checkApiGet(api, `/bank_accounts/${bank_account_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_bank_account",
+    "Create a new bank account. Provide either raw_bank_account or plaid_bank_account, plus exactly one of employee, company, or contractor to indicate who owns the account.",
+    {
+      raw_bank_account: z.record(z.unknown()).optional().describe('Bank account details dict with keys: account_number (required), routing_number (required), subtype (required -- "checking" or "savings"), institution_name (optional).'),
+      plaid_bank_account: z.record(z.unknown()).optional().describe("Plaid token dict with key: plaid_processor_token (required)."),
+      employee: z.string().optional().describe("ID of the employee who owns this account."),
+      company: z.string().optional().describe("ID of the company who owns this account."),
+      contractor: z.string().optional().describe("ID of the contractor who owns this account."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ raw_bank_account, plaid_bank_account, employee, company, contractor, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (raw_bank_account !== undefined) body.raw_bank_account = raw_bank_account;
+      if (plaid_bank_account !== undefined) body.plaid_bank_account = plaid_bank_account;
+      if (employee !== undefined) body.employee = employee;
+      if (company !== undefined) body.company = company;
+      if (contractor !== undefined) body.contractor = contractor;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/bank_accounts", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_bank_account",
+    "Update a bank account.",
+    {
+      bank_account_id: z.string().describe("The Check bank account ID."),
+      raw_bank_account: z.record(z.unknown()).optional().describe('Bank account details dict with keys: account_number, routing_number, subtype ("checking" or "savings"), institution_name.'),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ bank_account_id, raw_bank_account, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (raw_bank_account !== undefined) body.raw_bank_account = raw_bank_account;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/bank_accounts/${bank_account_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_bank_account",
+    "Delete a bank account.",
+    {
+      bank_account_id: z.string().describe("The Check bank account ID."),
+    },
+    async ({ bank_account_id }) => {
+      const result = await checkApiDelete(api, `/bank_accounts/${bank_account_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "reveal_bank_account_number",
+    "Reveal the full account number for a bank account.",
+    {
+      bank_account_id: z.string().describe("The Check bank account ID."),
+    },
+    async ({ bank_account_id }) => {
+      const result = await checkApiGet(api, `/bank_accounts/${bank_account_id}/reveal`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/companies.ts
+++ b/ts/src/tools/companies.ts
@@ -1,0 +1,537 @@
+/** Company tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiPut,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  // ---------------------------------------------------------------------------
+  // Read tools
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_companies",
+    "List companies, optionally filtering by active status or specific IDs.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      active: z.boolean().optional().describe("Filter by active status."),
+      ids: z.array(z.string()).optional().describe("Filter to specific company IDs."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, active, ids, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (active !== undefined) params.active = String(active);
+      if (ids !== undefined) params.ids = ids.join(",");
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/companies", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company",
+    "Get details for a specific company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiGet(api, `/companies/${company_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_paydays",
+    "Get paydays for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      start_date: z.string().optional().describe("Start date filter (YYYY-MM-DD)."),
+      end_date: z.string().optional().describe("End date filter (YYYY-MM-DD)."),
+      pay_schedule: z.string().optional().describe("Filter to a specific pay schedule ID."),
+    },
+    async ({ company_id, start_date, end_date, pay_schedule }) => {
+      const params: Record<string, unknown> = {};
+      if (start_date !== undefined) params.start_date = start_date;
+      if (end_date !== undefined) params.end_date = end_date;
+      if (pay_schedule !== undefined) params.pay_schedule = pay_schedule;
+      const result = await checkApiGet(api, `/companies/${company_id}/paydays`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_tax_deposits",
+    "List tax deposits for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/companies/${company_id}/tax_deposits`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_benefit_aggregations",
+    "Get benefit aggregations for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      start_date: z.string().optional().describe("Start date filter (YYYY-MM-DD)."),
+      end_date: z.string().optional().describe("End date filter (YYYY-MM-DD)."),
+    },
+    async ({ company_id, start_date, end_date }) => {
+      const params: Record<string, unknown> = {};
+      if (start_date !== undefined) params.start_date = start_date;
+      if (end_date !== undefined) params.end_date = end_date;
+      const result = await checkApiGet(api, `/companies/${company_id}/benefit_aggregations`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll_journal_report",
+    "Get the payroll journal report for a company within a date range.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      start_date: z.string().describe("Report start date (YYYY-MM-DD)."),
+      end_date: z.string().describe("Report end date (YYYY-MM-DD)."),
+    },
+    async ({ company_id, start_date, end_date }) => {
+      const params: Record<string, unknown> = { start_date, end_date };
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/payroll_journal`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll_summary_report",
+    "Get the payroll summary report for a company within a date range.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      start_date: z.string().describe("Report start date (YYYY-MM-DD)."),
+      end_date: z.string().describe("Report end date (YYYY-MM-DD)."),
+    },
+    async ({ company_id, start_date, end_date }) => {
+      const params: Record<string, unknown> = { start_date, end_date };
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/payroll_summary`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_tax_liabilities_report",
+    "Get the tax liabilities report for a company within a date range.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      start_date: z.string().describe("Report start date (YYYY-MM-DD)."),
+      end_date: z.string().describe("Report end date (YYYY-MM-DD)."),
+    },
+    async ({ company_id, start_date, end_date }) => {
+      const params: Record<string, unknown> = { start_date, end_date };
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/tax_liabilities`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_contractor_payments_report",
+    "Get the contractor payments report for a company within a date range.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      start_date: z.string().describe("Report start date (YYYY-MM-DD)."),
+      end_date: z.string().describe("Report end date (YYYY-MM-DD)."),
+    },
+    async ({ company_id, start_date, end_date }) => {
+      const params: Record<string, unknown> = { start_date, end_date };
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/contractor_payments`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_child_support_payments_report",
+    "Get the child support payments report for a company within a date range.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      start_date: z.string().describe("Report start date (YYYY-MM-DD)."),
+      end_date: z.string().describe("Report end date (YYYY-MM-DD)."),
+    },
+    async ({ company_id, start_date, end_date }) => {
+      const params: Record<string, unknown> = { start_date, end_date };
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/child_support_payments`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_w4_exemption_status_report",
+    "Get the W-4 exemption status report for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/w4_exemption_status`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_applied_for_ids_detailed_report",
+    "Get the detailed applied-for IDs report for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/applied_for_ids_detailed`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_w2_preview_report",
+    "Get the W-2 preview report for a company for a specific year.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      year: z.string().describe("Tax year (e.g. 2024)."),
+    },
+    async ({ company_id, year }) => {
+      const params: Record<string, unknown> = { year };
+      const result = await checkApiGet(api, `/companies/${company_id}/reports/w2_preview`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_federal_ein_verifications",
+    "List federal EIN verifications for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/companies/${company_id}/federal_ein_verifications`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_federal_ein_verification",
+    "Get details for a specific federal EIN verification.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      verification_id: z.string().describe("The federal EIN verification ID."),
+    },
+    async ({ company_id, verification_id }) => {
+      const result = await checkApiGet(api, `/companies/${company_id}/federal_ein_verifications/${verification_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_signatories",
+    "List signatories for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/companies/${company_id}/signatories`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_enrollment_profile",
+    "Get the enrollment profile for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiGet(api, `/companies/${company_id}/enrollment_profile`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Write tools
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_company",
+    "Create a new company.",
+    {
+      legal_name: z.string().describe("The company's legal name."),
+      trade_name: z.string().optional().describe("The company's trade name / DBA."),
+      other_business_name: z.string().optional().describe("Any other business name."),
+      business_type: z.string().optional().describe('Business entity type (e.g. "llc", "s_corp", "c_corp").'),
+      industry_type: z.string().optional().describe("Industry type / NAICS code."),
+      website: z.string().optional().describe("Company website URL."),
+      email: z.string().optional().describe("Company email address."),
+      phone: z.string().optional().describe("Company phone number."),
+      address: z.record(z.unknown()).optional().describe("Company address dict with keys: line1, line2, city, state, postal_code, country."),
+      pay_frequency: z.string().optional().describe('Default pay frequency (e.g. "weekly", "biweekly", "semimonthly", "monthly").'),
+      start_date: z.string().optional().describe("Company start date (YYYY-MM-DD)."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ legal_name, trade_name, other_business_name, business_type, industry_type, website, email, phone, address, pay_frequency, start_date, metadata }) => {
+      const body: Record<string, unknown> = { legal_name };
+      if (trade_name !== undefined) body.trade_name = trade_name;
+      if (other_business_name !== undefined) body.other_business_name = other_business_name;
+      if (business_type !== undefined) body.business_type = business_type;
+      if (industry_type !== undefined) body.industry_type = industry_type;
+      if (website !== undefined) body.website = website;
+      if (email !== undefined) body.email = email;
+      if (phone !== undefined) body.phone = phone;
+      if (address !== undefined) body.address = address;
+      if (pay_frequency !== undefined) body.pay_frequency = pay_frequency;
+      if (start_date !== undefined) body.start_date = start_date;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/companies", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_company",
+    "Update an existing company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      legal_name: z.string().optional().describe("The company's legal name."),
+      trade_name: z.string().optional().describe("The company's trade name / DBA."),
+      other_business_name: z.string().optional().describe("Any other business name."),
+      business_type: z.string().optional().describe('Business entity type (e.g. "llc", "s_corp", "c_corp").'),
+      industry_type: z.string().optional().describe("Industry type / NAICS code."),
+      website: z.string().optional().describe("Company website URL."),
+      email: z.string().optional().describe("Company email address."),
+      phone: z.string().optional().describe("Company phone number."),
+      address: z.record(z.unknown()).optional().describe("Company address dict with keys: line1, line2, city, state, postal_code, country."),
+      principal_place_of_business: z.record(z.unknown()).optional().describe("Principal place of business address."),
+      pay_frequency: z.string().optional().describe('Default pay frequency (e.g. "weekly", "biweekly", "semimonthly", "monthly").'),
+      processing_period: z.string().optional().describe('Processing period setting (e.g. "two_day", "four_day").'),
+      start_date: z.string().optional().describe("Company start date (YYYY-MM-DD)."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+      default_bank_account: z.string().optional().describe("Default bank account ID."),
+    },
+    async ({ company_id, legal_name, trade_name, other_business_name, business_type, industry_type, website, email, phone, address, principal_place_of_business, pay_frequency, processing_period, start_date, metadata, default_bank_account }) => {
+      const body: Record<string, unknown> = {};
+      if (legal_name !== undefined) body.legal_name = legal_name;
+      if (trade_name !== undefined) body.trade_name = trade_name;
+      if (other_business_name !== undefined) body.other_business_name = other_business_name;
+      if (business_type !== undefined) body.business_type = business_type;
+      if (industry_type !== undefined) body.industry_type = industry_type;
+      if (website !== undefined) body.website = website;
+      if (email !== undefined) body.email = email;
+      if (phone !== undefined) body.phone = phone;
+      if (address !== undefined) body.address = address;
+      if (principal_place_of_business !== undefined) body.principal_place_of_business = principal_place_of_business;
+      if (pay_frequency !== undefined) body.pay_frequency = pay_frequency;
+      if (processing_period !== undefined) body.processing_period = processing_period;
+      if (start_date !== undefined) body.start_date = start_date;
+      if (metadata !== undefined) body.metadata = metadata;
+      if (default_bank_account !== undefined) body.default_bank_account = default_bank_account;
+      const result = await checkApiPatch(api, `/companies/${company_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "onboard_company",
+    "Onboard a company, transitioning it from setup to active.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/onboard`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_signatory",
+    "Create a new signatory for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      first_name: z.string().describe("Signatory's first name."),
+      last_name: z.string().describe("Signatory's last name."),
+      title: z.string().describe("Signatory's title."),
+      email: z.string().describe("Signatory's email address."),
+      middle_name: z.string().optional().describe("Signatory's middle name."),
+    },
+    async ({ company_id, first_name, last_name, title, email, middle_name }) => {
+      const body: Record<string, unknown> = { first_name, last_name, title, email };
+      if (middle_name !== undefined) body.middle_name = middle_name;
+      const result = await checkApiPost(api, `/companies/${company_id}/signatories`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_enrollment_profile",
+    "Create an enrollment profile for a company. Pass all fields as a data dict since there are 20+ optional fields.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.record(z.unknown()).describe("Enrollment profile data with fields such as employee_count, contractor_count, pay_period_amount, previous_payroll_provider, first_payroll, first_payroll_of_year, user_since, expected_first_payday, approved_for_payment_processing, etc."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPut(api, `/companies/${company_id}/enrollment_profile`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_enrollment_profile",
+    "Update the enrollment profile for a company. Pass all fields as a data dict since there are 20+ optional fields.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.record(z.unknown()).describe("Enrollment profile update data with fields such as employee_count, contractor_count, pay_period_amount, previous_payroll_provider, first_payroll, first_payroll_of_year, user_since, expected_first_payday, approved_for_payment_processing, etc."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPatch(api, `/companies/${company_id}/enrollment_profile`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "start_implementation",
+    "Start implementation for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/start_implementation`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "cancel_implementation",
+    "Cancel implementation for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/cancel_implementation`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "request_embedded_setup",
+    "Request embedded setup for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/request_embedded_setup`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/compensation.ts
+++ b/ts/src/tools/compensation.ts
@@ -1,0 +1,778 @@
+/** Compensation tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiDelete,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  // ---------------------------------------------------------------------------
+  // Pay Schedules
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_pay_schedules",
+    "List pay schedules, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to pay schedules belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/pay_schedules", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_pay_schedule",
+    "Get details for a specific pay schedule.",
+    {
+      pay_schedule_id: z.string().describe("The Check pay schedule ID."),
+    },
+    async ({ pay_schedule_id }) => {
+      const result = await checkApiGet(api, `/pay_schedules/${pay_schedule_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_pay_schedule",
+    "Create a new pay schedule.",
+    {
+      company: z.string().describe("The Check company ID."),
+      pay_frequency: z.string().describe('Pay frequency (e.g. "weekly", "biweekly", "semimonthly", "monthly").'),
+      first_payday: z.string().describe("First payday date (YYYY-MM-DD)."),
+      first_period_end: z.string().describe("First period end date (YYYY-MM-DD)."),
+      second_payday: z.string().optional().describe("Second payday date for semimonthly schedules (YYYY-MM-DD)."),
+      name: z.string().optional().describe("Human-readable name for the pay schedule."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ company, pay_frequency, first_payday, first_period_end, second_payday, name, metadata }) => {
+      const body: Record<string, unknown> = { company, pay_frequency, first_payday, first_period_end };
+      if (second_payday !== undefined) body.second_payday = second_payday;
+      if (name !== undefined) body.name = name;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/pay_schedules", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_pay_schedule",
+    "Update an existing pay schedule.",
+    {
+      pay_schedule_id: z.string().describe("The Check pay schedule ID."),
+      pay_frequency: z.string().optional().describe('Pay frequency (e.g. "weekly", "biweekly", "semimonthly", "monthly").'),
+      first_payday: z.string().optional().describe("First payday date (YYYY-MM-DD)."),
+      first_period_end: z.string().optional().describe("First period end date (YYYY-MM-DD)."),
+      second_payday: z.string().optional().describe("Second payday date for semimonthly schedules (YYYY-MM-DD)."),
+      name: z.string().optional().describe("Human-readable name for the pay schedule."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ pay_schedule_id, pay_frequency, first_payday, first_period_end, second_payday, name, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (pay_frequency !== undefined) body.pay_frequency = pay_frequency;
+      if (first_payday !== undefined) body.first_payday = first_payday;
+      if (first_period_end !== undefined) body.first_period_end = first_period_end;
+      if (second_payday !== undefined) body.second_payday = second_payday;
+      if (name !== undefined) body.name = name;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/pay_schedules/${pay_schedule_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_pay_schedule",
+    "Delete a pay schedule.",
+    {
+      pay_schedule_id: z.string().describe("The Check pay schedule ID."),
+    },
+    async ({ pay_schedule_id }) => {
+      const result = await checkApiDelete(api, `/pay_schedules/${pay_schedule_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_pay_schedule_paydays",
+    "Get paydays for a pay schedule.",
+    {
+      pay_schedule_id: z.string().describe("The Check pay schedule ID."),
+      start_date: z.string().optional().describe("Start date filter (YYYY-MM-DD)."),
+      end_date: z.string().optional().describe("End date filter (YYYY-MM-DD)."),
+    },
+    async ({ pay_schedule_id, start_date, end_date }) => {
+      const params: Record<string, unknown> = {};
+      if (start_date !== undefined) params.start_date = start_date;
+      if (end_date !== undefined) params.end_date = end_date;
+      const result = await checkApiGet(api, `/pay_schedules/${pay_schedule_id}/paydays`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Benefits
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_benefits",
+    "List benefits, optionally filtered by company or employee.",
+    {
+      company: z.string().optional().describe('Filter to benefits belonging to this Check company ID (e.g. "com_xxxxx").'),
+      employee: z.string().optional().describe('Filter to benefits for this Check employee ID (e.g. "emp_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, employee, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (employee !== undefined) params.employee = employee;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/benefits", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_benefit",
+    "Get details for a specific benefit.",
+    {
+      benefit_id: z.string().describe("The Check benefit ID."),
+    },
+    async ({ benefit_id }) => {
+      const result = await checkApiGet(api, `/benefits/${benefit_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_benefit",
+    "Create a new employee benefit.",
+    {
+      employee: z.string().describe("The Check employee ID."),
+      company_benefit: z.string().describe("The Check company benefit ID."),
+      benefit: z.string().optional().describe("Benefit type identifier."),
+      period: z.string().optional().describe('Deduction period (e.g. "per_paycheck").'),
+      description: z.string().optional().describe("Benefit description."),
+      company_contribution_amount: z.string().optional().describe("Company contribution amount per period."),
+      company_contribution_percent: z.number().optional().describe("Company contribution percentage."),
+      company_period_amount: z.string().optional().describe("Company contribution period cap."),
+      employee_contribution_amount: z.string().optional().describe("Employee contribution amount per period."),
+      employee_contribution_percent: z.number().optional().describe("Employee contribution percentage."),
+      employee_period_amount: z.string().optional().describe("Employee contribution period cap."),
+      effective_start: z.string().optional().describe("Effective start date (YYYY-MM-DD)."),
+      effective_end: z.string().optional().describe("Effective end date (YYYY-MM-DD)."),
+      hsa_contribution_limit: z.string().optional().describe("HSA contribution limit type."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ employee, company_benefit, benefit, period, description, company_contribution_amount, company_contribution_percent, company_period_amount, employee_contribution_amount, employee_contribution_percent, employee_period_amount, effective_start, effective_end, hsa_contribution_limit, metadata }) => {
+      const body: Record<string, unknown> = { employee, company_benefit };
+      if (benefit !== undefined) body.benefit = benefit;
+      if (period !== undefined) body.period = period;
+      if (description !== undefined) body.description = description;
+      if (company_contribution_amount !== undefined) body.company_contribution_amount = company_contribution_amount;
+      if (company_contribution_percent !== undefined) body.company_contribution_percent = company_contribution_percent;
+      if (company_period_amount !== undefined) body.company_period_amount = company_period_amount;
+      if (employee_contribution_amount !== undefined) body.employee_contribution_amount = employee_contribution_amount;
+      if (employee_contribution_percent !== undefined) body.employee_contribution_percent = employee_contribution_percent;
+      if (employee_period_amount !== undefined) body.employee_period_amount = employee_period_amount;
+      if (effective_start !== undefined) body.effective_start = effective_start;
+      if (effective_end !== undefined) body.effective_end = effective_end;
+      if (hsa_contribution_limit !== undefined) body.hsa_contribution_limit = hsa_contribution_limit;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/benefits", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_benefit",
+    "Update an existing employee benefit.",
+    {
+      benefit_id: z.string().describe("The Check benefit ID."),
+      benefit: z.string().optional().describe("Benefit type identifier."),
+      period: z.string().optional().describe('Deduction period (e.g. "per_paycheck").'),
+      description: z.string().optional().describe("Benefit description."),
+      company_contribution_amount: z.string().optional().describe("Company contribution amount per period."),
+      company_contribution_percent: z.number().optional().describe("Company contribution percentage."),
+      company_period_amount: z.string().optional().describe("Company contribution period cap."),
+      employee_contribution_amount: z.string().optional().describe("Employee contribution amount per period."),
+      employee_contribution_percent: z.number().optional().describe("Employee contribution percentage."),
+      employee_period_amount: z.string().optional().describe("Employee contribution period cap."),
+      effective_start: z.string().optional().describe("Effective start date (YYYY-MM-DD)."),
+      effective_end: z.string().optional().describe("Effective end date (YYYY-MM-DD)."),
+      hsa_contribution_limit: z.string().optional().describe("HSA contribution limit type."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ benefit_id, benefit, period, description, company_contribution_amount, company_contribution_percent, company_period_amount, employee_contribution_amount, employee_contribution_percent, employee_period_amount, effective_start, effective_end, hsa_contribution_limit, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (benefit !== undefined) body.benefit = benefit;
+      if (period !== undefined) body.period = period;
+      if (description !== undefined) body.description = description;
+      if (company_contribution_amount !== undefined) body.company_contribution_amount = company_contribution_amount;
+      if (company_contribution_percent !== undefined) body.company_contribution_percent = company_contribution_percent;
+      if (company_period_amount !== undefined) body.company_period_amount = company_period_amount;
+      if (employee_contribution_amount !== undefined) body.employee_contribution_amount = employee_contribution_amount;
+      if (employee_contribution_percent !== undefined) body.employee_contribution_percent = employee_contribution_percent;
+      if (employee_period_amount !== undefined) body.employee_period_amount = employee_period_amount;
+      if (effective_start !== undefined) body.effective_start = effective_start;
+      if (effective_end !== undefined) body.effective_end = effective_end;
+      if (hsa_contribution_limit !== undefined) body.hsa_contribution_limit = hsa_contribution_limit;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/benefits/${benefit_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_benefit",
+    "Delete a benefit.",
+    {
+      benefit_id: z.string().describe("The Check benefit ID."),
+    },
+    async ({ benefit_id }) => {
+      const result = await checkApiDelete(api, `/benefits/${benefit_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Post-Tax Deductions
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_post_tax_deductions",
+    "List post-tax deductions, optionally filtered by company or employee.",
+    {
+      company: z.string().optional().describe('Filter to post-tax deductions belonging to this Check company ID (e.g. "com_xxxxx").'),
+      employee: z.string().optional().describe('Filter to post-tax deductions for this Check employee ID (e.g. "emp_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, employee, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (employee !== undefined) params.employee = employee;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/post_tax_deductions", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_post_tax_deduction",
+    "Get details for a specific post-tax deduction.",
+    {
+      deduction_id: z.string().describe("The Check post-tax deduction ID."),
+    },
+    async ({ deduction_id }) => {
+      const result = await checkApiGet(api, `/post_tax_deductions/${deduction_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_post_tax_deduction",
+    "Create a new post-tax deduction.",
+    {
+      employee: z.string().describe("The Check employee ID."),
+      type: z.string().describe('Deduction type (e.g. "miscellaneous", "child_support", "miscellaneous_garnishment").'),
+      description: z.string().describe("Deduction description."),
+      effective_start: z.string().describe("Effective start date (YYYY-MM-DD)."),
+      effective_end: z.string().optional().describe("Effective end date (YYYY-MM-DD)."),
+      miscellaneous: z.record(z.unknown()).optional().describe("Miscellaneous deduction configuration."),
+      child_support: z.record(z.unknown()).optional().describe("Child support deduction configuration."),
+      miscellaneous_garnishment: z.record(z.unknown()).optional().describe("Miscellaneous garnishment configuration."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+      managed: z.boolean().optional().describe("Whether the deduction is managed."),
+    },
+    async ({ employee, type, description, effective_start, effective_end, miscellaneous, child_support, miscellaneous_garnishment, metadata, managed }) => {
+      const body: Record<string, unknown> = { employee, type, description, effective_start };
+      if (effective_end !== undefined) body.effective_end = effective_end;
+      if (miscellaneous !== undefined) body.miscellaneous = miscellaneous;
+      if (child_support !== undefined) body.child_support = child_support;
+      if (miscellaneous_garnishment !== undefined) body.miscellaneous_garnishment = miscellaneous_garnishment;
+      if (metadata !== undefined) body.metadata = metadata;
+      if (managed !== undefined) body.managed = managed;
+      const result = await checkApiPost(api, "/post_tax_deductions", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_post_tax_deduction",
+    "Update an existing post-tax deduction.",
+    {
+      deduction_id: z.string().describe("The Check post-tax deduction ID."),
+      description: z.string().optional().describe("Deduction description."),
+      effective_start: z.string().optional().describe("Effective start date (YYYY-MM-DD)."),
+      effective_end: z.string().optional().describe("Effective end date (YYYY-MM-DD)."),
+      miscellaneous: z.record(z.unknown()).optional().describe("Miscellaneous deduction configuration."),
+      child_support: z.record(z.unknown()).optional().describe("Child support deduction configuration."),
+      miscellaneous_garnishment: z.record(z.unknown()).optional().describe("Miscellaneous garnishment configuration."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+      managed: z.boolean().optional().describe("Whether the deduction is managed."),
+    },
+    async ({ deduction_id, description, effective_start, effective_end, miscellaneous, child_support, miscellaneous_garnishment, metadata, managed }) => {
+      const body: Record<string, unknown> = {};
+      if (description !== undefined) body.description = description;
+      if (effective_start !== undefined) body.effective_start = effective_start;
+      if (effective_end !== undefined) body.effective_end = effective_end;
+      if (miscellaneous !== undefined) body.miscellaneous = miscellaneous;
+      if (child_support !== undefined) body.child_support = child_support;
+      if (miscellaneous_garnishment !== undefined) body.miscellaneous_garnishment = miscellaneous_garnishment;
+      if (metadata !== undefined) body.metadata = metadata;
+      if (managed !== undefined) body.managed = managed;
+      const result = await checkApiPatch(api, `/post_tax_deductions/${deduction_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_post_tax_deduction",
+    "Delete a post-tax deduction.",
+    {
+      deduction_id: z.string().describe("The Check post-tax deduction ID."),
+    },
+    async ({ deduction_id }) => {
+      const result = await checkApiDelete(api, `/post_tax_deductions/${deduction_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Company Benefits
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_benefits",
+    "List company benefits, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to company benefits belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/company_benefits", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_benefit",
+    "Get details for a specific company benefit.",
+    {
+      company_benefit_id: z.string().describe("The Check company benefit ID."),
+    },
+    async ({ company_benefit_id }) => {
+      const result = await checkApiGet(api, `/company_benefits/${company_benefit_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_company_benefit",
+    "Create a new company benefit.",
+    {
+      company: z.string().describe("The Check company ID."),
+      benefit: z.string().describe("Benefit type identifier."),
+      description: z.string().describe("Company benefit description."),
+      period: z.string().optional().describe('Deduction period (e.g. "per_paycheck").'),
+      company_contribution_amount: z.string().optional().describe("Company contribution amount per period."),
+      company_contribution_percent: z.number().optional().describe("Company contribution percentage."),
+      company_period_amount: z.string().optional().describe("Company contribution period cap."),
+      employee_contribution_amount: z.string().optional().describe("Employee contribution amount per period."),
+      employee_contribution_percent: z.number().optional().describe("Employee contribution percentage."),
+      employee_period_amount: z.string().optional().describe("Employee contribution period cap."),
+      effective_start: z.string().optional().describe("Effective start date (YYYY-MM-DD)."),
+      effective_end: z.string().optional().describe("Effective end date (YYYY-MM-DD)."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ company, benefit, description, period, company_contribution_amount, company_contribution_percent, company_period_amount, employee_contribution_amount, employee_contribution_percent, employee_period_amount, effective_start, effective_end, metadata }) => {
+      const body: Record<string, unknown> = { company, benefit, description };
+      if (period !== undefined) body.period = period;
+      if (company_contribution_amount !== undefined) body.company_contribution_amount = company_contribution_amount;
+      if (company_contribution_percent !== undefined) body.company_contribution_percent = company_contribution_percent;
+      if (company_period_amount !== undefined) body.company_period_amount = company_period_amount;
+      if (employee_contribution_amount !== undefined) body.employee_contribution_amount = employee_contribution_amount;
+      if (employee_contribution_percent !== undefined) body.employee_contribution_percent = employee_contribution_percent;
+      if (employee_period_amount !== undefined) body.employee_period_amount = employee_period_amount;
+      if (effective_start !== undefined) body.effective_start = effective_start;
+      if (effective_end !== undefined) body.effective_end = effective_end;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/company_benefits", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_company_benefit",
+    "Update an existing company benefit.",
+    {
+      company_benefit_id: z.string().describe("The Check company benefit ID."),
+      description: z.string().optional().describe("Company benefit description."),
+      period: z.string().optional().describe('Deduction period (e.g. "per_paycheck").'),
+      company_contribution_amount: z.string().optional().describe("Company contribution amount per period."),
+      company_contribution_percent: z.number().optional().describe("Company contribution percentage."),
+      company_period_amount: z.string().optional().describe("Company contribution period cap."),
+      employee_contribution_amount: z.string().optional().describe("Employee contribution amount per period."),
+      employee_contribution_percent: z.number().optional().describe("Employee contribution percentage."),
+      employee_period_amount: z.string().optional().describe("Employee contribution period cap."),
+      effective_start: z.string().optional().describe("Effective start date (YYYY-MM-DD)."),
+      effective_end: z.string().optional().describe("Effective end date (YYYY-MM-DD)."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ company_benefit_id, description, period, company_contribution_amount, company_contribution_percent, company_period_amount, employee_contribution_amount, employee_contribution_percent, employee_period_amount, effective_start, effective_end, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (description !== undefined) body.description = description;
+      if (period !== undefined) body.period = period;
+      if (company_contribution_amount !== undefined) body.company_contribution_amount = company_contribution_amount;
+      if (company_contribution_percent !== undefined) body.company_contribution_percent = company_contribution_percent;
+      if (company_period_amount !== undefined) body.company_period_amount = company_period_amount;
+      if (employee_contribution_amount !== undefined) body.employee_contribution_amount = employee_contribution_amount;
+      if (employee_contribution_percent !== undefined) body.employee_contribution_percent = employee_contribution_percent;
+      if (employee_period_amount !== undefined) body.employee_period_amount = employee_period_amount;
+      if (effective_start !== undefined) body.effective_start = effective_start;
+      if (effective_end !== undefined) body.effective_end = effective_end;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/company_benefits/${company_benefit_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_company_benefit",
+    "Delete a company benefit.",
+    {
+      company_benefit_id: z.string().describe("The Check company benefit ID."),
+    },
+    async ({ company_benefit_id }) => {
+      const result = await checkApiDelete(api, `/company_benefits/${company_benefit_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Earning Rates
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_earning_rates",
+    "List earning rates, optionally filtered by company or employee.",
+    {
+      company: z.string().optional().describe('Filter to earning rates belonging to this Check company ID (e.g. "com_xxxxx").'),
+      employee: z.string().optional().describe('Filter to earning rates for this Check employee ID (e.g. "emp_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, employee, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (employee !== undefined) params.employee = employee;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/earning_rates", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_earning_rate",
+    "Get details for a specific earning rate.",
+    {
+      earning_rate_id: z.string().describe("The Check earning rate ID."),
+    },
+    async ({ earning_rate_id }) => {
+      const result = await checkApiGet(api, `/earning_rates/${earning_rate_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_earning_rate",
+    "Create a new earning rate.",
+    {
+      employee: z.string().describe("The Check employee ID."),
+      amount: z.string().describe("Earning rate amount."),
+      period: z.string().describe('Earning rate period (e.g. "hour", "year").'),
+      name: z.string().optional().describe("Human-readable name for the earning rate."),
+      workweek_hours: z.number().optional().describe("Number of hours in a standard workweek."),
+    },
+    async ({ employee, amount, period, name, workweek_hours }) => {
+      const body: Record<string, unknown> = { employee, amount, period };
+      if (name !== undefined) body.name = name;
+      if (workweek_hours !== undefined) body.workweek_hours = workweek_hours;
+      const result = await checkApiPost(api, "/earning_rates", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_earning_rate",
+    "Update an existing earning rate.",
+    {
+      earning_rate_id: z.string().describe("The Check earning rate ID."),
+      name: z.string().optional().describe("Human-readable name for the earning rate."),
+      active: z.boolean().optional().describe("Whether the earning rate is active."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ earning_rate_id, name, active, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (active !== undefined) body.active = active;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/earning_rates/${earning_rate_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Earning Codes
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_earning_codes",
+    "List earning codes, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to earning codes belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/earning_codes", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_earning_code",
+    "Get details for a specific earning code.",
+    {
+      earning_code_id: z.string().describe("The Check earning code ID."),
+    },
+    async ({ earning_code_id }) => {
+      const result = await checkApiGet(api, `/earning_codes/${earning_code_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_earning_code",
+    "Create a new earning code.",
+    {
+      company: z.string().describe("The Check company ID."),
+      name: z.string().describe("Earning code name."),
+      type: z.string().describe("Earning code type."),
+      active: z.boolean().optional().describe("Whether the earning code is active."),
+      calculation_overrides: z.record(z.unknown()).optional().describe("Calculation override configuration."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ company, name, type, active, calculation_overrides, metadata }) => {
+      const body: Record<string, unknown> = { company, name, type };
+      if (active !== undefined) body.active = active;
+      if (calculation_overrides !== undefined) body.calculation_overrides = calculation_overrides;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/earning_codes", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_earning_code",
+    "Update an existing earning code.",
+    {
+      earning_code_id: z.string().describe("The Check earning code ID."),
+      active: z.boolean().optional().describe("Whether the earning code is active."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ earning_code_id, active, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (active !== undefined) body.active = active;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/earning_codes/${earning_code_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Net Pay Splits
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_net_pay_splits",
+    "List net pay splits, optionally filtered by company or employee.",
+    {
+      company: z.string().optional().describe('Filter to net pay splits belonging to this Check company ID (e.g. "com_xxxxx").'),
+      employee: z.string().optional().describe('Filter to net pay splits for this Check employee ID (e.g. "emp_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, employee, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (employee !== undefined) params.employee = employee;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/net_pay_splits", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_net_pay_split",
+    "Get details for a specific net pay split.",
+    {
+      net_pay_split_id: z.string().describe("The Check net pay split ID."),
+    },
+    async ({ net_pay_split_id }) => {
+      const result = await checkApiGet(api, `/net_pay_splits/${net_pay_split_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_net_pay_split",
+    "Create a new net pay split configuration.",
+    {
+      splits: z.array(z.record(z.unknown())).describe("Array of split objects defining how net pay is distributed."),
+      employee: z.string().optional().describe("The Check employee ID."),
+      contractor: z.string().optional().describe("The Check contractor ID."),
+      is_default: z.boolean().optional().describe("Whether this is the default net pay split."),
+    },
+    async ({ splits, employee, contractor, is_default }) => {
+      const body: Record<string, unknown> = { splits };
+      if (employee !== undefined) body.employee = employee;
+      if (contractor !== undefined) body.contractor = contractor;
+      if (is_default !== undefined) body.is_default = is_default;
+      const result = await checkApiPost(api, "/net_pay_splits", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/components.ts
+++ b/ts/src/tools/components.ts
@@ -1,0 +1,109 @@
+/** Component tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiPost,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+interface ComponentDef {
+  entityType: string;
+  entityLabel: string;
+  componentName: string;
+}
+
+const COMPANY_COMPONENTS = [
+  "previous_provider_access",
+  "accounting_integration",
+  "authorization_documents",
+  "business_details",
+  "checklist",
+  "company_reports",
+  "connect_bank_account",
+  "details",
+  "early_enrollment",
+  "employee_setup",
+  "filing_authorization",
+  "filing_preview",
+  "full_service_setup_submission",
+  "integrations",
+  "integrations_authorize",
+  "pay_history",
+  "payment_setup",
+  "progress_tracker",
+  "run_payroll",
+  "signatory_agreements",
+  "tax_documents",
+  "tax_setup",
+  "team_setup",
+  "terms_of_service",
+  "verification_documents",
+];
+
+const EMPLOYEE_COMPONENTS = [
+  "benefits",
+  "payment_setup",
+  "paystubs",
+  "post_tax_deductions",
+  "profile",
+  "ssn_setup",
+  "tax_documents",
+  "tax_setup",
+  "withholdings_setup",
+];
+
+const CONTRACTOR_COMPONENTS = [
+  "tax_documents",
+];
+
+function buildComponentDefs(): ComponentDef[] {
+  const defs: ComponentDef[] = [];
+  for (const name of COMPANY_COMPONENTS) {
+    defs.push({ entityType: "companies", entityLabel: "company", componentName: name });
+  }
+  for (const name of EMPLOYEE_COMPONENTS) {
+    defs.push({ entityType: "employees", entityLabel: "employee", componentName: name });
+  }
+  for (const name of CONTRACTOR_COMPONENTS) {
+    defs.push({ entityType: "contractors", entityLabel: "contractor", componentName: name });
+  }
+  return defs;
+}
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  const componentDefs = buildComponentDefs();
+
+  for (const def of componentDefs) {
+    const toolName = `create_${def.entityLabel}_${def.componentName}_component`;
+
+    tool(
+      server,
+      filter,
+      toolsetName,
+      toolName,
+      `Create a ${def.componentName} component for a ${def.entityLabel}.`,
+      {
+        entity_id: z.string().describe(`The Check ${def.entityLabel} ID.`),
+        data: z.record(z.unknown()).optional().describe("Optional component configuration data."),
+      },
+      async ({ entity_id, data }) => {
+        const result = await checkApiPost(
+          api,
+          `/${def.entityType}/${entity_id}/components/${def.componentName}`,
+          data,
+        );
+        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+      },
+    );
+  }
+}

--- a/ts/src/tools/contractor-payments.ts
+++ b/ts/src/tools/contractor-payments.ts
@@ -1,0 +1,152 @@
+/** Contractor payment tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiDelete,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_contractor_payments",
+    "List contractor payments, optionally filtered by company or contractor.",
+    {
+      company: z.string().optional().describe('Filter to contractor payments belonging to this Check company ID (e.g. "com_xxxxx").'),
+      contractor: z.string().optional().describe('Filter to payments for this Check contractor ID (e.g. "ctr_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return (default 10, max 100)."),
+      ids: z.array(z.string()).optional().describe("Filter to specific contractor payment IDs."),
+      cursor: z.string().optional().describe("Pagination cursor from a previous response."),
+    },
+    async ({ company, contractor, limit, ids, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (contractor !== undefined) params.contractor = contractor;
+      if (limit !== undefined) params.limit = limit;
+      if (ids !== undefined) params.ids = ids.join(",");
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/contractor_payments", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_contractor_payment",
+    "Get details for a specific contractor payment.",
+    {
+      contractor_payment_id: z.string().describe("The Check contractor payment ID."),
+    },
+    async ({ contractor_payment_id }) => {
+      const result = await checkApiGet(api, `/contractor_payments/${contractor_payment_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_contractor_payment",
+    "Create a new contractor payment.",
+    {
+      contractor: z.string().describe("The Check contractor ID."),
+      payroll: z.string().describe("The Check payroll ID."),
+      payment_method: z.string().optional().describe('How the contractor will be paid -- "direct_deposit" or "manual". Default: "direct_deposit".'),
+      amount: z.string().optional().describe('The amount to pay the contractor (e.g. "1500.00"). Default: "0.00".'),
+      reimbursement_amount: z.string().optional().describe('Reimbursement amount (e.g. "50.00"). Default: "0.00".'),
+      workplace: z.string().optional().describe("Workplace ID associated with this payment."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+      paper_check_number: z.string().optional().describe("Check number for accounting on printed checks."),
+    },
+    async ({ contractor, payroll, payment_method, amount, reimbursement_amount, workplace, metadata, paper_check_number }) => {
+      const body: Record<string, unknown> = { contractor, payroll };
+      if (payment_method !== undefined) body.payment_method = payment_method;
+      if (amount !== undefined) body.amount = amount;
+      if (reimbursement_amount !== undefined) body.reimbursement_amount = reimbursement_amount;
+      if (workplace !== undefined) body.workplace = workplace;
+      if (metadata !== undefined) body.metadata = metadata;
+      if (paper_check_number !== undefined) body.paper_check_number = paper_check_number;
+      const result = await checkApiPost(api, "/contractor_payments", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_contractor_payment",
+    "Update an existing contractor payment.",
+    {
+      contractor_payment_id: z.string().describe("The Check contractor payment ID."),
+      contractor: z.string().optional().describe("The Check contractor ID."),
+      payment_method: z.string().optional().describe('How the contractor will be paid -- "direct_deposit" or "manual".'),
+      amount: z.string().optional().describe('The amount to pay the contractor (e.g. "1500.00").'),
+      reimbursement_amount: z.string().optional().describe('Reimbursement amount (e.g. "50.00").'),
+      workplace: z.string().optional().describe("Workplace ID associated with this payment."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+      paper_check_number: z.string().optional().describe("Check number for accounting on printed checks."),
+    },
+    async ({ contractor_payment_id, contractor, payment_method, amount, reimbursement_amount, workplace, metadata, paper_check_number }) => {
+      const body: Record<string, unknown> = {};
+      if (contractor !== undefined) body.contractor = contractor;
+      if (payment_method !== undefined) body.payment_method = payment_method;
+      if (amount !== undefined) body.amount = amount;
+      if (reimbursement_amount !== undefined) body.reimbursement_amount = reimbursement_amount;
+      if (workplace !== undefined) body.workplace = workplace;
+      if (metadata !== undefined) body.metadata = metadata;
+      if (paper_check_number !== undefined) body.paper_check_number = paper_check_number;
+      const result = await checkApiPatch(api, `/contractor_payments/${contractor_payment_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_contractor_payment",
+    "Delete a contractor payment.",
+    {
+      contractor_payment_id: z.string().describe("The Check contractor payment ID."),
+    },
+    async ({ contractor_payment_id }) => {
+      const result = await checkApiDelete(api, `/contractor_payments/${contractor_payment_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_contractor_payment_paper_check",
+    "Get paper check details for a contractor payment.",
+    {
+      contractor_payment_id: z.string().describe("The Check contractor payment ID."),
+    },
+    async ({ contractor_payment_id }) => {
+      const result = await checkApiGet(api, `/contractor_payments/${contractor_payment_id}/paper_check`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/contractors.ts
+++ b/ts/src/tools/contractors.ts
@@ -1,0 +1,264 @@
+/** Contractor tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_contractors",
+    "List contractors, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to contractors belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return (default 10, max 100)."),
+      ids: z.array(z.string()).optional().describe("Filter to specific contractor IDs."),
+      cursor: z.string().optional().describe("Pagination cursor from a previous response."),
+    },
+    async ({ company, limit, ids, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (ids !== undefined) params.ids = ids.join(",");
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/contractors", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_contractor",
+    "Get details for a specific contractor.",
+    {
+      contractor_id: z.string().describe('The Check contractor ID (e.g. "ctr_xxxxx").'),
+    },
+    async ({ contractor_id }) => {
+      const result = await checkApiGet(api, `/contractors/${contractor_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_contractor",
+    "Create a new contractor.",
+    {
+      company: z.string().describe("The Check company ID."),
+      type: z.string().optional().describe('Contractor type — "individual" or "business".'),
+      first_name: z.string().optional().describe("Contractor's first name (or business primary contact's first name)."),
+      middle_name: z.string().optional().describe("Contractor's middle name."),
+      last_name: z.string().optional().describe("Contractor's last name (or business primary contact's last name)."),
+      business_name: z.string().optional().describe("Business name (for business-type contractors)."),
+      dob: z.string().optional().describe("Date of birth (YYYY-MM-DD)."),
+      start_date: z.string().optional().describe("Most recent start date of contract (YYYY-MM-DD)."),
+      termination_date: z.string().optional().describe("Most recent termination date (YYYY-MM-DD)."),
+      workplaces: z.array(z.string()).optional().describe("List of workplace IDs where the contractor works."),
+      primary_workplace: z.string().optional().describe("Workplace ID of the contractor's primary workplace."),
+      email: z.string().optional().describe("Contractor's email address."),
+      ssn: z.string().optional().describe("Contractor's Social Security Number."),
+      ein: z.string().optional().describe("Contractor's Employer Identification Number (for businesses)."),
+      default_net_pay_split: z.string().optional().describe("ID of contractor's default net pay split."),
+      payment_method_preference: z.string().optional().describe('"direct_deposit" or "manual".'),
+      address: z.record(z.unknown()).optional().describe("Address object with keys: line1, line2, city, state, postal_code, country."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ company, type, first_name, middle_name, last_name, business_name, dob, start_date, termination_date, workplaces, primary_workplace, email, ssn, ein, default_net_pay_split, payment_method_preference, address, metadata }) => {
+      const body: Record<string, unknown> = { company };
+      if (type !== undefined) body.type = type;
+      if (first_name !== undefined) body.first_name = first_name;
+      if (middle_name !== undefined) body.middle_name = middle_name;
+      if (last_name !== undefined) body.last_name = last_name;
+      if (business_name !== undefined) body.business_name = business_name;
+      if (dob !== undefined) body.dob = dob;
+      if (start_date !== undefined) body.start_date = start_date;
+      if (termination_date !== undefined) body.termination_date = termination_date;
+      if (workplaces !== undefined) body.workplaces = workplaces;
+      if (primary_workplace !== undefined) body.primary_workplace = primary_workplace;
+      if (email !== undefined) body.email = email;
+      if (ssn !== undefined) body.ssn = ssn;
+      if (ein !== undefined) body.ein = ein;
+      if (default_net_pay_split !== undefined) body.default_net_pay_split = default_net_pay_split;
+      if (payment_method_preference !== undefined) body.payment_method_preference = payment_method_preference;
+      if (address !== undefined) body.address = address;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/contractors", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_contractor",
+    "Update an existing contractor.",
+    {
+      contractor_id: z.string().describe("The Check contractor ID."),
+      type: z.string().optional().describe('Contractor type — "individual" or "business".'),
+      first_name: z.string().optional().describe("Contractor's first name."),
+      middle_name: z.string().optional().describe("Contractor's middle name."),
+      last_name: z.string().optional().describe("Contractor's last name."),
+      business_name: z.string().optional().describe("Business name (for business-type contractors)."),
+      dob: z.string().optional().describe("Date of birth (YYYY-MM-DD)."),
+      start_date: z.string().optional().describe("Most recent start date of contract (YYYY-MM-DD)."),
+      termination_date: z.string().optional().describe("Most recent termination date (YYYY-MM-DD)."),
+      workplaces: z.array(z.string()).optional().describe("List of workplace IDs where the contractor works."),
+      primary_workplace: z.string().optional().describe("Workplace ID of the contractor's primary workplace."),
+      email: z.string().optional().describe("Contractor's email address."),
+      ssn: z.string().optional().describe("Contractor's Social Security Number."),
+      ein: z.string().optional().describe("Contractor's Employer Identification Number (for businesses)."),
+      default_net_pay_split: z.string().optional().describe("ID of contractor's default net pay split."),
+      payment_method_preference: z.string().optional().describe('"direct_deposit" or "manual".'),
+      address: z.record(z.unknown()).optional().describe("Address object with keys: line1, line2, city, state, postal_code, country."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ contractor_id, type, first_name, middle_name, last_name, business_name, dob, start_date, termination_date, workplaces, primary_workplace, email, ssn, ein, default_net_pay_split, payment_method_preference, address, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (type !== undefined) body.type = type;
+      if (first_name !== undefined) body.first_name = first_name;
+      if (middle_name !== undefined) body.middle_name = middle_name;
+      if (last_name !== undefined) body.last_name = last_name;
+      if (business_name !== undefined) body.business_name = business_name;
+      if (dob !== undefined) body.dob = dob;
+      if (start_date !== undefined) body.start_date = start_date;
+      if (termination_date !== undefined) body.termination_date = termination_date;
+      if (workplaces !== undefined) body.workplaces = workplaces;
+      if (primary_workplace !== undefined) body.primary_workplace = primary_workplace;
+      if (email !== undefined) body.email = email;
+      if (ssn !== undefined) body.ssn = ssn;
+      if (ein !== undefined) body.ein = ein;
+      if (default_net_pay_split !== undefined) body.default_net_pay_split = default_net_pay_split;
+      if (payment_method_preference !== undefined) body.payment_method_preference = payment_method_preference;
+      if (address !== undefined) body.address = address;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/contractors/${contractor_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "onboard_contractor",
+    "Onboard a contractor, transitioning them to active status.",
+    {
+      contractor_id: z.string().describe("The Check contractor ID."),
+    },
+    async ({ contractor_id }) => {
+      const result = await checkApiPost(api, `/contractors/${contractor_id}/onboard`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_contractor_payments_for_contractor",
+    "List payments for a specific contractor.",
+    {
+      contractor_id: z.string().describe("The Check contractor ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ contractor_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/contractors/${contractor_id}/payments`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_contractor_payment_for_payroll",
+    "Get a contractor payment for a specific payroll.",
+    {
+      contractor_id: z.string().describe("The Check contractor ID."),
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ contractor_id, payroll_id }) => {
+      const result = await checkApiGet(api, `/contractors/${contractor_id}/payments/${payroll_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_contractor_forms",
+    "List forms for a contractor.",
+    {
+      contractor_id: z.string().describe("The Check contractor ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ contractor_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/contractors/${contractor_id}/forms`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "submit_contractor_form",
+    "Submit a contractor form.",
+    {
+      contractor_id: z.string().describe("The Check contractor ID."),
+      form_id: z.string().describe("The form ID."),
+      parameters: z.array(z.record(z.unknown())).optional().describe('List of name/value objects representing form fields. Example: [{"name": "field_name", "value": "field_value"}].'),
+    },
+    async ({ contractor_id, form_id, parameters }) => {
+      const body: Record<string, unknown> | undefined = parameters !== undefined ? { parameters } : undefined;
+      const result = await checkApiPost(api, `/contractors/${contractor_id}/forms/${form_id}/submit`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "reveal_contractor_ssn",
+    "Reveal the SSN/EIN for a contractor.",
+    {
+      contractor_id: z.string().describe("The Check contractor ID."),
+    },
+    async ({ contractor_id }) => {
+      const result = await checkApiGet(api, `/contractors/${contractor_id}/reveal`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/documents.ts
+++ b/ts/src/tools/documents.ts
@@ -1,0 +1,346 @@
+/** Document tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  // --- Company Tax Documents ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_tax_documents",
+    "List company tax documents.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/company_tax_documents", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_tax_document",
+    "Get a specific company tax document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/company_tax_documents/${document_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "download_company_tax_document",
+    "Download a company tax document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/company_tax_documents/${document_id}/download`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Company Authorization Documents ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_authorization_documents",
+    "List company authorization documents.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/company_authorization_documents", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_authorization_document",
+    "Get a specific company authorization document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/company_authorization_documents/${document_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "download_company_authorization_document",
+    "Download a company authorization document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/company_authorization_documents/${document_id}/download`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Employee Tax Documents ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_tax_documents",
+    "List employee tax documents.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/employee_tax_documents", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_tax_document",
+    "Get a specific employee tax document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/employee_tax_documents/${document_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "download_employee_tax_document",
+    "Download an employee tax document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/employee_tax_documents/${document_id}/download`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Contractor Tax Documents ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_contractor_tax_documents",
+    "List contractor tax documents.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/contractor_tax_documents", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_contractor_tax_document",
+    "Get a specific contractor tax document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/contractor_tax_documents/${document_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "download_contractor_tax_document",
+    "Download a contractor tax document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/contractor_tax_documents/${document_id}/download`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Setup Documents ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_setup_documents",
+    "List setup documents.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/setup_documents", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_setup_document",
+    "Get a specific setup document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/setup_documents/${document_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "download_setup_document",
+    "Download a setup document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/setup_documents/${document_id}/download`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Company Provided Documents ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_provided_documents",
+    "List company-provided documents.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/company_provided_documents", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_provided_document",
+    "Get a specific company-provided document.",
+    {
+      document_id: z.string().describe("The document ID."),
+    },
+    async ({ document_id }) => {
+      const result = await checkApiGet(api, `/company_provided_documents/${document_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_company_provided_document",
+    "Create a company-provided document.",
+    {
+      company: z.string().describe("The Check company ID."),
+      document_type: z.string().optional().describe('Type of document — one of "940", "941", "943", "944", "945", "cp_575", "147_c", "signatory_photo_id", "voided_check", "bank_statement", "ss4", "bank_account_owner_id", "bank_letter", "profit_and_loss", "cash_flow_statement", "balance_sheet", "articles_of_incorporation", "articles_of_incorporation_signatory_amendment", "state_registration".'),
+    },
+    async ({ company, document_type }) => {
+      const body: Record<string, unknown> = { company };
+      if (document_type !== undefined) body.document_type = document_type;
+      const result = await checkApiPost(api, "/company_provided_documents", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "upload_company_provided_document_file",
+    "Upload a file for a company-provided document.",
+    {
+      document_id: z.string().describe("The document ID."),
+      data: z.record(z.unknown()).optional().describe("Upload metadata."),
+    },
+    async ({ document_id, data }) => {
+      const result = await checkApiPost(api, `/company_provided_documents/${document_id}/upload`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/employees.ts
+++ b/ts/src/tools/employees.ts
@@ -1,0 +1,372 @@
+/** Employee tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employees",
+    "List employees, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to employees belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return (default 10, max 100)."),
+      ids: z.array(z.string()).optional().describe("Filter to specific employee IDs."),
+      cursor: z.string().optional().describe("Pagination cursor from a previous response."),
+    },
+    async ({ company, limit, ids, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (ids !== undefined) params.ids = ids.join(",");
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/employees", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee",
+    "Get details for a specific employee.",
+    {
+      employee_id: z.string().describe('The Check employee ID (e.g. "emp_xxxxx").'),
+    },
+    async ({ employee_id }) => {
+      const result = await checkApiGet(api, `/employees/${employee_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_employee",
+    "Create a new employee.",
+    {
+      company: z.string().describe("The Check company ID the employee belongs to."),
+      first_name: z.string().describe("Employee's first name."),
+      last_name: z.string().describe("Employee's last name."),
+      middle_name: z.string().optional().describe("Employee's middle name."),
+      email: z.string().optional().describe("Employee's email address."),
+      dob: z.string().optional().describe("Date of birth (YYYY-MM-DD)."),
+      start_date: z.string().optional().describe("Most recent start date of employment (YYYY-MM-DD)."),
+      termination_date: z.string().optional().describe("Most recent termination date (YYYY-MM-DD)."),
+      residence: z.record(z.unknown()).optional().describe("Residence address object with keys: line1, line2, city, state, postal_code, country."),
+      workplaces: z.array(z.string()).optional().describe("List of workplace IDs where the employee works."),
+      primary_workplace: z.string().optional().describe("Workplace ID of the employee's primary workplace."),
+      ssn: z.string().optional().describe("Employee's Social Security Number. Only last four digits available after set."),
+      payment_method_preference: z.string().optional().describe('"direct_deposit" or "manual".'),
+      default_net_pay_split: z.string().optional().describe("ID of employee's default net pay split."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ company, first_name, last_name, middle_name, email, dob, start_date, termination_date, residence, workplaces, primary_workplace, ssn, payment_method_preference, default_net_pay_split, metadata }) => {
+      const body: Record<string, unknown> = { company, first_name, last_name };
+      if (middle_name !== undefined) body.middle_name = middle_name;
+      if (email !== undefined) body.email = email;
+      if (dob !== undefined) body.dob = dob;
+      if (start_date !== undefined) body.start_date = start_date;
+      if (termination_date !== undefined) body.termination_date = termination_date;
+      if (residence !== undefined) body.residence = residence;
+      if (workplaces !== undefined) body.workplaces = workplaces;
+      if (primary_workplace !== undefined) body.primary_workplace = primary_workplace;
+      if (ssn !== undefined) body.ssn = ssn;
+      if (payment_method_preference !== undefined) body.payment_method_preference = payment_method_preference;
+      if (default_net_pay_split !== undefined) body.default_net_pay_split = default_net_pay_split;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/employees", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_employee",
+    "Update an existing employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      first_name: z.string().optional().describe("Employee's first name."),
+      middle_name: z.string().optional().describe("Employee's middle name."),
+      last_name: z.string().optional().describe("Employee's last name."),
+      email: z.string().optional().describe("Employee's email address."),
+      dob: z.string().optional().describe("Date of birth (YYYY-MM-DD)."),
+      start_date: z.string().optional().describe("Most recent start date of employment (YYYY-MM-DD)."),
+      termination_date: z.string().optional().describe("Most recent termination date (YYYY-MM-DD)."),
+      residence: z.record(z.unknown()).optional().describe("Residence address object with keys: line1, line2, city, state, postal_code, country."),
+      workplaces: z.array(z.string()).optional().describe("List of workplace IDs where the employee works."),
+      primary_workplace: z.string().optional().describe("Workplace ID of the employee's primary workplace."),
+      ssn: z.string().optional().describe("Employee's Social Security Number."),
+      payment_method_preference: z.string().optional().describe('"direct_deposit" or "manual".'),
+      default_net_pay_split: z.string().optional().describe("ID of employee's default net pay split."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ employee_id, first_name, middle_name, last_name, email, dob, start_date, termination_date, residence, workplaces, primary_workplace, ssn, payment_method_preference, default_net_pay_split, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (first_name !== undefined) body.first_name = first_name;
+      if (middle_name !== undefined) body.middle_name = middle_name;
+      if (last_name !== undefined) body.last_name = last_name;
+      if (email !== undefined) body.email = email;
+      if (dob !== undefined) body.dob = dob;
+      if (start_date !== undefined) body.start_date = start_date;
+      if (termination_date !== undefined) body.termination_date = termination_date;
+      if (residence !== undefined) body.residence = residence;
+      if (workplaces !== undefined) body.workplaces = workplaces;
+      if (primary_workplace !== undefined) body.primary_workplace = primary_workplace;
+      if (ssn !== undefined) body.ssn = ssn;
+      if (payment_method_preference !== undefined) body.payment_method_preference = payment_method_preference;
+      if (default_net_pay_split !== undefined) body.default_net_pay_split = default_net_pay_split;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/employees/${employee_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "onboard_employee",
+    "Onboard an employee, transitioning them to active status.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+    },
+    async ({ employee_id }) => {
+      const result = await checkApiPost(api, `/employees/${employee_id}/onboard`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Paystubs ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_paystubs",
+    "List paystubs for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ employee_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/employees/${employee_id}/paystubs`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_paystub",
+    "Get a specific paystub for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ employee_id, payroll_id }) => {
+      const result = await checkApiGet(api, `/employees/${employee_id}/paystubs/${payroll_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Forms ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_forms",
+    "List forms for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ employee_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/employees/${employee_id}/forms`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_form",
+    "Get a specific form for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      form_id: z.string().describe("The form ID."),
+    },
+    async ({ employee_id, form_id }) => {
+      const result = await checkApiGet(api, `/employees/${employee_id}/forms/${form_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "submit_employee_form",
+    "Submit an employee form.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      form_id: z.string().describe("The form ID."),
+      parameters: z.array(z.record(z.unknown())).optional().describe('List of name/value objects representing form fields. Example: [{"name": "field_name", "value": "field_value"}].'),
+    },
+    async ({ employee_id, form_id, parameters }) => {
+      const body: Record<string, unknown> | undefined = parameters !== undefined ? { parameters } : undefined;
+      const result = await checkApiPost(api, `/employees/${employee_id}/forms/${form_id}/submit`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "sign_and_submit_employee_form",
+    "Sign and submit an employee form.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      form_id: z.string().describe("The form ID."),
+      parameters: z.array(z.record(z.unknown())).optional().describe('List of name/value objects representing form fields. Example: [{"name": "field_name", "value": "field_value"}].'),
+    },
+    async ({ employee_id, form_id, parameters }) => {
+      const body: Record<string, unknown> | undefined = parameters !== undefined ? { parameters } : undefined;
+      const result = await checkApiPost(api, `/employees/${employee_id}/forms/${form_id}/sign_and_submit`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Company Defined Attributes ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_company_defined_attributes",
+    "Get company-defined attributes for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+    },
+    async ({ employee_id }) => {
+      const result = await checkApiGet(api, `/employees/${employee_id}/company_defined_attributes`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_employee_company_defined_attributes",
+    "Update company-defined attributes for an employee. The schema is dynamic and defined per-company, so attributes are passed as a free-form object.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      data: z.record(z.unknown()).describe("Attributes to update (schema varies by company configuration)."),
+    },
+    async ({ employee_id, data }) => {
+      const result = await checkApiPatch(api, `/employees/${employee_id}/company_defined_attributes`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Reciprocity Elections ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_reciprocity_elections",
+    "Get reciprocity elections for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+    },
+    async ({ employee_id }) => {
+      const result = await checkApiGet(api, `/employees/${employee_id}/reciprocity_elections`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_employee_reciprocity_elections",
+    "Update reciprocity elections for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      data: z.record(z.unknown()).describe("Reciprocity election data (complex nested structure)."),
+    },
+    async ({ employee_id, data }) => {
+      const result = await checkApiPatch(api, `/employees/${employee_id}/reciprocity_elections`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Other ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "reveal_employee_ssn",
+    "Reveal the SSN for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+    },
+    async ({ employee_id }) => {
+      const result = await checkApiGet(api, `/employees/${employee_id}/reveal`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "authorize_employee_partner",
+    "Authorize a partner for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      data: z.record(z.unknown()).optional().describe("Partner authorization details."),
+    },
+    async ({ employee_id, data }) => {
+      const result = await checkApiPost(api, `/employees/${employee_id}/authorize_partner`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/external-payrolls.ts
+++ b/ts/src/tools/external-payrolls.ts
@@ -1,0 +1,174 @@
+/** External payroll tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiDelete,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_external_payrolls",
+    "List external payrolls, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to external payrolls belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return (default 10, max 100)."),
+      ids: z.array(z.string()).optional().describe("Filter to specific external payroll IDs."),
+      cursor: z.string().optional().describe("Pagination cursor from a previous response."),
+    },
+    async ({ company, limit, ids, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (ids !== undefined) params.ids = ids.join(",");
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/external_payrolls", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_external_payroll",
+    "Get details for a specific external payroll.",
+    {
+      payroll_id: z.string().describe("The Check external payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiGet(api, `/external_payrolls/${payroll_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_external_payroll",
+    "Create a new external payroll.",
+    {
+      company: z.string().describe("The Check company ID."),
+      period_start: z.string().describe("Pay period start date (YYYY-MM-DD)."),
+      period_end: z.string().describe("Pay period end date (YYYY-MM-DD)."),
+      payday: z.string().describe("Payday date (YYYY-MM-DD)."),
+      pay_frequency: z.string().optional().describe("Frequency at which the external payroll was paid."),
+      items: z.array(z.record(z.unknown())).optional().describe('List of external payroll item objects. Each may include "employee", "earnings" (list), "reimbursements" (list), "taxes" (list), "benefits" (list), "post_tax_deductions" (list).'),
+      contractor_payments: z.array(z.record(z.unknown())).optional().describe('List of contractor payment objects. Each may include "contractor", "amount", "reimbursement_amount".'),
+    },
+    async ({ company, period_start, period_end, payday, pay_frequency, items, contractor_payments }) => {
+      const body: Record<string, unknown> = { company, period_start, period_end, payday };
+      if (pay_frequency !== undefined) body.pay_frequency = pay_frequency;
+      if (items !== undefined) body.items = items;
+      if (contractor_payments !== undefined) body.contractor_payments = contractor_payments;
+      const result = await checkApiPost(api, "/external_payrolls", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_external_payroll",
+    "Update an existing external payroll.",
+    {
+      payroll_id: z.string().describe("The Check external payroll ID."),
+      period_start: z.string().optional().describe("Pay period start date (YYYY-MM-DD)."),
+      period_end: z.string().optional().describe("Pay period end date (YYYY-MM-DD)."),
+      payday: z.string().optional().describe("Payday date (YYYY-MM-DD)."),
+      pay_frequency: z.string().optional().describe("Frequency at which the external payroll was paid."),
+      items: z.array(z.record(z.unknown())).optional().describe("List of external payroll item objects (see create_external_payroll)."),
+      contractor_payments: z.array(z.record(z.unknown())).optional().describe("List of contractor payment objects (see create_external_payroll)."),
+    },
+    async ({ payroll_id, period_start, period_end, payday, pay_frequency, items, contractor_payments }) => {
+      const body: Record<string, unknown> = {};
+      if (period_start !== undefined) body.period_start = period_start;
+      if (period_end !== undefined) body.period_end = period_end;
+      if (payday !== undefined) body.payday = payday;
+      if (pay_frequency !== undefined) body.pay_frequency = pay_frequency;
+      if (items !== undefined) body.items = items;
+      if (contractor_payments !== undefined) body.contractor_payments = contractor_payments;
+      const result = await checkApiPatch(api, `/external_payrolls/${payroll_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_external_payroll",
+    "Delete an external payroll.",
+    {
+      payroll_id: z.string().describe("The Check external payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiDelete(api, `/external_payrolls/${payroll_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "approve_external_payroll",
+    "Approve an external payroll.",
+    {
+      payroll_id: z.string().describe("The Check external payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/external_payrolls/${payroll_id}/approve`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "reopen_external_payroll",
+    "Reopen an external payroll.",
+    {
+      payroll_id: z.string().describe("The Check external payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/external_payrolls/${payroll_id}/reopen`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "preview_external_payroll",
+    "Preview an external payroll.",
+    {
+      external_payroll_id: z.string().describe("The Check external payroll ID."),
+    },
+    async ({ external_payroll_id }) => {
+      const result = await checkApiGet(api, `/external_payrolls/${external_payroll_id}/preview`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/forms.ts
+++ b/ts/src/tools/forms.ts
@@ -1,0 +1,92 @@
+/** Form tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_forms",
+    "List forms, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to forms belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/forms", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_form",
+    "Get details for a specific form.",
+    {
+      form_id: z.string().describe("The Check form ID."),
+    },
+    async ({ form_id }) => {
+      const result = await checkApiGet(api, `/forms/${form_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "render_form",
+    "Render a form for display.",
+    {
+      form_id: z.string().describe("The Check form ID."),
+    },
+    async ({ form_id }) => {
+      const result = await checkApiGet(api, `/forms/${form_id}/render`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "validate_form",
+    "Validate form data before submission.",
+    {
+      form_id: z.string().describe("The Check form ID."),
+      parameters: z.array(z.object({
+        name: z.string().describe("Form field name."),
+        value: z.string().describe("Form field value."),
+      })).describe('List of name/value dicts representing form fields. Example: [{"name": "field_name", "value": "field_value"}].'),
+    },
+    async ({ form_id, parameters }) => {
+      const body: Record<string, unknown> = { parameters };
+      const result = await checkApiPost(api, `/forms/${form_id}/validate`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/index.ts
+++ b/ts/src/tools/index.ts
@@ -1,0 +1,53 @@
+/** Tool registration orchestrator — imports all 17 modules. */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CheckApiOptions } from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+
+import { register as bankAccounts } from "./bank-accounts.js";
+import { register as companies } from "./companies.js";
+import { register as compensation } from "./compensation.js";
+import { register as components } from "./components.js";
+import { register as contractorPayments } from "./contractor-payments.js";
+import { register as contractors } from "./contractors.js";
+import { register as documents } from "./documents.js";
+import { register as employees } from "./employees.js";
+import { register as externalPayrolls } from "./external-payrolls.js";
+import { register as forms } from "./forms.js";
+import { register as payments } from "./payments.js";
+import { register as payrollItems } from "./payroll-items.js";
+import { register as payrolls } from "./payrolls.js";
+import { register as platform } from "./platform.js";
+import { register as tax } from "./tax.js";
+import { register as webhooks } from "./webhooks.js";
+import { register as workplaces } from "./workplaces.js";
+
+const TOOLSETS: Record<string, typeof webhooks> = {
+  bank_accounts: bankAccounts,
+  companies,
+  compensation,
+  components,
+  contractor_payments: contractorPayments,
+  contractors,
+  documents,
+  employees,
+  external_payrolls: externalPayrolls,
+  forms,
+  payments,
+  payroll_items: payrollItems,
+  payrolls,
+  platform,
+  tax,
+  webhooks,
+  workplaces,
+};
+
+export function registerAll(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+): void {
+  for (const [toolsetName, mod] of Object.entries(TOOLSETS)) {
+    mod(server, api, filter, toolsetName);
+  }
+}

--- a/ts/src/tools/payments.ts
+++ b/ts/src/tools/payments.ts
@@ -1,0 +1,122 @@
+/** Payment tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_payments",
+    "List payments, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to payments belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/payments", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payment",
+    "Get details for a specific payment.",
+    {
+      payment_id: z.string().describe("The Check payment ID."),
+    },
+    async ({ payment_id }) => {
+      const result = await checkApiGet(api, `/payments/${payment_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_payment_attempts",
+    "List payment attempts for a payment.",
+    {
+      payment_id: z.string().describe("The Check payment ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ payment_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/payments/${payment_id}/payment_attempts`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "retry_payment",
+    "Retry a failed payment.",
+    {
+      payment_id: z.string().describe("The Check payment ID."),
+    },
+    async ({ payment_id }) => {
+      const result = await checkApiPost(api, `/payments/${payment_id}/retry`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "refund_payment",
+    "Refund a payment.",
+    {
+      payment_id: z.string().describe("The Check payment ID."),
+    },
+    async ({ payment_id }) => {
+      const result = await checkApiPost(api, `/payments/${payment_id}/refund`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "cancel_payment",
+    "Cancel a payment.",
+    {
+      payment_id: z.string().describe("The Check payment ID."),
+    },
+    async ({ payment_id }) => {
+      const result = await checkApiPost(api, `/payments/${payment_id}/cancel`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/payroll-items.ts
+++ b/ts/src/tools/payroll-items.ts
@@ -1,0 +1,185 @@
+/** Payroll item tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiDelete,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_payroll_items",
+    "List payroll items, optionally filtered by company, employee, or payroll.",
+    {
+      company: z.string().optional().describe('Filter to payroll items belonging to this Check company ID (e.g. "com_xxxxx").'),
+      employee: z.string().optional().describe('Filter to payroll items for this Check employee ID (e.g. "emp_xxxxx").'),
+      payroll: z.string().optional().describe('Filter to payroll items for this Check payroll ID (e.g. "prl_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return (default 10, max 100)."),
+      ids: z.array(z.string()).optional().describe("Filter to specific payroll item IDs."),
+      cursor: z.string().optional().describe("Pagination cursor from a previous response."),
+    },
+    async ({ company, employee, payroll, limit, ids, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (employee !== undefined) params.employee = employee;
+      if (payroll !== undefined) params.payroll = payroll;
+      if (limit !== undefined) params.limit = limit;
+      if (ids !== undefined) params.ids = ids.join(",");
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/payroll_items", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll_item",
+    "Get details for a specific payroll item.",
+    {
+      payroll_item_id: z.string().describe("The Check payroll item ID."),
+    },
+    async ({ payroll_item_id }) => {
+      const result = await checkApiGet(api, `/payroll_items/${payroll_item_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_payroll_item",
+    "Create a new payroll item.",
+    {
+      payroll: z.string().describe("The Check payroll ID."),
+      employee: z.string().describe("The Check employee ID."),
+      payment_method: z.string().optional().describe('Payment method — "direct_deposit" or "manual".'),
+      earnings: z.array(z.record(z.unknown())).optional().describe('List of earning objects. Each requires "workplace" and may include "type", "earning_code", "description", "earning_rate", "amount", "hours", "piece_units", "metadata".'),
+      reimbursements: z.array(z.record(z.unknown())).optional().describe('List of reimbursement objects. Each requires "amount" and may include "description", "code", "metadata".'),
+    },
+    async ({ payroll, employee, payment_method, earnings, reimbursements }) => {
+      const body: Record<string, unknown> = { payroll, employee };
+      if (payment_method !== undefined) body.payment_method = payment_method;
+      if (earnings !== undefined) body.earnings = earnings;
+      if (reimbursements !== undefined) body.reimbursements = reimbursements;
+      const result = await checkApiPost(api, "/payroll_items", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_payroll_item",
+    "Update an existing payroll item.",
+    {
+      payroll_item_id: z.string().describe("The Check payroll item ID."),
+      payment_method: z.string().optional().describe('Payment method — "direct_deposit" or "manual".'),
+      earnings: z.array(z.record(z.unknown())).optional().describe("List of earning objects (see create_payroll_item for shape)."),
+      reimbursements: z.array(z.record(z.unknown())).optional().describe("List of reimbursement objects (see create_payroll_item for shape)."),
+      benefit_overrides: z.array(z.record(z.unknown())).optional().describe('List of benefit override objects. Each requires "benefit" and may include "employee_contribution_amount", "company_contribution_amount".'),
+      post_tax_deduction_overrides: z.array(z.record(z.unknown())).optional().describe('List of post-tax deduction override objects. Each requires "post_tax_deduction" and "amount".'),
+      pto_balance_hours: z.number().optional().describe("Employee's remaining PTO hour balance for paystub display."),
+      sick_balance_hours: z.number().optional().describe("Employee's remaining sick hour balance for paystub display."),
+      supplemental_tax_calc_method: z.string().optional().describe('Tax calculation method — "flat" or "aggregate".'),
+      paper_check_number: z.string().optional().describe("Check number for printed checks."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ payroll_item_id, payment_method, earnings, reimbursements, benefit_overrides, post_tax_deduction_overrides, pto_balance_hours, sick_balance_hours, supplemental_tax_calc_method, paper_check_number, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (payment_method !== undefined) body.payment_method = payment_method;
+      if (earnings !== undefined) body.earnings = earnings;
+      if (reimbursements !== undefined) body.reimbursements = reimbursements;
+      if (benefit_overrides !== undefined) body.benefit_overrides = benefit_overrides;
+      if (post_tax_deduction_overrides !== undefined) body.post_tax_deduction_overrides = post_tax_deduction_overrides;
+      if (pto_balance_hours !== undefined) body.pto_balance_hours = pto_balance_hours;
+      if (sick_balance_hours !== undefined) body.sick_balance_hours = sick_balance_hours;
+      if (supplemental_tax_calc_method !== undefined) body.supplemental_tax_calc_method = supplemental_tax_calc_method;
+      if (paper_check_number !== undefined) body.paper_check_number = paper_check_number;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/payroll_items/${payroll_item_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "bulk_update_payroll_items",
+    "Bulk update payroll items. The payload is a complex bulk structure — pass the full request body as a dict.",
+    {
+      data: z.record(z.unknown()).describe("Bulk update payload with items array."),
+    },
+    async ({ data }) => {
+      const result = await checkApiPatch(api, "/payroll_items", data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_payroll_item",
+    "Delete a payroll item.",
+    {
+      payroll_item_id: z.string().describe("The Check payroll item ID."),
+    },
+    async ({ payroll_item_id }) => {
+      const result = await checkApiDelete(api, `/payroll_items/${payroll_item_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "bulk_delete_payroll_items",
+    "Bulk delete payroll items.",
+    {
+      ids: z.array(z.string()).describe("List of payroll item IDs to delete."),
+    },
+    async ({ ids }) => {
+      const params: Record<string, unknown> = { ids: ids.join(",") };
+      const result = await checkApiDelete(api, "/payroll_items", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll_item_paper_check",
+    "Get paper check details for a payroll item.",
+    {
+      payroll_item_id: z.string().describe("The Check payroll item ID."),
+    },
+    async ({ payroll_item_id }) => {
+      const result = await checkApiGet(api, `/payroll_items/${payroll_item_id}/paper_check`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/payrolls.ts
+++ b/ts/src/tools/payrolls.ts
@@ -1,0 +1,309 @@
+/** Payroll tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiDelete,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_payrolls",
+    "List payrolls, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to payrolls belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return (default 10, max 100)."),
+      ids: z.array(z.string()).optional().describe("Filter to specific payroll IDs."),
+      cursor: z.string().optional().describe("Pagination cursor from a previous response."),
+    },
+    async ({ company, limit, ids, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (ids !== undefined) params.ids = ids.join(",");
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/payrolls", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll",
+    "Get details for a specific payroll.",
+    {
+      payroll_id: z.string().describe('The Check payroll ID (e.g. "prl_xxxxx").'),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiGet(api, `/payrolls/${payroll_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_payroll",
+    "Create a new payroll.",
+    {
+      company: z.string().describe("The Check company ID."),
+      period_start: z.string().describe("Pay period start date (YYYY-MM-DD)."),
+      period_end: z.string().describe("Pay period end date (YYYY-MM-DD)."),
+      payday: z.string().describe("Payday date (YYYY-MM-DD)."),
+      type: z.string().optional().describe('Payroll type — "regular", "off_cycle", or "amendment". Default: "regular".'),
+      processing_period: z.string().optional().describe('Processing period — "three_day", "two_day", or "one_day".'),
+      pay_frequency: z.string().optional().describe('Pay frequency — "weekly", "biweekly", "semimonthly", "monthly", "quarterly", or "annually". Default: "biweekly".'),
+      funding_payment_method: z.string().optional().describe('Funding method — "ach" or "wire". Default: "ach".'),
+      pay_schedule: z.string().optional().describe("ID of the pay schedule this payroll relates to."),
+      off_cycle_options: z.record(z.unknown()).optional().describe("Off-cycle config object with keys: force_supplemental_withholding (bool), apply_benefits (bool), apply_post_tax_deductions (bool)."),
+      items: z.array(z.record(z.unknown())).optional().describe('List of payroll item objects. Each requires "employee" and may include "payment_method", "earnings" (list), "reimbursements" (list), "benefit_overrides" (list), "post_tax_deduction_overrides" (list), "pto_balance_hours", "sick_balance_hours", "metadata".'),
+      contractor_payments: z.array(z.record(z.unknown())).optional().describe('List of contractor payment objects. Each requires "contractor" and may include "payment_method", "amount", "reimbursement_amount", "workplace", "paper_check_number".'),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+      bank_account: z.string().optional().describe("ID of the bank account to fund the payroll."),
+    },
+    async ({ company, period_start, period_end, payday, type, processing_period, pay_frequency, funding_payment_method, pay_schedule, off_cycle_options, items, contractor_payments, metadata, bank_account }) => {
+      const body: Record<string, unknown> = { company, period_start, period_end, payday };
+      if (type !== undefined) body.type = type;
+      if (processing_period !== undefined) body.processing_period = processing_period;
+      if (pay_frequency !== undefined) body.pay_frequency = pay_frequency;
+      if (funding_payment_method !== undefined) body.funding_payment_method = funding_payment_method;
+      if (pay_schedule !== undefined) body.pay_schedule = pay_schedule;
+      if (off_cycle_options !== undefined) body.off_cycle_options = off_cycle_options;
+      if (items !== undefined) body.items = items;
+      if (contractor_payments !== undefined) body.contractor_payments = contractor_payments;
+      if (metadata !== undefined) body.metadata = metadata;
+      if (bank_account !== undefined) body.bank_account = bank_account;
+      const result = await checkApiPost(api, "/payrolls", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_payroll",
+    "Update an existing payroll.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+      period_start: z.string().optional().describe("Pay period start date (YYYY-MM-DD)."),
+      period_end: z.string().optional().describe("Pay period end date (YYYY-MM-DD)."),
+      payday: z.string().optional().describe("Payday date (YYYY-MM-DD)."),
+      type: z.string().optional().describe('Payroll type — "regular", "off_cycle", or "amendment".'),
+      processing_period: z.string().optional().describe('Processing period — "three_day", "two_day", or "one_day".'),
+      pay_frequency: z.string().optional().describe('Pay frequency — "weekly", "biweekly", "semimonthly", "monthly", "quarterly", or "annually".'),
+      funding_payment_method: z.string().optional().describe('Funding method — "ach" or "wire".'),
+      pay_schedule: z.string().optional().describe("ID of the pay schedule this payroll relates to."),
+      off_cycle_options: z.record(z.unknown()).optional().describe("Off-cycle config object with keys: force_supplemental_withholding (bool), apply_benefits (bool), apply_post_tax_deductions (bool)."),
+      items: z.array(z.record(z.unknown())).optional().describe("List of payroll item objects (see create_payroll for shape)."),
+      contractor_payments: z.array(z.record(z.unknown())).optional().describe("List of contractor payment objects (see create_payroll for shape)."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+      bank_account: z.string().optional().describe("ID of the bank account to fund the payroll."),
+    },
+    async ({ payroll_id, period_start, period_end, payday, type, processing_period, pay_frequency, funding_payment_method, pay_schedule, off_cycle_options, items, contractor_payments, metadata, bank_account }) => {
+      const body: Record<string, unknown> = {};
+      if (period_start !== undefined) body.period_start = period_start;
+      if (period_end !== undefined) body.period_end = period_end;
+      if (payday !== undefined) body.payday = payday;
+      if (type !== undefined) body.type = type;
+      if (processing_period !== undefined) body.processing_period = processing_period;
+      if (pay_frequency !== undefined) body.pay_frequency = pay_frequency;
+      if (funding_payment_method !== undefined) body.funding_payment_method = funding_payment_method;
+      if (pay_schedule !== undefined) body.pay_schedule = pay_schedule;
+      if (off_cycle_options !== undefined) body.off_cycle_options = off_cycle_options;
+      if (items !== undefined) body.items = items;
+      if (contractor_payments !== undefined) body.contractor_payments = contractor_payments;
+      if (metadata !== undefined) body.metadata = metadata;
+      if (bank_account !== undefined) body.bank_account = bank_account;
+      const result = await checkApiPatch(api, `/payrolls/${payroll_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_payroll",
+    "Delete a payroll.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiDelete(api, `/payrolls/${payroll_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "preview_payroll",
+    "Preview a payroll before approval.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiGet(api, `/payrolls/${payroll_id}/preview`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "approve_payroll",
+    "Approve a payroll for processing.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/payrolls/${payroll_id}/approve`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "reopen_payroll",
+    "Reopen a previously approved payroll.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/payrolls/${payroll_id}/reopen`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll_paper_checks",
+    "Get paper checks for a payroll.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiGet(api, `/payrolls/${payroll_id}/paper_checks`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll_cash_requirement_report",
+    "Get a cash requirement report for a payroll.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiGet(api, `/payrolls/${payroll_id}/reports/cash_requirement`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_payroll_paper_checks_report",
+    "Get a paper checks report for a payroll.",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiGet(api, `/payrolls/${payroll_id}/reports/paper_checks`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --- Simulation ---
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "simulate_start_processing",
+    "Simulate starting payroll processing (sandbox only).",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/payrolls/${payroll_id}/simulate/start_processing`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "simulate_complete_funding",
+    "Simulate completing payroll funding (sandbox only).",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/payrolls/${payroll_id}/simulate/complete_funding`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "simulate_fail_funding",
+    "Simulate failing payroll funding (sandbox only).",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/payrolls/${payroll_id}/simulate/fail_funding`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "simulate_complete_disbursements",
+    "Simulate completing payroll disbursements (sandbox only).",
+    {
+      payroll_id: z.string().describe("The Check payroll ID."),
+    },
+    async ({ payroll_id }) => {
+      const result = await checkApiPost(api, `/payrolls/${payroll_id}/simulate/complete_disbursements`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/platform.ts
+++ b/ts/src/tools/platform.ts
@@ -1,0 +1,547 @@
+/** Platform tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  // ---------------------------------------------------------------------------
+  // Read tools
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_notifications",
+    "List notifications, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to notifications belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/notifications", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_notification",
+    "Get details for a specific notification.",
+    {
+      notification_id: z.string().describe("The Check notification ID."),
+    },
+    async ({ notification_id }) => {
+      const result = await checkApiGet(api, `/notifications/${notification_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_communications",
+    "List communications, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to communications belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/communications", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_communication",
+    "Get details for a specific communication.",
+    {
+      communication_id: z.string().describe("The Check communication ID."),
+    },
+    async ({ communication_id }) => {
+      const result = await checkApiGet(api, `/communications/${communication_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_usage_summaries",
+    "List usage summaries.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/usage_summaries", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_usage_records",
+    "List usage records.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/usage_records", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_integration_partners",
+    "List integration partners.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/integration_partners", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_integration_partner",
+    "Get details for a specific integration partner.",
+    {
+      partner_id: z.string().describe("The Check integration partner ID."),
+    },
+    async ({ partner_id }) => {
+      const result = await checkApiGet(api, `/integration_partners/${partner_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_integration_permissions",
+    "List integration permissions.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/integration_permissions", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_integration_permission",
+    "Get details for a specific integration permission.",
+    {
+      permission_id: z.string().describe("The Check integration permission ID."),
+    },
+    async ({ permission_id }) => {
+      const result = await checkApiGet(api, `/integration_permissions/${permission_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_integration_accesses",
+    "List integration accesses.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/integration_accesses", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_accounting_accounts",
+    "List accounting accounts for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/companies/${company_id}/accounting_accounts`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_accounting_mappings",
+    "Get accounting mappings for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiGet(api, `/companies/${company_id}/accounting_mappings`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_accounting_sync_attempts",
+    "List accounting sync attempts for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/companies/${company_id}/accounting_sync_attempts`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_groups",
+    "List company groups.",
+    {
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/company_groups", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "validate_address",
+    "Validate a US address. Returns the validated/standardized address or validation errors.",
+    {
+      line1: z.string().describe("Street address line 1."),
+      city: z.string().describe("City name."),
+      state: z.string().describe("Two-letter state code."),
+      postal_code: z.string().describe("ZIP or postal code."),
+      line2: z.string().optional().describe("Street address line 2."),
+      country: z.string().optional().describe("Country code (default: US)."),
+    },
+    async ({ line1, city, state, postal_code, line2, country }) => {
+      const body: Record<string, unknown> = { line1, city, state, postal_code };
+      if (line2 !== undefined) body.line2 = line2;
+      if (country !== undefined) body.country = country;
+      const result = await checkApiPost(api, "/addresses/validate", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_setups",
+    "List setups, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to setups belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/setups", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_setup",
+    "Get details for a specific setup.",
+    {
+      setup_id: z.string().describe("The Check setup ID."),
+    },
+    async ({ setup_id }) => {
+      const result = await checkApiGet(api, `/setups/${setup_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_requirements",
+    "List requirements, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to requirements belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/requirements", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_requirement",
+    "Get details for a specific requirement.",
+    {
+      requirement_id: z.string().describe("The Check requirement ID."),
+    },
+    async ({ requirement_id }) => {
+      const result = await checkApiGet(api, `/requirements/${requirement_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_applied_for_ids_report",
+    "Get the applied-for IDs report across all companies.",
+    {},
+    async () => {
+      const result = await checkApiGet(api, "/reports/applied_for_ids");
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Write tools
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_communication",
+    "Create a new communication.",
+    {
+      company: z.string().describe("The Check company ID."),
+      type: z.string().optional().describe("Communication type."),
+      email: z.record(z.unknown()).optional().describe("Email configuration object."),
+    },
+    async ({ company, type, email }) => {
+      const body: Record<string, unknown> = { company };
+      if (type !== undefined) body.type = type;
+      if (email !== undefined) body.email = email;
+      const result = await checkApiPost(api, "/communications", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "authorize_integration_partner",
+    "Authorize an integration partner.",
+    {
+      partner_id: z.string().describe("The Check integration partner ID."),
+      data: z.record(z.unknown()).optional().describe("Authorization data."),
+    },
+    async ({ partner_id, data }) => {
+      const result = await checkApiPost(api, `/integration_partners/${partner_id}/authorize`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "refresh_accounting_accounts",
+    "Refresh accounting accounts for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/accounting_accounts/refresh`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_accounting_mappings",
+    "Update accounting mappings for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.record(z.unknown()).describe("Accounting mappings data."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPatch(api, `/companies/${company_id}/accounting_mappings`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "toggle_accounting_mappings",
+    "Toggle accounting mappings for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.record(z.unknown()).describe("Toggle configuration data."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/accounting_mappings/toggle`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "sync_accounting",
+    "Trigger an accounting sync for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.record(z.unknown()).optional().describe("Sync configuration data."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/accounting_sync`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_company_group",
+    "Create a new company group.",
+    {
+      name: z.string().optional().describe("Name of the company group."),
+      companies: z.array(z.record(z.unknown())).optional().describe("List of company objects to include in the group."),
+    },
+    async ({ name, companies }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (companies !== undefined) body.companies = companies;
+      const result = await checkApiPost(api, "/company_groups", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_company_group",
+    "Update an existing company group.",
+    {
+      group_id: z.string().describe("The Check company group ID."),
+      name: z.string().optional().describe("Name of the company group."),
+      companies: z.array(z.record(z.unknown())).optional().describe("List of company objects to include in the group."),
+    },
+    async ({ group_id, name, companies }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (companies !== undefined) body.companies = companies;
+      const result = await checkApiPatch(api, `/company_groups/${group_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/tax.ts
+++ b/ts/src/tools/tax.ts
@@ -1,0 +1,561 @@
+/** Tax tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  // ---------------------------------------------------------------------------
+  // Read tools
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_tax_params",
+    "Get tax parameters for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+    },
+    async ({ company_id }) => {
+      const result = await checkApiGet(api, `/company_tax_params/${company_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_tax_param_settings",
+    "List tax parameter settings for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/company_tax_params/${company_id}/settings`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_company_tax_param_setting",
+    "Get a specific tax parameter setting for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      setting_id: z.string().describe("The tax parameter setting ID."),
+    },
+    async ({ company_id, setting_id }) => {
+      const result = await checkApiGet(api, `/company_tax_params/${company_id}/settings/${setting_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_jurisdictions",
+    "List tax jurisdictions for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/company_tax_params/${company_id}/jurisdictions`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_tax_params",
+    "List employee tax parameters, optionally filtered by employee.",
+    {
+      employee: z.string().optional().describe('Filter to tax params for this Check employee ID (e.g. "emp_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ employee, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (employee !== undefined) params.employee = employee;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/employee_tax_params", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_tax_params",
+    "Get tax parameters for a specific employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+    },
+    async ({ employee_id }) => {
+      const result = await checkApiGet(api, `/employee_tax_params/${employee_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_tax_param_settings",
+    "List tax parameter settings for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ employee_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/employee_tax_params/${employee_id}/settings`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_tax_param_setting",
+    "Get a specific tax parameter setting for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      setting_id: z.string().describe("The tax parameter setting ID."),
+    },
+    async ({ employee_id, setting_id }) => {
+      const result = await checkApiGet(api, `/employee_tax_params/${employee_id}/settings/${setting_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_jurisdictions",
+    "List tax jurisdictions for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ employee_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/employee_tax_params/${employee_id}/jurisdictions`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "bulk_get_employee_tax_param_settings",
+    "Bulk get employee tax parameter settings. Pass the full request body as a dict.",
+    {
+      data: z.record(z.unknown()).describe("Bulk get payload with employee IDs and filters."),
+    },
+    async ({ data }) => {
+      const result = await checkApiPost(api, "/employee_tax_param_settings/bulk_get", data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_company_tax_elections",
+    "List tax elections for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/companies/${company_id}/tax_elections`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_tax_elections",
+    "List tax elections for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ employee_id, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, `/employees/${employee_id}/tax_elections`, params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_tax_filings",
+    "List tax filings, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to tax filings belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/tax_filings", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_tax_filing",
+    "Get details for a specific tax filing.",
+    {
+      tax_filing_id: z.string().describe("The Check tax filing ID."),
+    },
+    async ({ tax_filing_id }) => {
+      const result = await checkApiGet(api, `/tax_filings/${tax_filing_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_tax_filing_event",
+    "Get details for a specific tax filing event.",
+    {
+      event_id: z.string().describe("The Check tax filing event ID."),
+    },
+    async ({ event_id }) => {
+      const result = await checkApiGet(api, `/tax_filing_events/${event_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_exempt_status",
+    "Get exempt status for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+    },
+    async ({ employee_id }) => {
+      const result = await checkApiGet(api, `/employees/${employee_id}/exempt_status`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_exemptible_taxes",
+    "List exemptible taxes, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to exemptible taxes belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/exemptible_taxes", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_employee_tax_statements",
+    "List employee tax statements, optionally filtered by employee.",
+    {
+      employee: z.string().optional().describe('Filter to tax statements for this Check employee ID (e.g. "emp_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ employee, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (employee !== undefined) params.employee = employee;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/employee_tax_statements", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_employee_tax_statement",
+    "Get details for a specific employee tax statement.",
+    {
+      statement_id: z.string().describe("The Check employee tax statement ID."),
+    },
+    async ({ statement_id }) => {
+      const result = await checkApiGet(api, `/employee_tax_statements/${statement_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_tax_package",
+    "Get details for a specific tax package.",
+    {
+      tax_package_id: z.string().describe("The Check tax package ID."),
+    },
+    async ({ tax_package_id }) => {
+      const result = await checkApiGet(api, `/tax_packages/${tax_package_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Write tools
+  // ---------------------------------------------------------------------------
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_company_tax_params",
+    "Update tax parameters for a company. Pass the full array of tax param updates.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.array(z.record(z.unknown())).describe("Array of tax parameter update objects."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPatch(api, `/company_tax_params/${company_id}`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_employee_tax_params",
+    "Update tax parameters for an employee. Pass the full array of tax param updates.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      data: z.array(z.record(z.unknown())).describe("Array of tax parameter update objects."),
+    },
+    async ({ employee_id, data }) => {
+      const result = await checkApiPatch(api, `/employee_tax_params/${employee_id}`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "bulk_update_employee_tax_param_settings",
+    "Bulk update employee tax parameter settings. Pass the full request body as a dict.",
+    {
+      data: z.record(z.unknown()).describe("Bulk update payload with settings data."),
+    },
+    async ({ data }) => {
+      const result = await checkApiPost(api, "/employee_tax_param_settings/bulk_update", data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_company_tax_elections",
+    "Create tax elections for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.record(z.unknown()).describe("Tax election creation data."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPost(api, `/companies/${company_id}/tax_elections`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_company_tax_elections",
+    "Update tax elections for a company.",
+    {
+      company_id: z.string().describe("The Check company ID."),
+      data: z.record(z.unknown()).describe("Tax election update data."),
+    },
+    async ({ company_id, data }) => {
+      const result = await checkApiPatch(api, `/companies/${company_id}/tax_elections`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_employee_tax_elections",
+    "Update tax elections for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      data: z.record(z.unknown()).describe("Tax election update data."),
+    },
+    async ({ employee_id, data }) => {
+      const result = await checkApiPatch(api, `/employees/${employee_id}/tax_elections`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "request_tax_filing_refile",
+    "Request a refile for a tax filing.",
+    {
+      tax_filing_id: z.string().describe("The Check tax filing ID."),
+    },
+    async ({ tax_filing_id }) => {
+      const result = await checkApiPost(api, `/tax_filings/${tax_filing_id}/request_refile`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_exempt_status",
+    "Update exempt status for an employee.",
+    {
+      employee_id: z.string().describe("The Check employee ID."),
+      data: z.record(z.unknown()).describe("Exempt status update data."),
+    },
+    async ({ employee_id, data }) => {
+      const result = await checkApiPatch(api, `/employees/${employee_id}/exempt_status`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_exemptible_tax",
+    "Update a specific exemptible tax.",
+    {
+      tax_id: z.string().describe("The Check exemptible tax ID."),
+      data: z.record(z.unknown()).describe("Exemptible tax update data."),
+    },
+    async ({ tax_id, data }) => {
+      const result = await checkApiPatch(api, `/exemptible_taxes/${tax_id}`, data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "bulk_update_exemptible_taxes",
+    "Bulk update exemptible taxes. Pass the full request body as a dict.",
+    {
+      data: z.record(z.unknown()).describe("Bulk update payload with exemptible tax data."),
+    },
+    async ({ data }) => {
+      const result = await checkApiPatch(api, "/exemptible_taxes", data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "request_tax_package",
+    "Request a tax package for a company.",
+    {
+      company: z.string().describe("The Check company ID."),
+      contents: z.record(z.unknown()).optional().describe("Tax package contents configuration."),
+    },
+    async ({ company, contents }) => {
+      const body: Record<string, unknown> = { company };
+      if (contents !== undefined) body.contents = contents;
+      const result = await checkApiPost(api, "/tax_packages", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/webhooks.ts
+++ b/ts/src/tools/webhooks.ts
@@ -1,0 +1,140 @@
+/** Webhook tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiDelete,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_webhook_configs",
+    "List webhook configurations, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to webhook configs belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return."),
+      cursor: z.string().optional().describe("Pagination cursor."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/webhook_configs", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_webhook_config",
+    "Get details for a specific webhook configuration.",
+    {
+      webhook_config_id: z.string().describe("The Check webhook config ID."),
+    },
+    async ({ webhook_config_id }) => {
+      const result = await checkApiGet(api, `/webhook_configs/${webhook_config_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_webhook_config",
+    "Create a new webhook configuration.",
+    {
+      url: z.string().describe("The webhook endpoint URL."),
+    },
+    async ({ url }) => {
+      const body: Record<string, unknown> = { url };
+      const result = await checkApiPost(api, "/webhook_configs", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_webhook_config",
+    "Update a webhook configuration.",
+    {
+      webhook_config_id: z.string().describe("The Check webhook config ID."),
+      url: z.string().optional().describe("The webhook endpoint URL."),
+      active: z.boolean().optional().describe("Whether the webhook config is active."),
+    },
+    async ({ webhook_config_id, url, active }) => {
+      const body: Record<string, unknown> = {};
+      if (url !== undefined) body.url = url;
+      if (active !== undefined) body.active = active;
+      const result = await checkApiPatch(api, `/webhook_configs/${webhook_config_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "delete_webhook_config",
+    "Delete a webhook configuration.",
+    {
+      webhook_config_id: z.string().describe("The Check webhook config ID."),
+    },
+    async ({ webhook_config_id }) => {
+      const result = await checkApiDelete(api, `/webhook_configs/${webhook_config_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "ping_webhook_config",
+    "Send a test ping to a webhook configuration.",
+    {
+      webhook_config_id: z.string().describe("The Check webhook config ID."),
+    },
+    async ({ webhook_config_id }) => {
+      const result = await checkApiPost(api, `/webhook_configs/${webhook_config_id}/ping`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "retry_webhook_events",
+    "Retry failed webhook events. The payload structure varies -- pass the full request body as a dict with event IDs or filters.",
+    {
+      data: z.record(z.unknown()).describe("Retry configuration (event IDs or filters)."),
+    },
+    async ({ data }) => {
+      const result = await checkApiPost(api, "/webhook_events/retry", data);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/src/tools/workplaces.ts
+++ b/ts/src/tools/workplaces.ts
@@ -1,0 +1,107 @@
+/** Workplace tools for the Check API. */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiList,
+  type CheckApiOptions,
+} from "../helpers.js";
+import type { ToolFilter } from "../tool-filter.js";
+import { tool } from "./_register.js";
+
+
+
+export function register(
+  server: McpServer,
+  api: CheckApiOptions,
+  filter: ToolFilter,
+  toolsetName: string,
+) {
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "list_workplaces",
+    "List workplaces, optionally filtered by company.",
+    {
+      company: z.string().optional().describe('Filter to workplaces belonging to this Check company ID (e.g. "com_xxxxx").'),
+      limit: z.number().optional().describe("Maximum number of results to return (default 10, max 100)."),
+      cursor: z.string().optional().describe("Pagination cursor from a previous response."),
+    },
+    async ({ company, limit, cursor }) => {
+      const params: Record<string, unknown> = {};
+      if (company !== undefined) params.company = company;
+      if (limit !== undefined) params.limit = limit;
+      if (cursor !== undefined) params.cursor = cursor;
+      const result = await checkApiList(api, "/workplaces", params);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "get_workplace",
+    "Get details for a specific workplace.",
+    {
+      workplace_id: z.string().describe('The Check workplace ID (e.g. "wrk_xxxxx").'),
+    },
+    async ({ workplace_id }) => {
+      const result = await checkApiGet(api, `/workplaces/${workplace_id}`);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "create_workplace",
+    "Create a new workplace.",
+    {
+      company: z.string().describe("The Check company ID."),
+      address: z.record(z.unknown()).describe("Workplace address dict with keys: line1 (required), line2, city (required), state (required), postal_code (required), country."),
+      name: z.string().optional().describe("Human-readable name for the workplace."),
+      active: z.boolean().optional().describe("Whether the workplace can be associated with employees. Default: true."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ company, address, name, active, metadata }) => {
+      const body: Record<string, unknown> = { company, address };
+      if (name !== undefined) body.name = name;
+      if (active !== undefined) body.active = active;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPost(api, "/workplaces", body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  tool(
+    server,
+    filter,
+    toolsetName,
+    "update_workplace",
+    "Update an existing workplace.",
+    {
+      workplace_id: z.string().describe("The Check workplace ID."),
+      company: z.string().optional().describe("The Check company ID."),
+      name: z.string().optional().describe("Human-readable name for the workplace."),
+      address: z.record(z.unknown()).optional().describe("Address dict with keys: line1, line2, city, state, postal_code, country."),
+      active: z.boolean().optional().describe("Whether the workplace can be associated with employees."),
+      metadata: z.string().optional().describe("Additional JSON metadata string."),
+    },
+    async ({ workplace_id, company, name, address, active, metadata }) => {
+      const body: Record<string, unknown> = {};
+      if (company !== undefined) body.company = company;
+      if (name !== undefined) body.name = name;
+      if (address !== undefined) body.address = address;
+      if (active !== undefined) body.active = active;
+      if (metadata !== undefined) body.metadata = metadata;
+      const result = await checkApiPatch(api, `/workplaces/${workplace_id}`, body);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}

--- a/ts/test/helpers.test.ts
+++ b/ts/test/helpers.test.ts
@@ -1,0 +1,196 @@
+/** Tests for HTTP helpers — mock native fetch. */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  checkApiGet,
+  checkApiPost,
+  checkApiPatch,
+  checkApiPut,
+  checkApiDelete,
+  checkApiList,
+  extractCursor,
+  formatListResponse,
+  type CheckApiOptions,
+} from "../src/helpers.js";
+
+const api: CheckApiOptions = {
+  apiKey: "test-key",
+  baseUrl: "https://sandbox.checkhq.com",
+};
+
+function mockFetch(response: { status: number; json?: unknown; text?: string }) {
+  const fn = vi.fn(async () => ({
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status,
+    json: async () => response.json,
+    text: async () => response.text ?? JSON.stringify(response.json),
+  }));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- extractCursor ---
+
+describe("extractCursor", () => {
+  it("extracts cursor from URL", () => {
+    expect(extractCursor("https://sandbox.checkhq.com/items?cursor=c2")).toBe("c2");
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(extractCursor(null)).toBeNull();
+    expect(extractCursor(undefined)).toBeNull();
+  });
+
+  it("returns null for URL without cursor", () => {
+    expect(extractCursor("https://sandbox.checkhq.com/items")).toBeNull();
+  });
+});
+
+// --- formatListResponse ---
+
+describe("formatListResponse", () => {
+  it("normalizes paginated response", () => {
+    const result = formatListResponse({
+      results: [{ id: "i_1" }],
+      next: "https://sandbox.checkhq.com/items?cursor=c2",
+      previous: null,
+    });
+    expect(result.results).toEqual([{ id: "i_1" }]);
+    expect(result.next_cursor).toBe("c2");
+    expect(result.previous_cursor).toBeNull();
+  });
+});
+
+// --- checkApiGet ---
+
+describe("checkApiGet", () => {
+  it("makes GET request and returns JSON", async () => {
+    const fetchMock = mockFetch({ status: 200, json: { id: "t_1" } });
+    const result = await checkApiGet(api, "/test");
+    expect(result).toEqual({ id: "t_1" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://sandbox.checkhq.com/test");
+    expect(init.method).toBe("GET");
+  });
+
+  it("sends query params", async () => {
+    const fetchMock = mockFetch({ status: 200, json: { id: "t_1" } });
+    await checkApiGet(api, "/test", { limit: 5 });
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("limit=5");
+  });
+});
+
+// --- checkApiPost ---
+
+describe("checkApiPost", () => {
+  it("makes POST request with body", async () => {
+    const fetchMock = mockFetch({ status: 201, json: { id: "t_new" } });
+    const result = await checkApiPost(api, "/test", { name: "foo" });
+    expect(result).toEqual({ id: "t_new" });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ name: "foo" }));
+  });
+});
+
+// --- checkApiPatch ---
+
+describe("checkApiPatch", () => {
+  it("makes PATCH request", async () => {
+    mockFetch({ status: 200, json: { id: "t_1", name: "updated" } });
+    const result = await checkApiPatch(api, "/test/t_1", { name: "updated" });
+    expect((result as Record<string, unknown>).name).toBe("updated");
+  });
+});
+
+// --- checkApiPut ---
+
+describe("checkApiPut", () => {
+  it("makes PUT request", async () => {
+    mockFetch({ status: 200, json: { id: "t_1", name: "replaced" } });
+    const result = await checkApiPut(api, "/test/t_1", { name: "replaced" });
+    expect((result as Record<string, unknown>).name).toBe("replaced");
+  });
+});
+
+// --- checkApiDelete ---
+
+describe("checkApiDelete", () => {
+  it("returns success for 204", async () => {
+    mockFetch({ status: 204 });
+    const result = await checkApiDelete(api, "/test/t_1");
+    expect(result).toEqual({ success: true });
+  });
+
+  it("returns JSON for non-204", async () => {
+    mockFetch({ status: 200, json: { deleted: true } });
+    const result = await checkApiDelete(api, "/test/t_1");
+    expect(result).toEqual({ deleted: true });
+  });
+});
+
+// --- checkApiList ---
+
+describe("checkApiList", () => {
+  it("normalizes list response", async () => {
+    mockFetch({
+      status: 200,
+      json: {
+        next: "https://sandbox.checkhq.com/items?cursor=c2",
+        previous: null,
+        results: [{ id: "i_1" }],
+      },
+    });
+    const result = await checkApiList(api, "/items");
+    expect(result.results).toEqual([{ id: "i_1" }]);
+    expect(result.next_cursor).toBe("c2");
+    expect(result.previous_cursor).toBeNull();
+  });
+});
+
+// --- Error handling ---
+
+describe("error handling", () => {
+  it("returns error dict for HTTP error with JSON body", async () => {
+    mockFetch({ status: 422, json: { detail: "Validation error" } });
+    const result = await checkApiGet(api, "/bad");
+    expect(result.error).toBe(true);
+    expect(result.status_code).toBe(422);
+    expect(result.detail).toEqual({ detail: "Validation error" });
+  });
+
+  it("returns error dict for HTTP error with text body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error("not json");
+        },
+        text: async () => "Internal Server Error",
+      })),
+    );
+    const result = await checkApiGet(api, "/bad");
+    expect(result.error).toBe(true);
+    expect(result.status_code).toBe(500);
+  });
+
+  it("returns error dict for network error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("Network failure");
+      }),
+    );
+    const result = await checkApiGet(api, "/bad");
+    expect(result.error).toBe(true);
+    expect(result.detail).toContain("Network failure");
+  });
+});

--- a/ts/test/tool-filter.test.ts
+++ b/ts/test/tool-filter.test.ts
@@ -1,0 +1,246 @@
+/** Tests for ToolFilter — port of test_tool_filter.py. */
+
+import { describe, it, expect } from "vitest";
+import { TOOLSETS, ToolFilter, isWriteTool } from "../src/tool-filter.js";
+
+// --- isWriteTool ---
+
+describe("isWriteTool", () => {
+  it.each([
+    "create_company",
+    "update_employee",
+    "delete_payroll",
+    "bulk_update_payroll_items",
+    "bulk_delete_payroll_items",
+    "approve_payroll",
+    "reopen_payroll",
+    "onboard_company",
+    "submit_employee_form",
+    "sign_and_submit_employee_form",
+    "authorize_integration_partner",
+    "simulate_start_processing",
+    "retry_payment",
+    "refund_payment",
+    "cancel_payment",
+    "start_implementation",
+    "cancel_implementation",
+    "request_embedded_setup",
+    "ping_webhook_config",
+    "refresh_accounting_accounts",
+    "toggle_accounting_mappings",
+    "sync_accounting",
+    "upload_company_provided_document_file",
+    "request_tax_filing_refile",
+  ])("detects %s as write tool", (name) => {
+    expect(isWriteTool(name)).toBe(true);
+  });
+
+  it.each([
+    "list_companies",
+    "get_company",
+    "get_employee",
+    "list_payrolls",
+    "preview_payroll",
+    "download_company_tax_document",
+    "validate_address",
+    "list_webhook_configs",
+    "reveal_employee_ssn",
+    "get_enrollment_profile",
+  ])("does not flag %s as write tool", (name) => {
+    expect(isWriteTool(name)).toBe(false);
+  });
+});
+
+// --- ToolFilter.fromEnv ---
+
+describe("ToolFilter.fromEnv", () => {
+  it("returns defaults with no env vars", () => {
+    const tf = ToolFilter.fromEnv({
+      CHECK_API_KEY: "key",
+    });
+    expect(tf.toolsets).toBeNull();
+    expect(tf.tools).toBeNull();
+    expect(tf.excludeTools.size).toBe(0);
+    expect(tf.readOnly).toBe(false);
+  });
+
+  it("parses toolsets", () => {
+    const tf = ToolFilter.fromEnv({
+      CHECK_API_KEY: "key",
+      CHECK_TOOLSETS: "companies, employees",
+    });
+    expect(tf.toolsets).toEqual(new Set(["companies", "employees"]));
+  });
+
+  it("parses tools", () => {
+    const tf = ToolFilter.fromEnv({
+      CHECK_API_KEY: "key",
+      CHECK_TOOLS: "list_companies,get_company",
+    });
+    expect(tf.tools).toEqual(new Set(["list_companies", "get_company"]));
+  });
+
+  it("parses exclude_tools", () => {
+    const tf = ToolFilter.fromEnv({
+      CHECK_API_KEY: "key",
+      CHECK_EXCLUDE_TOOLS: "create_company,delete_company",
+    });
+    expect(tf.excludeTools).toEqual(new Set(["create_company", "delete_company"]));
+  });
+
+  it("parses read_only true", () => {
+    for (const val of ["1", "true", "yes", "True", "YES"]) {
+      const tf = ToolFilter.fromEnv({ CHECK_API_KEY: "key", CHECK_READ_ONLY: val });
+      expect(tf.readOnly).toBe(true);
+    }
+  });
+
+  it("parses read_only false", () => {
+    for (const val of ["0", "false", "no", ""]) {
+      const tf = ToolFilter.fromEnv({ CHECK_API_KEY: "key", CHECK_READ_ONLY: val });
+      expect(tf.readOnly).toBe(false);
+    }
+  });
+
+  it("treats empty strings as null", () => {
+    const tf = ToolFilter.fromEnv({
+      CHECK_API_KEY: "key",
+      CHECK_TOOLSETS: "",
+      CHECK_TOOLS: "",
+    });
+    expect(tf.toolsets).toBeNull();
+    expect(tf.tools).toBeNull();
+  });
+});
+
+// --- ToolFilter.fromHeaders ---
+
+describe("ToolFilter.fromHeaders", () => {
+  it("parses all headers", () => {
+    const headers = new Headers({
+      "x-mcp-toolsets": "companies,employees",
+      "x-mcp-tools": "list_companies",
+      "x-mcp-exclude-tools": "create_company",
+      "x-mcp-readonly": "true",
+    });
+    const tf = ToolFilter.fromHeaders(headers);
+    expect(tf.toolsets).toEqual(new Set(["companies", "employees"]));
+    expect(tf.tools).toEqual(new Set(["list_companies"]));
+    expect(tf.excludeTools).toEqual(new Set(["create_company"]));
+    expect(tf.readOnly).toBe(true);
+  });
+
+  it("returns defaults for empty headers", () => {
+    const tf = ToolFilter.fromHeaders(new Headers());
+    expect(tf.isDefault()).toBe(true);
+  });
+});
+
+// --- isToolAllowed precedence ---
+
+describe("isToolAllowed", () => {
+  it("allows everything with no filter", () => {
+    const tf = new ToolFilter();
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(true);
+  });
+
+  it("exclude wins over everything", () => {
+    const tf = new ToolFilter({
+      tools: new Set(["create_company"]),
+      excludeTools: new Set(["create_company"]),
+    });
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(false);
+  });
+
+  it("readOnly blocks write tools", () => {
+    const tf = new ToolFilter({ readOnly: true });
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(false);
+    expect(tf.isToolAllowed("list_companies", "companies")).toBe(true);
+  });
+
+  it("readOnly takes precedence over tools allowlist", () => {
+    const tf = new ToolFilter({
+      tools: new Set(["create_company"]),
+      readOnly: true,
+    });
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(false);
+  });
+
+  it("tools allowlist", () => {
+    const tf = new ToolFilter({
+      tools: new Set(["list_companies", "get_company"]),
+    });
+    expect(tf.isToolAllowed("list_companies", "companies")).toBe(true);
+    expect(tf.isToolAllowed("get_company", "companies")).toBe(true);
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(false);
+    expect(tf.isToolAllowed("list_employees", "employees")).toBe(false);
+  });
+
+  it("tools overrides toolsets", () => {
+    const tf = new ToolFilter({
+      toolsets: new Set(["employees"]),
+      tools: new Set(["list_companies"]),
+    });
+    expect(tf.isToolAllowed("list_companies", "companies")).toBe(true);
+    expect(tf.isToolAllowed("list_employees", "employees")).toBe(false);
+  });
+
+  it("toolsets filter", () => {
+    const tf = new ToolFilter({ toolsets: new Set(["companies"]) });
+    expect(tf.isToolAllowed("list_companies", "companies")).toBe(true);
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(true);
+    expect(tf.isToolAllowed("list_employees", "employees")).toBe(false);
+  });
+
+  it("exclude with toolsets", () => {
+    const tf = new ToolFilter({
+      toolsets: new Set(["companies"]),
+      excludeTools: new Set(["create_company"]),
+    });
+    expect(tf.isToolAllowed("list_companies", "companies")).toBe(true);
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(false);
+  });
+
+  it("readOnly with toolsets", () => {
+    const tf = new ToolFilter({
+      toolsets: new Set(["companies"]),
+      readOnly: true,
+    });
+    expect(tf.isToolAllowed("list_companies", "companies")).toBe(true);
+    expect(tf.isToolAllowed("create_company", "companies")).toBe(false);
+    expect(tf.isToolAllowed("list_employees", "employees")).toBe(false);
+  });
+});
+
+// --- Invalid toolset handling ---
+
+describe("invalid toolsets", () => {
+  it("strips unknown toolsets", () => {
+    const tf = new ToolFilter({ toolsets: new Set(["companies", "not_a_real_one"]) });
+    expect(tf.toolsets).toEqual(new Set(["companies"]));
+  });
+
+  it("all unknown yields empty set", () => {
+    const tf = new ToolFilter({ toolsets: new Set(["bogus"]) });
+    expect(tf.toolsets!.size).toBe(0);
+    expect(tf.isToolAllowed("list_companies", "companies")).toBe(false);
+  });
+});
+
+// --- TOOLSETS constant ---
+
+describe("TOOLSETS", () => {
+  it("has 17 toolsets", () => {
+    expect(TOOLSETS.size).toBe(17);
+  });
+
+  it("contains expected toolsets", () => {
+    const expected = new Set([
+      "bank_accounts", "companies", "compensation", "components",
+      "contractor_payments", "contractors", "documents", "employees",
+      "external_payrolls", "forms", "payments", "payroll_items",
+      "payrolls", "platform", "tax", "webhooks", "workplaces",
+    ]);
+    expect(TOOLSETS).toEqual(expected);
+  });
+});

--- a/ts/test/tools/smoke.test.ts
+++ b/ts/test/tools/smoke.test.ts
@@ -1,0 +1,55 @@
+/** Smoke test: verify all tools register correctly and count matches expectations. */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { buildApiOptions } from "../../src/helpers.js";
+import { ToolFilter } from "../../src/tool-filter.js";
+import { registerAll } from "../../src/tools/index.js";
+
+const api = buildApiOptions("test-key");
+
+describe("tool registration", () => {
+  let server: McpServer;
+  let toolNames: string[];
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    toolNames = [];
+
+    // Spy on server.tool to capture registered tool names
+    const originalTool = server.tool.bind(server);
+    server.tool = vi.fn((...args: unknown[]) => {
+      const name = args[0] as string;
+      toolNames.push(name);
+      return (originalTool as Function)(...args);
+    }) as typeof server.tool;
+  });
+
+  it("registers all 263 tools with no filter", () => {
+    const filter = new ToolFilter();
+    registerAll(server, api, filter);
+    expect(toolNames.length).toBe(263);
+  });
+
+  it("registers no component tools in read-only mode", () => {
+    const filter = new ToolFilter({ readOnly: true });
+    registerAll(server, api, filter);
+    const componentTools = toolNames.filter((n) => n.includes("_component"));
+    expect(componentTools.length).toBe(0);
+  });
+
+  it("filters by toolset", () => {
+    const filter = new ToolFilter({ toolsets: new Set(["webhooks"]) });
+    registerAll(server, api, filter);
+    expect(toolNames.length).toBe(7);
+    expect(toolNames).toContain("list_webhook_configs");
+    expect(toolNames).toContain("retry_webhook_events");
+  });
+
+  it("all tool names are unique", () => {
+    const filter = new ToolFilter();
+    registerAll(server, api, filter);
+    const unique = new Set(toolNames);
+    expect(unique.size).toBe(toolNames.length);
+  });
+});

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test", "src/stdio.ts"]
+}

--- a/ts/vitest.config.ts
+++ b/ts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/ts/wrangler.toml
+++ b/ts/wrangler.toml
@@ -1,0 +1,4 @@
+name = "mcp-server-check"
+main = "src/index.ts"
+compatibility_date = "2025-03-13"
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## Summary

- Adds a complete TypeScript port of the MCP server in ts/ alongside the existing Python code
- Targets Cloudflare Workers with native fetch and @modelcontextprotocol/sdk McpServer
- All 263 tools across 17 toolsets ported with matching names, parameters, and behavior
- Per-request server construction via McpAgent -- filtered tools simply are not registered
- Same error contract as Python: never throws, always returns {error, status_code, detail}
- ToolFilter class with identical precedence: excludeTools > readOnly > tools > toolsets
- Includes Cloudflare Worker entrypoint (streamable HTTP) + stdio entrypoint for local dev
- 75 tests passing (helpers, tool-filter, and full 263-tool registration smoke test)
- TypeScript compiles with zero errors

## Test plan

- [x] npm run typecheck -- no TypeScript errors
- [x] npm test -- 75 tests pass (helpers, tool-filter, smoke)
- [x] Smoke test verifies all 263 tools register with no filter
- [ ] npx wrangler dev -- server starts, hit /mcp endpoint
- [ ] Test with MCP Inspector against local dev server
- [ ] npx tsx src/stdio.ts -- stdio mode works for Claude Desktop

Generated with [Claude Code](https://claude.com/claude-code)