### PR TITLE
Reduce tool count and improve architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ An [MCP](https://modelcontextprotocol.io/) server that wraps the [Check Payroll 
 ## Quickstart
 
 ```bash
-# Install and run with uvx (no clone needed)
-CHECK_API_KEY=your-key uvx mcp-server-check
-```
-
-Or install from source:
-
-```bash
 git clone https://github.com/check-technologies/mcp-server-check.git
 cd mcp-server-check
 uv sync
@@ -63,7 +56,7 @@ There are 17 toolsets, one per API module: `bank_accounts`, `companies`, `compen
 Enable only specific toolsets:
 
 ```bash
-CHECK_TOOLSETS=companies,employees CHECK_API_KEY=your-key uvx mcp-server-check
+CHECK_TOOLSETS=companies,employees CHECK_API_KEY=your-key uv run mcp-server-check
 ```
 
 #### Individual Tools
@@ -71,7 +64,7 @@ CHECK_TOOLSETS=companies,employees CHECK_API_KEY=your-key uvx mcp-server-check
 Allow only specific tools by name:
 
 ```bash
-CHECK_TOOLS=list_companies,get_company,list_employees CHECK_API_KEY=your-key uvx mcp-server-check
+CHECK_TOOLS=list_companies,get_company,list_employees CHECK_API_KEY=your-key uv run mcp-server-check
 ```
 
 #### Excluding Tools
@@ -79,7 +72,7 @@ CHECK_TOOLS=list_companies,get_company,list_employees CHECK_API_KEY=your-key uvx
 Hide specific tools while keeping everything else:
 
 ```bash
-CHECK_EXCLUDE_TOOLS=create_company,delete_company CHECK_API_KEY=your-key uvx mcp-server-check
+CHECK_EXCLUDE_TOOLS=create_company,delete_company CHECK_API_KEY=your-key uv run mcp-server-check
 ```
 
 #### Read-Only Mode
@@ -87,7 +80,7 @@ CHECK_EXCLUDE_TOOLS=create_company,delete_company CHECK_API_KEY=your-key uvx mcp
 Set `CHECK_READ_ONLY=1` to run the server with only read-only tools (list, get, download, preview, etc.). All create, update, delete, and other mutating tools are excluded. This is useful when you want to allow exploration of your Check data without risk of modifications.
 
 ```bash
-CHECK_READ_ONLY=1 CHECK_API_KEY=your-key uvx mcp-server-check
+CHECK_READ_ONLY=1 CHECK_API_KEY=your-key uv run mcp-server-check
 ```
 
 #### HTTP Headers (Remote Transport)
@@ -115,7 +108,7 @@ The LLM workflow becomes: browse toolsets or search for relevant tools → revie
 Set `CHECK_TOOL_MODE=all` to expose all tools individually (legacy mode):
 
 ```bash
-CHECK_TOOL_MODE=all CHECK_API_KEY=your-key uvx mcp-server-check
+CHECK_TOOL_MODE=all CHECK_API_KEY=your-key uv run mcp-server-check
 ```
 
 ## Usage with Claude Desktop
@@ -126,8 +119,8 @@ Add to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "check": {
-      "command": "uvx",
-      "args": ["mcp-server-check"],
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/mcp-server-check", "mcp-server-check"],
       "env": {
         "CHECK_API_KEY": "your-api-key"
       }
@@ -139,7 +132,7 @@ Add to your `claude_desktop_config.json`:
 ## Usage with Claude Code
 
 ```bash
-claude mcp add check -- uvx mcp-server-check
+claude mcp add check -- uv run --directory /path/to/mcp-server-check mcp-server-check
 ```
 
 Then set the `CHECK_API_KEY` environment variable in your shell before running Claude Code.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ CHECK_API_KEY=your-key uv run mcp-server-check
 |---|---|---|---|
 | `CHECK_API_KEY` | Yes | — | Your Check API key (Bearer token) |
 | `CHECK_API_BASE_URL` | No | `https://sandbox.checkhq.com` | API base URL |
+| `CHECK_TOOL_MODE` | No | `dynamic` | Tool mode: `dynamic` (3 meta-tools) or `all` (all tools individually) |
 | `CHECK_TOOLSETS` | No | — | Comma-separated list of toolsets to enable (e.g. `companies,employees`) |
 | `CHECK_TOOLS` | No | — | Comma-separated allowlist of individual tool names |
 | `CHECK_EXCLUDE_TOOLS` | No | — | Comma-separated list of tool names to hide |
@@ -100,6 +101,22 @@ X-MCP-Exclude-Tools: create_company,delete_company
 ```
 
 Header-based configuration takes precedence over environment variables when headers provide any filter settings.
+
+### Dynamic Tool Mode (Default)
+
+By default, the server runs in dynamic mode (`CHECK_TOOL_MODE=dynamic`), exposing 3 meta-tools instead of all individual tools. This avoids sending every tool schema to the LLM upfront, saving significant context window space.
+
+- **`search_tools(query, toolset?, limit?)`** — Search for tools by keyword with synonym matching. Returns matching tools with their full parameter schemas.
+- **`list_toolsets()`** — List all available toolsets with descriptions and example tools.
+- **`run_tool(tool_name, arguments?)`** — Execute a tool by name with a dict of arguments.
+
+The LLM workflow becomes: browse toolsets or search for relevant tools → review their parameter schemas → call `run_tool` with the correct arguments. All filtering (`CHECK_TOOLSETS`, `CHECK_READ_ONLY`, etc.) is applied at both the search and execution layers.
+
+Set `CHECK_TOOL_MODE=all` to expose all tools individually (legacy mode):
+
+```bash
+CHECK_TOOL_MODE=all CHECK_API_KEY=your-key uvx mcp-server-check
+```
 
 ## Usage with Claude Desktop
 
@@ -497,5 +514,5 @@ Generate embeddable UI component URLs via `POST /{entity_type}/{entity_id}/compo
 git clone https://github.com/check-technologies/mcp-server-check.git
 cd mcp-server-check
 uv sync --group dev
-uv run pytest  # 173 tests
+uv run pytest  # 311 tests
 ```

--- a/src/mcp_server_check/cli/codegen.py
+++ b/src/mcp_server_check/cli/codegen.py
@@ -14,7 +14,7 @@ import click
 import httpx
 
 from mcp_server_check.helpers import CheckContext
-from mcp_server_check.tools import _TOOLSETS
+from mcp_server_check.tools import collect_all_tools
 
 from .context import CLIContext
 from .output import output_result
@@ -322,22 +322,5 @@ def build_command(
 # ---------------------------------------------------------------------------
 
 
-def _collect_module_tools(module: Any) -> list[Callable]:
-    """Call *module*.register() with a collector to capture tool functions."""
-    functions: list[Callable] = []
-
-    class _Collector:
-        @staticmethod
-        def add_tool(fn: Callable, **kwargs: Any) -> None:
-            functions.append(fn)
-
-    module.register(_Collector(), read_only=False)
-    return functions
-
-
-def collect_tools() -> dict[str, list[Callable]]:
-    """Return ``{toolset_name: [func, ...]}`` for every registered toolset."""
-    return {
-        name: _collect_module_tools(module)
-        for name, module in _TOOLSETS.items()
-    }
+# Re-export for backwards compatibility and CLI usage
+collect_tools = collect_all_tools

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -129,19 +129,30 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
     async def run_tool(
         ctx: Context,
         tool_name: str,
-        arguments: dict | None = None,
+        arguments: str | dict | None = None,
     ) -> str:
         """Execute an API tool by name with the given arguments.
 
         Use search_tools first to find the tool name and its parameter schema.
 
         tool_name: The exact tool name (e.g. "list_companies", "get_employee").
-        arguments: Tool arguments as a dict (e.g. {"company_id": "com_xxx"}).
+        arguments: Tool arguments as a JSON string or dict (e.g. '{"company_id": "com_xxx"}'
+            or {"company_id": "com_xxx"}).
         """
         tf = server._get_active_filter()
-        parsed_args = arguments or {}
-        if not isinstance(parsed_args, dict):
-            return json.dumps({"error": "Arguments must be a JSON object"})
+        parsed_args: dict = {}
+        if arguments is not None:
+            if isinstance(arguments, str):
+                try:
+                    parsed_args = json.loads(arguments)
+                except json.JSONDecodeError as e:
+                    return json.dumps({"error": f"Invalid JSON arguments: {e}"})
+                if not isinstance(parsed_args, dict):
+                    return json.dumps({"error": "Arguments must be a JSON object"})
+            elif isinstance(arguments, dict):
+                parsed_args = arguments
+            else:
+                return json.dumps({"error": "Arguments must be a JSON string or object"})
 
         try:
             result = await index.run(

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from collections.abc import AsyncIterator, Sequence
@@ -9,12 +10,13 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import Tool as MCPTool
 
 from mcp_server_check.helpers import CheckContext
 from mcp_server_check.tool_filter import ToolFilter
+from mcp_server_check.tool_index import ToolIndex
 from mcp_server_check.tools import register_all
 
 DEFAULT_BASE_URL = "https://sandbox.checkhq.com"
@@ -39,6 +41,7 @@ class CheckMCP(FastMCP):
         super().__init__(*args, **kwargs)
         self._registry: dict[str, str] = {}
         self._static_filter: ToolFilter = ToolFilter.from_env()
+        self._tool_index: ToolIndex | None = None
 
     def _get_active_filter(self) -> ToolFilter:
         """Return the filter for the current request.
@@ -60,6 +63,9 @@ class CheckMCP(FastMCP):
     async def list_tools(self) -> list[MCPTool]:
         """List tools, filtered by the active configuration."""
         all_tools = await super().list_tools()
+        if self._tool_index is not None:
+            # Dynamic mode: the 3 meta-tools are always visible
+            return all_tools
         tf = self._get_active_filter()
         return [
             t
@@ -67,25 +73,213 @@ class CheckMCP(FastMCP):
             if tf.is_tool_allowed(t.name, self._registry.get(t.name, ""))
         ]
 
-    async def call_tool(
-        self, name: str, arguments: dict[str, Any]
-    ) -> Sequence[Any]:
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Sequence[Any]:
         """Call a tool, blocking if it's filtered out."""
+        if self._tool_index is not None:
+            # Dynamic mode: meta-tools handle their own filtering
+            return await super().call_tool(name, arguments)
         tf = self._get_active_filter()
         toolset = self._registry.get(name, "")
         if not tf.is_tool_allowed(name, toolset):
-            raise ToolError(f"Tool '{name}' is not available in the current configuration")
+            raise ToolError(
+                f"Tool '{name}' is not available in the current configuration"
+            )
         return await super().call_tool(name, arguments)
 
 
-mcp = CheckMCP("Check Payroll API", lifespan=lifespan)
-register_all(mcp, registry=mcp._registry)
+def _setup_dynamic_mode(server: CheckMCP) -> None:
+    """Configure the server with 3 meta-tools instead of individual tools."""
+    index = ToolIndex()
+    index.build()
+    server._tool_index = index
+
+    @server.tool()
+    def search_tools(
+        query: str = "",
+        toolset: str | None = None,
+        limit: int = 20,
+    ) -> str:
+        """Search for available API tools by keyword.
+
+        Returns matching tools with their full parameter schemas, ready for use
+        with run_tool. Call with an empty query to see all available toolsets.
+        Supports synonym matching (e.g. "pay employees" finds payroll tools).
+
+        query: Search keywords (e.g. "list companies", "create employee", "payroll").
+        toolset: Optional toolset name to restrict search (e.g. "companies", "employees").
+        limit: Maximum number of results (default 20).
+        """
+        tf = server._get_active_filter()
+        results = index.search(query, tool_filter=tf, toolset=toolset, limit=limit)
+        return json.dumps(results, indent=2)
+
+    @server.tool()
+    def list_toolsets() -> str:
+        """List all available API toolsets with descriptions.
+
+        Returns a summary of each toolset including its name, description,
+        tool count, and example tools. Use this to understand what's available
+        before searching for specific tools.
+        """
+        tf = server._get_active_filter()
+        results = index.search("", tool_filter=tf)
+        return json.dumps(results, indent=2)
+
+    @server.tool()
+    async def run_tool(
+        ctx: Context,
+        tool_name: str,
+        arguments: dict | None = None,
+    ) -> str:
+        """Execute an API tool by name with the given arguments.
+
+        Use search_tools first to find the tool name and its parameter schema.
+
+        tool_name: The exact tool name (e.g. "list_companies", "get_employee").
+        arguments: Tool arguments as a dict (e.g. {"company_id": "com_xxx"}).
+        """
+        tf = server._get_active_filter()
+        parsed_args = arguments or {}
+        if not isinstance(parsed_args, dict):
+            return json.dumps({"error": "Arguments must be a JSON object"})
+
+        try:
+            result = await index.run(
+                name=tool_name,
+                arguments=parsed_args,
+                context=ctx,
+                tool_filter=tf,
+            )
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+
+        return json.dumps(result) if isinstance(result, dict) else str(result)
+
+
+def _register_resources(server: CheckMCP) -> None:
+    """Register MCP resources for enum values and reference data."""
+    from mcp_server_check.tool_index import _TOOLSET_DESCRIPTIONS
+    from mcp_server_check.tools.companies import COMPANY_REPORT_TYPES
+    from mcp_server_check.tools.components import (
+        COMPANY_COMPONENTS,
+        CONTRACTOR_COMPONENTS,
+        EMPLOYEE_COMPONENTS,
+    )
+
+    # --- Enum resources ---
+
+    _ENUMS: dict[str, dict] = {
+        "business_type": {
+            "description": "Valid values for the business_type field on companies.",
+            "values": [
+                "sole_proprietorship",
+                "partnership",
+                "c_corporation",
+                "s_corporation",
+                "llc",
+            ],
+        },
+        "pay_frequency": {
+            "description": "Valid values for pay_frequency on companies and payrolls.",
+            "values": [
+                "weekly",
+                "biweekly",
+                "semimonthly",
+                "monthly",
+                "quarterly",
+                "annually",
+            ],
+        },
+        "processing_period": {
+            "description": "Valid values for processing_period on companies and payrolls.",
+            "values": ["four_day", "three_day", "two_day", "one_day"],
+        },
+        "payment_method_preference": {
+            "description": "Valid values for payment_method_preference on employees.",
+            "values": ["direct_deposit", "manual"],
+        },
+        "payroll_type": {
+            "description": "Valid values for the type field on payrolls.",
+            "values": ["regular", "off_cycle", "amendment"],
+        },
+        "funding_payment_method": {
+            "description": "Valid values for funding_payment_method on payrolls.",
+            "values": ["ach", "wire"],
+        },
+        "bank_account_subtype": {
+            "description": "Valid values for bank account subtype.",
+            "values": ["checking", "savings"],
+        },
+        "report_type": {
+            "description": "Valid report_type values for get_company_report.",
+            "values": COMPANY_REPORT_TYPES,
+        },
+        "company_component_type": {
+            "description": "Valid component_type values for company components.",
+            "values": COMPANY_COMPONENTS,
+        },
+        "employee_component_type": {
+            "description": "Valid component_type values for employee components.",
+            "values": EMPLOYEE_COMPONENTS,
+        },
+        "contractor_component_type": {
+            "description": "Valid component_type values for contractor components.",
+            "values": CONTRACTOR_COMPONENTS,
+        },
+    }
+
+    @server.resource("check://enums")
+    def list_enums() -> str:
+        """List all available enum types."""
+        return json.dumps(
+            {name: data["description"] for name, data in sorted(_ENUMS.items())},
+            indent=2,
+        )
+
+    def _make_enum_handler(data: dict):
+        def handler() -> str:
+            return json.dumps(data, indent=2)
+
+        return handler
+
+    for enum_name, enum_data in _ENUMS.items():
+        handler = _make_enum_handler(enum_data)
+        handler.__name__ = f"enum_{enum_name}"
+        handler.__qualname__ = f"enum_{enum_name}"
+        server.resource(f"check://enums/{enum_name}", name=f"enum_{enum_name}")(handler)
+
+    # --- Toolset reference ---
+
+    @server.resource("check://toolsets")
+    def list_toolset_descriptions() -> str:
+        """Human-readable descriptions of all toolsets."""
+        return json.dumps(_TOOLSET_DESCRIPTIONS, indent=2)
+
+
+def _create_server() -> CheckMCP:
+    """Create and configure the MCP server based on CHECK_TOOL_MODE."""
+    server = CheckMCP("Check Payroll API", lifespan=lifespan)
+    tool_mode = os.environ.get("CHECK_TOOL_MODE", "dynamic").lower()
+    if tool_mode == "all":
+        register_all(server, registry=server._registry)
+    else:
+        _setup_dynamic_mode(server)
+    _register_resources(server)
+    return server
+
+
+mcp = _create_server()
 
 
 def main():
     if not os.environ.get("CHECK_API_KEY"):
         print("Error: CHECK_API_KEY environment variable is required", file=sys.stderr)
         sys.exit(1)
+    tool_mode = os.environ.get("CHECK_TOOL_MODE", "dynamic").lower()
+    if tool_mode != "all":
+        print("Running in dynamic tool mode (3 meta-tools)", file=sys.stderr)
+    else:
+        print("Running in all-tools mode (legacy)", file=sys.stderr)
     if mcp._static_filter.read_only:
         print("Running in read-only mode (CHECK_READ_ONLY is set)", file=sys.stderr)
     if mcp._static_filter.toolsets:

--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -30,6 +30,7 @@ TOOLSETS: frozenset[str] = frozenset(
         "platform",
         "tax",
         "webhooks",
+        "workflows",
         "workplaces",
     }
 )
@@ -104,7 +105,9 @@ class ToolFilter:
         if self.toolsets is not None:
             invalid = self.toolsets - TOOLSETS
             if invalid:
-                logger.warning("Ignoring unknown toolset(s): %s", ", ".join(sorted(invalid)))
+                logger.warning(
+                    "Ignoring unknown toolset(s): %s", ", ".join(sorted(invalid))
+                )
                 object.__setattr__(self, "toolsets", self.toolsets & TOOLSETS)
 
     def is_tool_allowed(self, tool_name: str, toolset_name: str) -> bool:
@@ -133,7 +136,8 @@ class ToolFilter:
         return cls(
             toolsets=_parse_comma_set(os.environ.get("CHECK_TOOLSETS")),
             tools=_parse_comma_set(os.environ.get("CHECK_TOOLS")),
-            exclude_tools=_parse_comma_set(os.environ.get("CHECK_EXCLUDE_TOOLS")) or frozenset(),
+            exclude_tools=_parse_comma_set(os.environ.get("CHECK_EXCLUDE_TOOLS"))
+            or frozenset(),
             read_only=_parse_bool(os.environ.get("CHECK_READ_ONLY")),
         )
 

--- a/src/mcp_server_check/tool_index.py
+++ b/src/mcp_server_check/tool_index.py
@@ -1,0 +1,307 @@
+"""Tool metadata index for dynamic 2-tool MCP mode.
+
+Builds a searchable index of all tool functions, enabling LLMs to discover
+and execute tools on-demand via search_tools + run_tool instead of receiving
+all tool schemas upfront.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from mcp.server.fastmcp.tools.base import Tool
+
+from mcp_server_check.tool_filter import ToolFilter, is_write_tool
+from mcp_server_check.tools import collect_all_tools
+
+# Synonym groups: searching for any word in a group also matches others.
+_SYNONYMS: dict[str, set[str]] = {}
+_SYNONYM_GROUPS: list[set[str]] = [
+    {"pay", "payroll", "compensation", "earnings", "wages", "salary"},
+    {"employee", "worker", "staff", "team"},
+    {"company", "employer", "business", "organization"},
+    {"contractor", "vendor", "1099"},
+    {"create", "add", "new", "setup", "set"},
+    {"delete", "remove", "destroy"},
+    {"update", "edit", "modify", "change", "patch"},
+    {"list", "index", "all", "browse"},
+    {"get", "show", "view", "read", "fetch", "retrieve", "detail", "details"},
+    {"payment", "disbursement", "deposit", "transfer"},
+    {"tax", "withholding", "filing", "w2", "w4"},
+    {"bank", "account", "ach", "routing"},
+    {"report", "summary", "journal", "export"},
+    {"webhook", "callback", "event", "notification"},
+    {"approve", "submit", "confirm"},
+    {"simulate", "sandbox", "test"},
+]
+
+# Build the synonym lookup
+for group in _SYNONYM_GROUPS:
+    for word in group:
+        _SYNONYMS[word] = group
+
+
+def _expand_synonyms(tokens: set[str]) -> set[str]:
+    """Expand a set of tokens with synonyms."""
+    expanded = set(tokens)
+    for token in tokens:
+        if token in _SYNONYMS:
+            expanded |= _SYNONYMS[token]
+    return expanded
+
+
+@dataclass
+class ToolEntry:
+    """Metadata for a single tool in the index."""
+
+    name: str
+    description: str
+    toolset: str
+    is_write: bool
+    parameters: dict[str, Any]
+    tool: Tool
+    search_tokens: set[str] = field(default_factory=set)
+
+
+def _tokenize(text: str) -> set[str]:
+    """Split text into lowercase tokens for search matching."""
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+def _first_line(docstring: str | None) -> str:
+    """Extract the first non-empty line from a docstring."""
+    if not docstring:
+        return ""
+    for line in docstring.strip().split("\n"):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+# Toolset descriptions for the overview
+_TOOLSET_DESCRIPTIONS: dict[str, str] = {
+    "bank_accounts": "Create, update, delete, and view bank accounts for companies, employees, and contractors.",
+    "companies": "Manage companies, signatories, enrollment profiles, reports, and EIN verifications.",
+    "compensation": "Manage earning rates, earning codes, benefits, post-tax deductions, net pay splits, and pay schedules.",
+    "components": "Generate embedded UI component URLs for company, employee, and contractor onboarding flows.",
+    "contractor_payments": "Create, update, delete, and view contractor payment records.",
+    "contractors": "Manage 1099 contractors, their forms, and tax documents.",
+    "documents": "Access company tax documents, authorization documents, employee/contractor tax documents, and setup documents.",
+    "employees": "Manage W-2 employees, their forms, paystubs, attributes, and reciprocity elections.",
+    "external_payrolls": "Create and manage external (imported) payrolls for historical data.",
+    "forms": "List and render tax forms (W-4, state withholding, etc.).",
+    "payments": "View payments, payment attempts, and retry/refund/cancel payments.",
+    "payroll_items": "Create, update, and delete individual payroll line items within a payroll.",
+    "payrolls": "Create, preview, approve, and manage payroll runs. Includes sandbox simulation tools.",
+    "platform": "Platform-level tools: notifications, communications, usage, integrations, accounting, setups, and requirements.",
+    "tax": "Manage company and employee tax parameters, elections, filings, exemptions, and tax statements.",
+    "webhooks": "Create, update, delete, and test webhook configurations.",
+    "workflows": "Composite tools that combine multiple API calls: company overview, employee snapshot, payment diagnostics.",
+    "workplaces": "Create, update, and view company workplace locations.",
+}
+
+
+class ToolIndex:
+    """Searchable index of all tool functions."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, ToolEntry] = {}
+        self._toolset_entries: dict[str, list[ToolEntry]] = {}
+
+    def build(self) -> None:
+        """Build the index from all registered toolsets."""
+        all_tools = collect_all_tools()
+        for toolset_name, functions in all_tools.items():
+            toolset_list: list[ToolEntry] = []
+            for fn in functions:
+                tool = Tool.from_function(fn)
+                description = _first_line(fn.__doc__)
+                # Include parameter names in search tokens for richer matching
+                param_names = set()
+                props = tool.parameters.get("properties", {})
+                for pname in props:
+                    param_names |= _tokenize(pname)
+                tokens = (
+                    _tokenize(tool.name)
+                    | _tokenize(toolset_name)
+                    | _tokenize(description)
+                    | param_names
+                )
+                entry = ToolEntry(
+                    name=tool.name,
+                    description=description,
+                    toolset=toolset_name,
+                    is_write=is_write_tool(tool.name),
+                    parameters=tool.parameters,
+                    tool=tool,
+                    search_tokens=tokens,
+                )
+                self._entries[tool.name] = entry
+                toolset_list.append(entry)
+            self._toolset_entries[toolset_name] = toolset_list
+
+    def search(
+        self,
+        query: str,
+        tool_filter: ToolFilter,
+        toolset: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Search tools by keyword query.
+
+        Args:
+            query: Search keywords (e.g. "list companies"). Empty returns overview.
+            tool_filter: Active ToolFilter for visibility checks.
+            toolset: Optional toolset name to restrict search.
+            limit: Maximum results to return.
+
+        Returns:
+            List of tool metadata dicts with name, description, toolset, parameters.
+        """
+        if not query.strip():
+            return self._toolset_overview(tool_filter, toolset)
+
+        query_tokens = _tokenize(query)
+        if not query_tokens:
+            return self._toolset_overview(tool_filter, toolset)
+
+        # Expand query tokens with synonyms for broader matching
+        expanded_query = _expand_synonyms(query_tokens)
+
+        scored: list[tuple[float, ToolEntry]] = []
+        query_lower = query.lower().replace(" ", "_")
+
+        for entry in self._entries.values():
+            if not tool_filter.is_tool_allowed(entry.name, entry.toolset):
+                continue
+            if toolset and entry.toolset != toolset:
+                continue
+
+            # Direct token overlap (original query, no expansion)
+            direct_overlap = len(query_tokens & entry.search_tokens)
+            # Expanded token overlap (with synonyms)
+            expanded_overlap = len(expanded_query & entry.search_tokens)
+
+            if direct_overlap == 0 and expanded_overlap == 0:
+                continue
+
+            # Direct matches score higher than synonym matches
+            score = direct_overlap / len(query_tokens)
+            if expanded_overlap > direct_overlap:
+                score += (expanded_overlap - direct_overlap) / len(query_tokens) * 0.5
+
+            # Boost exact name match
+            if entry.name == query_lower:
+                score += 10.0
+            # Boost substring match in name
+            elif query_lower in entry.name:
+                score += 3.0
+            # Boost if name contains query as substring
+            elif entry.name in query_lower:
+                score += 1.0
+
+            scored.append((score, entry))
+
+        scored.sort(key=lambda x: (-x[0], x[1].name))
+        return [
+            {
+                "name": entry.name,
+                "description": entry.description,
+                "toolset": entry.toolset,
+                "parameters": entry.parameters,
+            }
+            for _, entry in scored[:limit]
+        ]
+
+    def _toolset_overview(
+        self, tool_filter: ToolFilter, toolset: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Return a summary of available toolsets when no query is given."""
+        result: list[dict[str, Any]] = []
+        for ts_name, entries in sorted(self._toolset_entries.items()):
+            if toolset and ts_name != toolset:
+                continue
+            allowed = [
+                e for e in entries if tool_filter.is_tool_allowed(e.name, e.toolset)
+            ]
+            if not allowed:
+                continue
+            example_names = [e.name for e in allowed[:3]]
+            result.append(
+                {
+                    "toolset": ts_name,
+                    "description": _TOOLSET_DESCRIPTIONS.get(ts_name, ""),
+                    "tool_count": len(allowed),
+                    "example_tools": example_names,
+                }
+            )
+        return result
+
+    def get_toolset_names(self) -> list[str]:
+        """Return sorted list of all toolset names."""
+        return sorted(self._toolset_entries.keys())
+
+    async def run(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Any,
+        tool_filter: ToolFilter,
+    ) -> Any:
+        """Look up and execute a tool by name.
+
+        Args:
+            name: Tool name to execute.
+            arguments: Tool arguments dict.
+            context: MCP Context object to inject.
+            tool_filter: Active ToolFilter for authorization.
+
+        Returns:
+            Tool execution result.
+
+        Raises:
+            ValueError: If tool not found or not allowed.
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            suggestion = self._suggest_tool(name)
+            msg = f"Unknown tool: '{name}'"
+            if suggestion:
+                msg += f". Did you mean '{suggestion}'?"
+            raise ValueError(msg)
+        if not tool_filter.is_tool_allowed(entry.name, entry.toolset):
+            raise ValueError(
+                f"Tool '{name}' is not available in the current configuration"
+            )
+        return await entry.tool.run(arguments, context=context)
+
+    def _suggest_tool(self, name: str) -> str | None:
+        """Find the closest matching tool name for error messages."""
+        tokens = _tokenize(name)
+        if not tokens:
+            return None
+        best_name = None
+        best_score = 0
+        for entry in self._entries.values():
+            overlap = len(tokens & _tokenize(entry.name))
+            if overlap > best_score:
+                best_score = overlap
+                best_name = entry.name
+        return best_name if best_score > 0 else None
+
+    def get_entry(self, name: str) -> ToolEntry | None:
+        """Get a tool entry by name."""
+        return self._entries.get(name)
+
+    @property
+    def entries(self) -> dict[str, ToolEntry]:
+        """All indexed tool entries."""
+        return self._entries
+
+    @property
+    def toolset_entries(self) -> dict[str, list[ToolEntry]]:
+        """Tool entries grouped by toolset."""
+        return self._toolset_entries

--- a/src/mcp_server_check/tools/__init__.py
+++ b/src/mcp_server_check/tools/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 from mcp.server.fastmcp import FastMCP
 
 from . import (
@@ -21,6 +24,7 @@ from . import (
     platform,
     tax,
     webhooks,
+    workflows,
     workplaces,
 )
 
@@ -41,8 +45,28 @@ _TOOLSETS = {
     "platform": platform,
     "tax": tax,
     "webhooks": webhooks,
+    "workflows": workflows,
     "workplaces": workplaces,
 }
+
+
+def collect_all_tools() -> dict[str, list[Callable]]:
+    """Return {toolset_name: [fn, ...]} for all toolsets.
+
+    Calls each module's register() with a collector to capture tool functions.
+    """
+    result: dict[str, list[Callable]] = {}
+    for name, module in _TOOLSETS.items():
+        functions: list[Callable] = []
+
+        class _Collector:
+            @staticmethod
+            def add_tool(fn: Callable, **kwargs: Any) -> None:
+                functions.append(fn)
+
+        module.register(_Collector(), read_only=False)
+        result[name] = functions
+    return result
 
 
 def register_all(mcp: FastMCP, registry: dict[str, str]) -> None:

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -269,119 +269,57 @@ async def get_company_benefit_aggregations(
 
 # --- Reports ---
 
+COMPANY_REPORT_TYPES = [
+    "payroll_journal",
+    "payroll_summary",
+    "tax_liabilities",
+    "contractor_payments",
+    "child_support_payments",
+    "w4_exemption_status",
+    "applied_for_ids_detailed",
+    "w2_preview",
+]
 
-async def get_payroll_journal_report(
-    ctx: Ctx, company_id: str, start_date: str, end_date: str
+
+async def get_company_report(
+    ctx: Ctx,
+    company_id: str,
+    report_type: str,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    year: str | None = None,
 ) -> dict:
-    """Get a payroll journal report for a company.
+    """Get a report for a company.
 
     Args:
         company_id: The Check company ID.
-        start_date: Report start date (YYYY-MM-DD).
-        end_date: Report end date (YYYY-MM-DD).
+        report_type: One of: "payroll_journal", "payroll_summary", "tax_liabilities",
+            "contractor_payments", "child_support_payments", "w4_exemption_status",
+            "applied_for_ids_detailed", "w2_preview".
+        start_date: Report start date (YYYY-MM-DD). Required for payroll_journal,
+            payroll_summary, tax_liabilities, contractor_payments, child_support_payments.
+        end_date: Report end date (YYYY-MM-DD). Required for the same reports as start_date.
+        year: Tax year (e.g. "2025"). Required for w2_preview.
     """
-    params = {"start_date": start_date, "end_date": end_date}
+    if report_type not in COMPANY_REPORT_TYPES:
+        return {
+            "error": True,
+            "detail": (
+                f"Unknown report_type: '{report_type}'. "
+                f"Valid types: {', '.join(COMPANY_REPORT_TYPES)}."
+            ),
+        }
+    params: dict = {}
+    if start_date is not None:
+        params["start_date"] = start_date
+    if end_date is not None:
+        params["end_date"] = end_date
+    if year is not None:
+        params["year"] = year
     return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/payroll_journal", params=params
-    )
-
-
-async def get_payroll_summary_report(
-    ctx: Ctx, company_id: str, start_date: str, end_date: str
-) -> dict:
-    """Get a payroll summary report for a company.
-
-    Args:
-        company_id: The Check company ID.
-        start_date: Report start date (YYYY-MM-DD).
-        end_date: Report end date (YYYY-MM-DD).
-    """
-    params = {"start_date": start_date, "end_date": end_date}
-    return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/payroll_summary", params=params
-    )
-
-
-async def get_tax_liabilities_report(
-    ctx: Ctx, company_id: str, start_date: str, end_date: str
-) -> dict:
-    """Get a tax liabilities report for a company.
-
-    Args:
-        company_id: The Check company ID.
-        start_date: Report start date (YYYY-MM-DD).
-        end_date: Report end date (YYYY-MM-DD).
-    """
-    params = {"start_date": start_date, "end_date": end_date}
-    return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/tax_liabilities", params=params
-    )
-
-
-async def get_contractor_payments_report(
-    ctx: Ctx, company_id: str, start_date: str, end_date: str
-) -> dict:
-    """Get a contractor payments report for a company.
-
-    Args:
-        company_id: The Check company ID.
-        start_date: Report start date (YYYY-MM-DD).
-        end_date: Report end date (YYYY-MM-DD).
-    """
-    params = {"start_date": start_date, "end_date": end_date}
-    return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/contractor_payments", params=params
-    )
-
-
-async def get_child_support_payments_report(
-    ctx: Ctx, company_id: str, start_date: str, end_date: str
-) -> dict:
-    """Get a child support payments report for a company.
-
-    Args:
-        company_id: The Check company ID.
-        start_date: Report start date (YYYY-MM-DD).
-        end_date: Report end date (YYYY-MM-DD).
-    """
-    params = {"start_date": start_date, "end_date": end_date}
-    return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/child_support_payments", params=params
-    )
-
-
-async def get_w4_exemption_status_report(ctx: Ctx, company_id: str) -> dict:
-    """Get a W-4 exemption status report for a company.
-
-    Args:
-        company_id: The Check company ID.
-    """
-    return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/w4_exemption_status"
-    )
-
-
-async def get_applied_for_ids_detailed_report(ctx: Ctx, company_id: str) -> dict:
-    """Get a detailed applied-for IDs report for a company.
-
-    Args:
-        company_id: The Check company ID.
-    """
-    return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/applied_for_ids_detailed"
-    )
-
-
-async def get_w2_preview_report(ctx: Ctx, company_id: str, year: str) -> dict:
-    """Get a W-2 preview report for a company.
-
-    Args:
-        company_id: The Check company ID.
-        year: Tax year (e.g. "2025").
-    """
-    params = {"year": year}
-    return await check_api_get(
-        ctx, f"/companies/{company_id}/reports/w2_preview", params=params
+        ctx,
+        f"/companies/{company_id}/reports/{report_type}",
+        params=params or None,
     )
 
 
@@ -755,14 +693,7 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(get_company_paydays)
     mcp.add_tool(list_company_tax_deposits)
     mcp.add_tool(get_company_benefit_aggregations)
-    mcp.add_tool(get_payroll_journal_report)
-    mcp.add_tool(get_payroll_summary_report)
-    mcp.add_tool(get_tax_liabilities_report)
-    mcp.add_tool(get_contractor_payments_report)
-    mcp.add_tool(get_child_support_payments_report)
-    mcp.add_tool(get_w4_exemption_status_report)
-    mcp.add_tool(get_applied_for_ids_detailed_report)
-    mcp.add_tool(get_w2_preview_report)
+    mcp.add_tool(get_company_report)
     mcp.add_tool(list_federal_ein_verifications)
     mcp.add_tool(get_federal_ein_verification)
     mcp.add_tool(list_signatories)

--- a/src/mcp_server_check/tools/components.py
+++ b/src/mcp_server_check/tools/components.py
@@ -1,19 +1,17 @@
 """Embedded UI component tools for the Check API.
 
-Uses factory functions to generate tools for the uniform component pattern:
-POST /{entity_type}/{entity_id}/components/{component_type}
+Replaces 35 individual component tools with 2 generic tools:
+- list_component_types: discover available component types per entity
+- create_component: create any component with entity_type + component_type
 """
 
 from __future__ import annotations
-
-from typing import Callable
 
 from mcp.server.fastmcp import FastMCP
 
 from mcp_server_check.helpers import Ctx, check_api_post
 
-# Component definitions: (entity_type, entity_prefix, component_name)
-_COMPANY_COMPONENTS = [
+COMPANY_COMPONENTS = [
     "previous_provider_access",
     "accounting_integration",
     "authorization_documents",
@@ -41,7 +39,7 @@ _COMPANY_COMPONENTS = [
     "verification_documents",
 ]
 
-_EMPLOYEE_COMPONENTS = [
+EMPLOYEE_COMPONENTS = [
     "benefits",
     "payment_setup",
     "paystubs",
@@ -53,64 +51,94 @@ _EMPLOYEE_COMPONENTS = [
     "withholdings_setup",
 ]
 
-_CONTRACTOR_COMPONENTS = [
+CONTRACTOR_COMPONENTS = [
     "tax_documents",
 ]
 
+_ENTITY_COMPONENTS: dict[str, list[str]] = {
+    "company": COMPANY_COMPONENTS,
+    "employee": EMPLOYEE_COMPONENTS,
+    "contractor": CONTRACTOR_COMPONENTS,
+}
 
-def _make_component_tool(
-    entity_type: str,
-    entity_label: str,
-    component_name: str,
-) -> Callable:
-    """Factory to create a component tool function."""
-    tool_name = f"create_{entity_label}_{component_name}_component"
-    entity_id_param = f"{entity_label}_id"
+_ENTITY_PATH: dict[str, str] = {
+    "company": "companies",
+    "employee": "employees",
+    "contractor": "contractors",
+}
 
-    async def component_tool(ctx: Ctx, entity_id: str, data: dict | None = None) -> dict:
-        return await check_api_post(
-            ctx,
-            f"/{entity_type}/{entity_id}/components/{component_name}",
-            data=data,
-        )
 
-    component_tool.__name__ = tool_name
-    component_tool.__qualname__ = tool_name
-    component_tool.__doc__ = (
-        f"Create a {component_name.replace('_', ' ')} component for a {entity_label}.\n\n"
-        f"Args:\n"
-        f"    entity_id: The Check {entity_label} ID.\n"
-        f"    data: Optional component configuration."
-    )
+async def list_component_types(ctx: Ctx, entity_type: str | None = None) -> dict:
+    """List available embedded UI component types.
 
-    # Fix the parameter name in annotations for better tool schema
-    component_tool.__annotations__ = {
-        "ctx": Ctx,
-        "entity_id": str,
-        "data": "dict | None",
-        "return": dict,
+    Returns the component types that can be created for each entity type.
+    Use this to discover valid component_type values for create_component.
+
+    Args:
+        entity_type: Filter to a specific entity type ("company", "employee",
+            or "contractor"). Omit to see all.
+    """
+    if entity_type is not None:
+        components = _ENTITY_COMPONENTS.get(entity_type)
+        if components is None:
+            return {
+                "error": True,
+                "detail": (
+                    f"Unknown entity_type: '{entity_type}'. "
+                    f"Must be one of: {', '.join(sorted(_ENTITY_COMPONENTS))}."
+                ),
+            }
+        return {"entity_type": entity_type, "component_types": components}
+    return {
+        entity: {"component_types": comps}
+        for entity, comps in _ENTITY_COMPONENTS.items()
     }
 
-    return component_tool
 
+async def create_component(
+    ctx: Ctx,
+    entity_type: str,
+    entity_id: str,
+    component_type: str,
+    data: dict | None = None,
+) -> dict:
+    """Create an embedded UI component URL for a company, employee, or contractor.
 
-def _build_tools() -> list[Callable]:
-    """Build all component tool functions."""
-    tools = []
-    for name in _COMPANY_COMPONENTS:
-        tools.append(_make_component_tool("companies", "company", name))
-    for name in _EMPLOYEE_COMPONENTS:
-        tools.append(_make_component_tool("employees", "employee", name))
-    for name in _CONTRACTOR_COMPONENTS:
-        tools.append(_make_component_tool("contractors", "contractor", name))
-    return tools
+    Returns a URL that can be embedded in an iframe to render the component.
 
-
-_ALL_TOOLS = _build_tools()
+    Args:
+        entity_type: One of "company", "employee", or "contractor".
+        entity_id: The Check entity ID (e.g. "com_xxxxx", "emp_xxxxx", "ctr_xxxxx").
+        component_type: The component to create. Use list_component_types to see
+            valid values (e.g. "tax_setup", "payment_setup", "run_payroll").
+        data: Optional component configuration.
+    """
+    path_prefix = _ENTITY_PATH.get(entity_type)
+    if path_prefix is None:
+        return {
+            "error": True,
+            "detail": (
+                f"Unknown entity_type: '{entity_type}'. "
+                f"Must be one of: {', '.join(sorted(_ENTITY_PATH))}."
+            ),
+        }
+    valid_types = _ENTITY_COMPONENTS.get(entity_type, [])
+    if component_type not in valid_types:
+        return {
+            "error": True,
+            "detail": (
+                f"Unknown component_type '{component_type}' for {entity_type}. "
+                f"Valid types: {', '.join(valid_types)}."
+            ),
+        }
+    return await check_api_post(
+        ctx,
+        f"/{path_prefix}/{entity_id}/components/{component_type}",
+        data=data,
+    )
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    if read_only:
-        return
-    for tool in _ALL_TOOLS:
-        mcp.add_tool(tool)
+    mcp.add_tool(list_component_types)
+    if not read_only:
+        mcp.add_tool(create_component)

--- a/src/mcp_server_check/tools/workflows.py
+++ b/src/mcp_server_check/tools/workflows.py
@@ -1,0 +1,163 @@
+"""Workflow-level composite tools for common multi-step operations.
+
+These tools compose multiple API calls server-side, saving the LLM
+3-4 round-trips per operation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server_check.helpers import Ctx, check_api_get, check_api_list
+
+
+async def get_company_overview(
+    ctx: Ctx,
+    company_id: str,
+    include_employees: bool = True,
+    include_payrolls: bool = True,
+    include_bank_accounts: bool = True,
+    employee_limit: int = 10,
+    payroll_limit: int = 5,
+) -> dict:
+    """Get a comprehensive overview of a company in a single call.
+
+    Returns the company details along with its employees, recent payrolls,
+    and bank accounts. This replaces 4 separate API calls.
+
+    Args:
+        company_id: The Check company ID (e.g. "com_xxxxx").
+        include_employees: Include the company's employees (default true).
+        include_payrolls: Include recent payrolls (default true).
+        include_bank_accounts: Include bank accounts (default true).
+        employee_limit: Max employees to return (default 10).
+        payroll_limit: Max payrolls to return (default 5).
+    """
+    # Always fetch the company
+    tasks: dict[str, asyncio.Task] = {}
+    async with asyncio.TaskGroup() as tg:
+        tasks["company"] = tg.create_task(
+            check_api_get(ctx, f"/companies/{company_id}")
+        )
+        if include_employees:
+            tasks["employees"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    "/employees",
+                    params={"company": company_id, "limit": employee_limit},
+                )
+            )
+        if include_payrolls:
+            tasks["payrolls"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    "/payrolls",
+                    params={"company": company_id, "limit": payroll_limit},
+                )
+            )
+        if include_bank_accounts:
+            tasks["bank_accounts"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    "/bank_accounts",
+                    params={"company": company_id},
+                )
+            )
+
+    result: dict = {"company": tasks["company"].result()}
+    if "employees" in tasks:
+        result["employees"] = tasks["employees"].result()
+    if "payrolls" in tasks:
+        result["payrolls"] = tasks["payrolls"].result()
+    if "bank_accounts" in tasks:
+        result["bank_accounts"] = tasks["bank_accounts"].result()
+    return result
+
+
+async def get_employee_snapshot(
+    ctx: Ctx,
+    employee_id: str,
+    include_tax_params: bool = True,
+    include_paystubs: bool = True,
+    paystub_limit: int = 5,
+) -> dict:
+    """Get a comprehensive snapshot of an employee in a single call.
+
+    Returns employee details along with their tax parameters and recent
+    paystubs. This replaces 3 separate API calls.
+
+    Args:
+        employee_id: The Check employee ID (e.g. "emp_xxxxx").
+        include_tax_params: Include employee tax parameters (default true).
+        include_paystubs: Include recent paystubs (default true).
+        paystub_limit: Max paystubs to return (default 5).
+    """
+    tasks: dict[str, asyncio.Task] = {}
+    async with asyncio.TaskGroup() as tg:
+        tasks["employee"] = tg.create_task(
+            check_api_get(ctx, f"/employees/{employee_id}")
+        )
+        if include_tax_params:
+            tasks["tax_params"] = tg.create_task(
+                check_api_get(ctx, f"/employee_tax_params/{employee_id}")
+            )
+        if include_paystubs:
+            tasks["paystubs"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    f"/employees/{employee_id}/paystubs",
+                    params={"limit": paystub_limit},
+                )
+            )
+
+    result: dict = {"employee": tasks["employee"].result()}
+    if "tax_params" in tasks:
+        result["tax_params"] = tasks["tax_params"].result()
+    if "paystubs" in tasks:
+        result["paystubs"] = tasks["paystubs"].result()
+    return result
+
+
+async def diagnose_payment(
+    ctx: Ctx,
+    payment_id: str,
+) -> dict:
+    """Get a diagnostic view of a payment with its attempts and related payroll item.
+
+    Useful for debugging failed or stuck payments. Returns the payment,
+    its payment attempts, and (if linked) the originating payroll item.
+    This replaces 3 separate API calls.
+
+    Args:
+        payment_id: The Check payment ID (e.g. "pmt_xxxxx").
+    """
+    tasks: dict[str, asyncio.Task] = {}
+    async with asyncio.TaskGroup() as tg:
+        tasks["payment"] = tg.create_task(check_api_get(ctx, f"/payments/{payment_id}"))
+        tasks["attempts"] = tg.create_task(
+            check_api_list(ctx, f"/payments/{payment_id}/payment_attempts")
+        )
+
+    payment = tasks["payment"].result()
+    result: dict = {
+        "payment": payment,
+        "payment_attempts": tasks["attempts"].result(),
+    }
+
+    # If the payment has a payroll_item, fetch it too
+    payroll_item_id = None
+    if isinstance(payment, dict) and "error" not in payment:
+        payroll_item_id = payment.get("payroll_item")
+    if payroll_item_id:
+        payroll_item = await check_api_get(ctx, f"/payroll_items/{payroll_item_id}")
+        result["payroll_item"] = payroll_item
+
+    return result
+
+
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
+    mcp.add_tool(get_company_overview)
+    mcp.add_tool(get_employee_snapshot)
+    mcp.add_tool(diagnose_payment)

--- a/tests/test_cli_codegen.py
+++ b/tests/test_cli_codegen.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import inspect
-import types
 import typing
 
 import click
-
 from mcp_server_check.cli.codegen import (
     CSVList,
     JSONParam,
@@ -20,7 +18,6 @@ from mcp_server_check.cli.codegen import (
     collect_tools,
 )
 from mcp_server_check.helpers import Ctx
-
 
 # ---------------------------------------------------------------------------
 # _singularize
@@ -73,17 +70,25 @@ class TestMakeCommandName:
         assert _make_command_name("get_company_paydays", "companies") == "get-paydays"
 
     def test_list_company_tax_deposits(self):
-        assert _make_command_name("list_company_tax_deposits", "companies") == "list-tax-deposits"
+        assert (
+            _make_command_name("list_company_tax_deposits", "companies")
+            == "list-tax-deposits"
+        )
 
     def test_list_employee_paystubs(self):
-        assert _make_command_name("list_employee_paystubs", "employees") == "list-paystubs"
+        assert (
+            _make_command_name("list_employee_paystubs", "employees") == "list-paystubs"
+        )
 
     def test_get_employee_paystub(self):
         assert _make_command_name("get_employee_paystub", "employees") == "get-paystub"
 
     def test_simulate_start_processing(self):
         """No toolset name in function → full name preserved."""
-        assert _make_command_name("simulate_start_processing", "payrolls") == "simulate-start-processing"
+        assert (
+            _make_command_name("simulate_start_processing", "payrolls")
+            == "simulate-start-processing"
+        )
 
     def test_approve_payroll(self):
         assert _make_command_name("approve_payroll", "payrolls") == "approve"
@@ -95,18 +100,29 @@ class TestMakeCommandName:
         assert _make_command_name("get_bank_account", "bank_accounts") == "get"
 
     def test_reveal_bank_account_numbers(self):
-        assert _make_command_name("reveal_bank_account_numbers", "bank_accounts") == "reveal-numbers"
+        assert (
+            _make_command_name("reveal_bank_account_numbers", "bank_accounts")
+            == "reveal-numbers"
+        )
 
     def test_list_contractor_payments(self):
-        assert _make_command_name("list_contractor_payments", "contractor_payments") == "list"
+        assert (
+            _make_command_name("list_contractor_payments", "contractor_payments")
+            == "list"
+        )
 
     def test_get_company_tax_params(self):
         """tax toolset — strips 'tax' from middle."""
-        assert _make_command_name("get_company_tax_params", "tax") == "get-company-params"
+        assert (
+            _make_command_name("get_company_tax_params", "tax") == "get-company-params"
+        )
 
     def test_no_match_full_name(self):
         """When toolset name not in function name, return full name."""
-        assert _make_command_name("get_payroll_journal_report", "companies") == "get-payroll-journal-report"
+        assert (
+            _make_command_name("get_payroll_journal_report", "companies")
+            == "get-payroll-journal-report"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -178,6 +194,7 @@ class TestIsIdParam:
 class TestBuildParams:
     def test_excludes_ctx(self):
         """The ctx parameter should never appear in click params."""
+
         async def sample(ctx: Ctx, company_id: str) -> dict:
             pass
 
@@ -307,7 +324,7 @@ class TestBuildCommand:
 class TestCollectTools:
     def test_returns_all_toolsets(self):
         tools = collect_tools()
-        assert len(tools) == 17
+        assert len(tools) == 18
         assert "companies" in tools
         assert "employees" in tools
         assert "payrolls" in tools

--- a/tests/test_companies.py
+++ b/tests/test_companies.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import httpx
 import pytest
-
 from mcp_server_check.tools.companies import (
+    COMPANY_REPORT_TYPES,
     create_company,
     get_company_paydays,
-    get_payroll_journal_report,
+    get_company_report,
     list_signatories,
     onboard_company,
     start_implementation,
@@ -21,9 +21,7 @@ BASE_URL = "https://sandbox.checkhq.com"
 @pytest.mark.anyio
 async def test_create_company(mock_api, ctx):
     mock_api.post("/companies").mock(
-        return_value=httpx.Response(
-            201, json={"id": "com_new", "legal_name": "New Co"}
-        )
+        return_value=httpx.Response(201, json={"id": "com_new", "legal_name": "New Co"})
     )
     result = await create_company(ctx, legal_name="New Co")
     assert result["id"] == "com_new"
@@ -62,14 +60,54 @@ async def test_get_company_paydays(mock_api, ctx):
 
 
 @pytest.mark.anyio
-async def test_get_payroll_journal_report(mock_api, ctx):
+async def test_get_company_report_with_dates(mock_api, ctx):
     route = mock_api.get("/companies/com_001/reports/payroll_journal").mock(
         return_value=httpx.Response(200, json={"report": "data"})
     )
-    result = await get_payroll_journal_report(
-        ctx, company_id="com_001", start_date="2026-01-01", end_date="2026-01-31"
+    result = await get_company_report(
+        ctx,
+        company_id="com_001",
+        report_type="payroll_journal",
+        start_date="2026-01-01",
+        end_date="2026-01-31",
     )
     assert result["report"] == "data"
+    assert "start_date=2026-01-01" in str(route.calls[0].request.url)
+
+
+@pytest.mark.anyio
+async def test_get_company_report_w2_preview(mock_api, ctx):
+    mock_api.get("/companies/com_001/reports/w2_preview").mock(
+        return_value=httpx.Response(200, json={"report": "w2"})
+    )
+    result = await get_company_report(
+        ctx, company_id="com_001", report_type="w2_preview", year="2025"
+    )
+    assert result["report"] == "w2"
+
+
+@pytest.mark.anyio
+async def test_get_company_report_no_params(mock_api, ctx):
+    mock_api.get("/companies/com_001/reports/w4_exemption_status").mock(
+        return_value=httpx.Response(200, json={"report": "w4"})
+    )
+    result = await get_company_report(
+        ctx, company_id="com_001", report_type="w4_exemption_status"
+    )
+    assert result["report"] == "w4"
+
+
+@pytest.mark.anyio
+async def test_get_company_report_invalid_type(mock_api, ctx):
+    result = await get_company_report(
+        ctx, company_id="com_001", report_type="nonexistent"
+    )
+    assert result["error"] is True
+    assert "Unknown report_type" in result["detail"]
+
+
+def test_report_type_count():
+    assert len(COMPANY_REPORT_TYPES) == 8
 
 
 @pytest.mark.anyio

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -4,43 +4,120 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from mcp_server_check.tools.components import (
+    COMPANY_COMPONENTS,
+    CONTRACTOR_COMPONENTS,
+    EMPLOYEE_COMPONENTS,
+    create_component,
+    list_component_types,
+)
 
-from mcp_server_check.tools.components import _ALL_TOOLS
+# --- list_component_types ---
 
 
 @pytest.mark.anyio
-async def test_company_component_tool(mock_api, ctx):
-    """Test a company component tool."""
-    tool = next(t for t in _ALL_TOOLS if t.__name__ == "create_company_run_payroll_component")
+async def test_list_all_component_types(mock_api, ctx):
+    result = await list_component_types(ctx)
+    assert "company" in result
+    assert "employee" in result
+    assert "contractor" in result
+    assert result["company"]["component_types"] == COMPANY_COMPONENTS
+    assert result["employee"]["component_types"] == EMPLOYEE_COMPONENTS
+    assert result["contractor"]["component_types"] == CONTRACTOR_COMPONENTS
+
+
+@pytest.mark.anyio
+async def test_list_component_types_filtered(mock_api, ctx):
+    result = await list_component_types(ctx, entity_type="employee")
+    assert result["entity_type"] == "employee"
+    assert result["component_types"] == EMPLOYEE_COMPONENTS
+
+
+@pytest.mark.anyio
+async def test_list_component_types_invalid_entity(mock_api, ctx):
+    result = await list_component_types(ctx, entity_type="invalid")
+    assert result["error"] is True
+    assert "Unknown entity_type" in result["detail"]
+
+
+# --- create_component ---
+
+
+@pytest.mark.anyio
+async def test_create_company_component(mock_api, ctx):
     mock_api.post("/companies/com_001/components/run_payroll").mock(
         return_value=httpx.Response(200, json={"url": "https://embed.checkhq.com/..."})
     )
-    result = await tool(ctx, entity_id="com_001")
+    result = await create_component(
+        ctx, entity_type="company", entity_id="com_001", component_type="run_payroll"
+    )
     assert "url" in result
 
 
 @pytest.mark.anyio
-async def test_employee_component_tool(mock_api, ctx):
-    """Test an employee component tool."""
-    tool = next(t for t in _ALL_TOOLS if t.__name__ == "create_employee_tax_setup_component")
+async def test_create_employee_component(mock_api, ctx):
     mock_api.post("/employees/emp_001/components/tax_setup").mock(
         return_value=httpx.Response(200, json={"url": "https://embed.checkhq.com/..."})
     )
-    result = await tool(ctx, entity_id="emp_001")
+    result = await create_component(
+        ctx, entity_type="employee", entity_id="emp_001", component_type="tax_setup"
+    )
     assert "url" in result
 
 
 @pytest.mark.anyio
-async def test_contractor_component_tool(mock_api, ctx):
-    """Test a contractor component tool."""
-    tool = next(t for t in _ALL_TOOLS if t.__name__ == "create_contractor_tax_documents_component")
+async def test_create_contractor_component(mock_api, ctx):
     mock_api.post("/contractors/ctr_001/components/tax_documents").mock(
         return_value=httpx.Response(200, json={"url": "https://embed.checkhq.com/..."})
     )
-    result = await tool(ctx, entity_id="ctr_001")
+    result = await create_component(
+        ctx,
+        entity_type="contractor",
+        entity_id="ctr_001",
+        component_type="tax_documents",
+    )
     assert "url" in result
 
 
-def test_component_tool_count():
-    """Verify we generated the expected number of component tools."""
-    assert len(_ALL_TOOLS) == 35  # 25 company + 9 employee + 1 contractor
+@pytest.mark.anyio
+async def test_create_component_with_data(mock_api, ctx):
+    mock_api.post("/companies/com_001/components/details").mock(
+        return_value=httpx.Response(200, json={"url": "https://embed.checkhq.com/..."})
+    )
+    result = await create_component(
+        ctx,
+        entity_type="company",
+        entity_id="com_001",
+        component_type="details",
+        data={"theme": "dark"},
+    )
+    assert "url" in result
+
+
+@pytest.mark.anyio
+async def test_create_component_invalid_entity_type(mock_api, ctx):
+    result = await create_component(
+        ctx, entity_type="invalid", entity_id="x", component_type="tax_setup"
+    )
+    assert result["error"] is True
+    assert "Unknown entity_type" in result["detail"]
+
+
+@pytest.mark.anyio
+async def test_create_component_invalid_component_type(mock_api, ctx):
+    result = await create_component(
+        ctx,
+        entity_type="company",
+        entity_id="com_001",
+        component_type="nonexistent",
+    )
+    assert result["error"] is True
+    assert "Unknown component_type" in result["detail"]
+    assert "nonexistent" in result["detail"]
+
+
+def test_component_type_counts():
+    """Verify expected component type counts."""
+    assert len(COMPANY_COMPONENTS) == 25
+    assert len(EMPLOYEE_COMPONENTS) == 9
+    assert len(CONTRACTOR_COMPONENTS) == 1

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,28 +4,39 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from mcp_server_check.server import CheckMCP, mcp
+from mcp_server_check.helpers import (
+    _extract_cursor,
+    _format_list_response,
+)
+from mcp_server_check.server import CheckMCP, _setup_dynamic_mode, lifespan
 from mcp_server_check.tool_filter import ToolFilter, is_write_tool
 from mcp_server_check.tools import register_all
 from mcp_server_check.tools.companies import get_company, list_companies
 from mcp_server_check.tools.employees import get_employee, list_employees
 from mcp_server_check.tools.payrolls import get_payroll, list_payrolls
 from mcp_server_check.tools.workplaces import get_workplace, list_workplaces
-from mcp_server_check.helpers import (
-    _extract_cursor,
-    _format_list_response,
-)
 
 BASE_URL = "https://sandbox.checkhq.com"
 
 
-# --- Helper to create a CheckMCP with a specific filter ---
+# --- Helper to create servers with specific configurations ---
 
-def _make_server(tool_filter: ToolFilter) -> CheckMCP:
-    """Create a CheckMCP instance with the given static filter."""
+
+def _make_all_tools_server(tool_filter: ToolFilter | None = None) -> CheckMCP:
+    """Create a CheckMCP instance in all-tools mode with the given static filter."""
     server = CheckMCP("Test")
     register_all(server, registry=server._registry)
-    server._static_filter = tool_filter
+    if tool_filter is not None:
+        server._static_filter = tool_filter
+    return server
+
+
+def _make_dynamic_server(tool_filter: ToolFilter | None = None) -> CheckMCP:
+    """Create a CheckMCP instance in dynamic mode."""
+    server = CheckMCP("Test Dynamic", lifespan=lifespan)
+    _setup_dynamic_mode(server)
+    if tool_filter is not None:
+        server._static_filter = tool_filter
     return server
 
 
@@ -247,13 +258,14 @@ async def test_api_error_returns_error_dict(mock_api, ctx):
     assert result["status_code"] == 404
 
 
-# --- Tool registration and filtering tests ---
+# --- Tool registration and filtering tests (all-tools mode) ---
 
 
 @pytest.mark.anyio
 async def test_tools_registered():
-    """All tools are registered (263+), filtering happens at list time."""
-    tools = await mcp.list_tools()
+    """All tools are registered in all-tools mode."""
+    server = _make_all_tools_server()
+    tools = await server.list_tools()
     tool_names = {t.name for t in tools}
     expected_core = {
         "list_companies",
@@ -268,31 +280,34 @@ async def test_tools_registered():
     assert expected_core.issubset(tool_names), (
         f"Missing core tools: {expected_core - tool_names}"
     )
-    assert len(tools) > 150, f"Expected 150+ tools, got {len(tools)}"
+    assert len(tools) > 100, f"Expected 100+ tools, got {len(tools)}"
 
 
 @pytest.mark.anyio
 async def test_registry_populated():
     """The registry maps every tool to its toolset."""
-    assert len(mcp._registry) > 150
-    assert mcp._registry["list_companies"] == "companies"
-    assert mcp._registry["list_employees"] == "employees"
-    assert mcp._registry["list_bank_accounts"] == "bank_accounts"
+    server = _make_all_tools_server()
+    assert len(server._registry) > 100
+    assert server._registry["list_companies"] == "companies"
+    assert server._registry["list_employees"] == "employees"
+    assert server._registry["list_bank_accounts"] == "bank_accounts"
 
 
 @pytest.mark.anyio
 async def test_read_only_mode():
     """Verify read-only mode excludes all write/mutating tools."""
-    server = _make_server(ToolFilter(read_only=True))
+    server = _make_all_tools_server(ToolFilter(read_only=True))
     ro_tools = await server.list_tools()
     ro_names = {t.name for t in ro_tools}
 
-    full_server = _make_server(ToolFilter())
+    full_server = _make_all_tools_server(ToolFilter())
     full_tools = await full_server.list_tools()
     full_names = {t.name for t in full_tools}
 
     # Read-only should be a strict subset of full
-    assert ro_names < full_names, "Read-only tools should be a strict subset of full tools"
+    assert ro_names < full_names, (
+        "Read-only tools should be a strict subset of full tools"
+    )
 
     # Read-only should have no write tools
     for name in ro_names:
@@ -302,13 +317,21 @@ async def test_read_only_mode():
 
     # Core read tools should still be present
     expected_read = {
-        "list_companies", "get_company",
-        "list_employees", "get_employee",
-        "list_payrolls", "get_payroll", "preview_payroll",
-        "list_workplaces", "get_workplace",
-        "list_payments", "get_payment",
-        "list_webhook_configs", "get_webhook_config",
-        "list_forms", "get_form",
+        "list_companies",
+        "get_company",
+        "list_employees",
+        "get_employee",
+        "list_payrolls",
+        "get_payroll",
+        "preview_payroll",
+        "list_workplaces",
+        "get_workplace",
+        "list_payments",
+        "get_payment",
+        "list_webhook_configs",
+        "get_webhook_config",
+        "list_forms",
+        "get_form",
         "validate_address",
     }
     assert expected_read.issubset(ro_names), (
@@ -319,7 +342,9 @@ async def test_read_only_mode():
 @pytest.mark.anyio
 async def test_toolset_filtering():
     """Only tools from selected toolsets are listed."""
-    server = _make_server(ToolFilter(toolsets=frozenset({"companies", "employees"})))
+    server = _make_all_tools_server(
+        ToolFilter(toolsets=frozenset({"companies", "employees"}))
+    )
     tools = await server.list_tools()
     tool_names = {t.name for t in tools}
 
@@ -337,7 +362,7 @@ async def test_toolset_filtering():
 @pytest.mark.anyio
 async def test_individual_tool_filtering():
     """Only individually named tools are listed when tools filter is set."""
-    server = _make_server(
+    server = _make_all_tools_server(
         ToolFilter(tools=frozenset({"list_companies", "get_company"}))
     )
     tools = await server.list_tools()
@@ -349,7 +374,7 @@ async def test_individual_tool_filtering():
 @pytest.mark.anyio
 async def test_exclude_tools():
     """Excluded tools are hidden regardless of other settings."""
-    server = _make_server(
+    server = _make_all_tools_server(
         ToolFilter(exclude_tools=frozenset({"create_company", "delete_payroll"}))
     )
     tools = await server.list_tools()
@@ -364,7 +389,7 @@ async def test_exclude_tools():
 @pytest.mark.anyio
 async def test_exclude_overrides_tools_allowlist():
     """Exclude takes precedence over the tools allowlist."""
-    server = _make_server(
+    server = _make_all_tools_server(
         ToolFilter(
             tools=frozenset({"list_companies", "create_company"}),
             exclude_tools=frozenset({"create_company"}),
@@ -379,7 +404,7 @@ async def test_exclude_overrides_tools_allowlist():
 @pytest.mark.anyio
 async def test_readonly_with_toolsets():
     """Read-only combined with toolsets filters both."""
-    server = _make_server(
+    server = _make_all_tools_server(
         ToolFilter(toolsets=frozenset({"companies"}), read_only=True)
     )
     tools = await server.list_tools()

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -12,7 +12,6 @@ from mcp_server_check.tool_filter import (
     is_write_tool,
 )
 
-
 # --- is_write_tool ---
 
 
@@ -235,14 +234,28 @@ class TestInvalidToolsets:
 
 
 class TestToolsets:
-    def test_has_17_toolsets(self):
-        assert len(TOOLSETS) == 17
+    def test_has_18_toolsets(self):
+        assert len(TOOLSETS) == 18
 
     def test_known_toolsets(self):
         expected = {
-            "bank_accounts", "companies", "compensation", "components",
-            "contractor_payments", "contractors", "documents", "employees",
-            "external_payrolls", "forms", "payments", "payroll_items",
-            "payrolls", "platform", "tax", "webhooks", "workplaces",
+            "bank_accounts",
+            "companies",
+            "compensation",
+            "components",
+            "contractor_payments",
+            "contractors",
+            "documents",
+            "employees",
+            "external_payrolls",
+            "forms",
+            "payments",
+            "payroll_items",
+            "payrolls",
+            "platform",
+            "tax",
+            "webhooks",
+            "workflows",
+            "workplaces",
         }
         assert TOOLSETS == expected

--- a/tests/test_tool_index.py
+++ b/tests/test_tool_index.py
@@ -1,0 +1,407 @@
+"""Tests for the tool index (dynamic mode)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from mcp_server_check.tool_filter import ToolFilter
+from mcp_server_check.tool_index import (
+    _TOOLSET_DESCRIPTIONS,
+    ToolIndex,
+    _expand_synonyms,
+    _first_line,
+    _tokenize,
+)
+
+# --- Unit tests for helpers ---
+
+
+class TestTokenize:
+    def test_basic(self):
+        assert _tokenize("list_companies") == {"list", "companies"}
+
+    def test_mixed_case(self):
+        assert _tokenize("List Companies") == {"list", "companies"}
+
+    def test_with_numbers(self):
+        assert _tokenize("get_w2_preview") == {"get", "w2", "preview"}
+
+    def test_empty(self):
+        assert _tokenize("") == set()
+
+
+class TestFirstLine:
+    def test_extracts_first_line(self):
+        assert _first_line("List companies in your account.\n\nArgs:") == (
+            "List companies in your account."
+        )
+
+    def test_none(self):
+        assert _first_line(None) == ""
+
+    def test_empty(self):
+        assert _first_line("") == ""
+
+    def test_leading_whitespace(self):
+        assert _first_line("\n  Hello world\n") == "Hello world"
+
+
+class TestExpandSynonyms:
+    def test_expands_known_synonym(self):
+        expanded = _expand_synonyms({"pay"})
+        assert "payroll" in expanded
+        assert "compensation" in expanded
+        assert "pay" in expanded
+
+    def test_unknown_word_passthrough(self):
+        expanded = _expand_synonyms({"xyzzy"})
+        assert expanded == {"xyzzy"}
+
+    def test_multiple_tokens(self):
+        expanded = _expand_synonyms({"list", "employee"})
+        assert "index" in expanded  # synonym of "list"
+        assert "worker" in expanded  # synonym of "employee"
+        assert "list" in expanded
+        assert "employee" in expanded
+
+
+# --- ToolIndex.build ---
+
+
+class TestToolIndexBuild:
+    def setup_method(self):
+        self.index = ToolIndex()
+        self.index.build()
+
+    def test_builds_all_tools(self):
+        assert len(self.index.entries) > 100
+
+    def test_has_expected_tools(self):
+        assert "list_companies" in self.index.entries
+        assert "get_employee" in self.index.entries
+        assert "create_payroll" in self.index.entries
+        assert "list_bank_accounts" in self.index.entries
+
+    def test_entry_has_metadata(self):
+        entry = self.index.entries["list_companies"]
+        assert entry.name == "list_companies"
+        assert entry.toolset == "companies"
+        assert entry.is_write is False
+        assert "List companies" in entry.description
+        assert isinstance(entry.parameters, dict)
+        assert entry.search_tokens
+
+    def test_write_tool_flagged(self):
+        assert self.index.entries["create_company"].is_write is True
+        assert self.index.entries["update_employee"].is_write is True
+        assert self.index.entries["delete_payroll"].is_write is True
+
+    def test_read_tool_flagged(self):
+        assert self.index.entries["list_companies"].is_write is False
+        assert self.index.entries["get_payroll"].is_write is False
+
+    def test_toolset_entries_populated(self):
+        assert "companies" in self.index.toolset_entries
+        assert "employees" in self.index.toolset_entries
+        assert len(self.index.toolset_entries["companies"]) > 5
+
+    def test_parameters_has_properties(self):
+        entry = self.index.entries["list_companies"]
+        assert "properties" in entry.parameters
+
+    def test_search_tokens_include_param_names(self):
+        entry = self.index.entries["list_companies"]
+        # The function has "limit", "active", "ids", "cursor" params
+        assert "limit" in entry.search_tokens
+
+
+# --- ToolIndex.search ---
+
+
+class TestToolIndexSearch:
+    def setup_method(self):
+        self.index = ToolIndex()
+        self.index.build()
+        self.no_filter = ToolFilter()
+
+    def test_search_by_keyword(self):
+        results = self.index.search("list companies", self.no_filter)
+        names = [r["name"] for r in results]
+        assert "list_companies" in names
+        # Should be first or near-first due to exact match boosting
+        assert names.index("list_companies") < 3
+
+    def test_search_returns_parameters(self):
+        results = self.index.search("list companies", self.no_filter, limit=1)
+        assert len(results) == 1
+        assert "parameters" in results[0]
+        assert "name" in results[0]
+        assert "description" in results[0]
+        assert "toolset" in results[0]
+
+    def test_search_with_toolset_filter(self):
+        results = self.index.search("list", self.no_filter, toolset="companies")
+        for r in results:
+            assert r["toolset"] == "companies"
+
+    def test_search_respects_limit(self):
+        results = self.index.search("list", self.no_filter, limit=3)
+        assert len(results) <= 3
+
+    def test_search_exact_name(self):
+        results = self.index.search("get_company", self.no_filter)
+        assert results[0]["name"] == "get_company"
+
+    def test_empty_query_returns_overview(self):
+        results = self.index.search("", self.no_filter)
+        # Should be toolset summaries
+        assert len(results) > 0
+        assert "toolset" in results[0]
+        assert "tool_count" in results[0]
+        assert "example_tools" in results[0]
+
+    def test_overview_includes_descriptions(self):
+        results = self.index.search("", self.no_filter)
+        for r in results:
+            assert "description" in r
+            # Every toolset should have a non-empty description
+            assert r["description"], f"Missing description for {r['toolset']}"
+
+    def test_overview_covers_all_toolsets(self):
+        results = self.index.search("", self.no_filter)
+        toolset_names = {r["toolset"] for r in results}
+        assert "companies" in toolset_names
+        assert "employees" in toolset_names
+        assert "payrolls" in toolset_names
+
+    def test_no_results_for_gibberish(self):
+        results = self.index.search("xyzzyplugh", self.no_filter)
+        assert results == []
+
+    def test_synonym_search_pay(self):
+        """Searching 'pay' should find payroll tools via synonym expansion."""
+        results = self.index.search("pay", self.no_filter)
+        names = [r["name"] for r in results]
+        # Should find payroll-related tools even though "pay" isn't in tool names
+        payroll_names = [n for n in names if "payroll" in n or "pay" in n]
+        assert len(payroll_names) > 0
+
+    def test_synonym_search_worker(self):
+        """Searching 'worker' should find employee tools via synonyms."""
+        results = self.index.search("worker", self.no_filter)
+        names = [r["name"] for r in results]
+        employee_names = [n for n in names if "employee" in n]
+        assert len(employee_names) > 0
+
+
+# --- ToolIndex.search with ToolFilter ---
+
+
+class TestToolIndexSearchFiltered:
+    def setup_method(self):
+        self.index = ToolIndex()
+        self.index.build()
+
+    def test_toolset_filter(self):
+        tf = ToolFilter(toolsets=frozenset({"companies"}))
+        results = self.index.search("list", tf)
+        for r in results:
+            assert r["toolset"] == "companies"
+
+    def test_read_only_excludes_write_tools(self):
+        tf = ToolFilter(read_only=True)
+        results = self.index.search("create company", tf)
+        names = [r["name"] for r in results]
+        assert "create_company" not in names
+
+    def test_exclude_tools(self):
+        tf = ToolFilter(exclude_tools=frozenset({"list_companies"}))
+        results = self.index.search("list companies", tf)
+        names = [r["name"] for r in results]
+        assert "list_companies" not in names
+
+    def test_tools_allowlist(self):
+        tf = ToolFilter(tools=frozenset({"list_companies", "get_company"}))
+        results = self.index.search("list", tf)
+        names = {r["name"] for r in results}
+        assert names.issubset({"list_companies", "get_company"})
+
+    def test_overview_respects_filter(self):
+        tf = ToolFilter(toolsets=frozenset({"companies", "employees"}))
+        results = self.index.search("", tf)
+        toolset_names = {r["toolset"] for r in results}
+        assert toolset_names == {"companies", "employees"}
+
+
+# --- ToolIndex.run ---
+
+
+class TestToolIndexRun:
+    def setup_method(self):
+        self.index = ToolIndex()
+        self.index.build()
+        self.no_filter = ToolFilter()
+
+    @pytest.mark.anyio
+    async def test_run_unknown_tool(self):
+        with pytest.raises(ValueError, match="Unknown tool"):
+            await self.index.run("nonexistent_tool", {}, None, self.no_filter)
+
+    @pytest.mark.anyio
+    async def test_run_unknown_tool_has_suggestion(self):
+        """Error message for unknown tool includes a suggestion."""
+        with pytest.raises(ValueError, match="Did you mean"):
+            await self.index.run("list_companie", {}, None, self.no_filter)
+
+    @pytest.mark.anyio
+    async def test_run_blocked_by_filter(self):
+        tf = ToolFilter(exclude_tools=frozenset({"list_companies"}))
+        with pytest.raises(ValueError, match="not available"):
+            await self.index.run("list_companies", {}, None, tf)
+
+    @pytest.mark.anyio
+    async def test_run_blocked_by_read_only(self):
+        tf = ToolFilter(read_only=True)
+        with pytest.raises(ValueError, match="not available"):
+            await self.index.run("create_company", {}, None, tf)
+
+    @pytest.mark.anyio
+    async def test_run_dispatches_correctly(self, mock_api, ctx):
+        """Run dispatches to the correct underlying tool function."""
+        import httpx as httpx_mod
+
+        mock_api.get("/companies").mock(
+            return_value=httpx_mod.Response(
+                200,
+                json={
+                    "next": None,
+                    "previous": None,
+                    "results": [{"id": "com_001"}],
+                },
+            )
+        )
+        result = await self.index.run("list_companies", {}, ctx, self.no_filter)
+        assert result["results"] == [{"id": "com_001"}]
+
+    @pytest.mark.anyio
+    async def test_run_with_arguments(self, mock_api, ctx):
+        import httpx as httpx_mod
+
+        mock_api.get("/companies/com_001").mock(
+            return_value=httpx_mod.Response(
+                200,
+                json={"id": "com_001", "legal_name": "Acme Corp"},
+            )
+        )
+        result = await self.index.run(
+            "get_company", {"company_id": "com_001"}, ctx, self.no_filter
+        )
+        assert result == {"id": "com_001", "legal_name": "Acme Corp"}
+
+
+# --- ToolIndex.get_toolset_names ---
+
+
+class TestToolIndexMeta:
+    def setup_method(self):
+        self.index = ToolIndex()
+        self.index.build()
+
+    def test_get_toolset_names(self):
+        names = self.index.get_toolset_names()
+        assert isinstance(names, list)
+        assert names == sorted(names)
+        assert "companies" in names
+        assert "employees" in names
+
+    def test_all_toolsets_have_descriptions(self):
+        for name in self.index.get_toolset_names():
+            assert name in _TOOLSET_DESCRIPTIONS, (
+                f"Missing description for toolset: {name}"
+            )
+
+
+# --- Dynamic mode server integration ---
+
+
+class TestDynamicModeServer:
+    def _make_dynamic_server(self):
+        from mcp_server_check.server import CheckMCP, _setup_dynamic_mode, lifespan
+
+        server = CheckMCP("Test Dynamic", lifespan=lifespan)
+        _setup_dynamic_mode(server)
+        return server
+
+    def _extract_text(self, result):
+        """Extract text from call_tool result (tuple of [TextContent, ...])."""
+        return result[0][0].text
+
+    @pytest.mark.anyio
+    async def test_list_tools_returns_three(self):
+        server = self._make_dynamic_server()
+        tools = await server.list_tools()
+        names = {t.name for t in tools}
+        assert names == {"search_tools", "list_toolsets", "run_tool"}
+
+    @pytest.mark.anyio
+    async def test_search_tools_callable(self):
+        server = self._make_dynamic_server()
+        result = await server.call_tool("search_tools", {"query": "list companies"})
+        text = self._extract_text(result)
+        parsed = json.loads(text)
+        assert isinstance(parsed, list)
+        names = [r["name"] for r in parsed]
+        assert "list_companies" in names
+
+    @pytest.mark.anyio
+    async def test_search_tools_empty_query(self):
+        server = self._make_dynamic_server()
+        result = await server.call_tool("search_tools", {"query": ""})
+        text = self._extract_text(result)
+        parsed = json.loads(text)
+        assert isinstance(parsed, list)
+        assert len(parsed) > 0
+        assert "toolset" in parsed[0]
+
+    @pytest.mark.anyio
+    async def test_list_toolsets(self):
+        server = self._make_dynamic_server()
+        result = await server.call_tool("list_toolsets", {})
+        text = self._extract_text(result)
+        parsed = json.loads(text)
+        assert isinstance(parsed, list)
+        assert len(parsed) > 0
+        assert "toolset" in parsed[0]
+        assert "description" in parsed[0]
+        assert "tool_count" in parsed[0]
+
+    @pytest.mark.anyio
+    async def test_run_tool_unknown(self):
+        server = self._make_dynamic_server()
+        result = await server.call_tool("run_tool", {"tool_name": "nonexistent"})
+        text = self._extract_text(result)
+        parsed = json.loads(text)
+        assert "error" in parsed
+
+    @pytest.mark.anyio
+    async def test_run_tool_accepts_dict_arguments(self):
+        """run_tool schema accepts arguments as a dict (not JSON string)."""
+        server = self._make_dynamic_server()
+        tools = await server.list_tools()
+        run_tool_schema = next(t for t in tools if t.name == "run_tool")
+        props = run_tool_schema.inputSchema.get("properties", {})
+        args_schema = props.get("arguments", {})
+        # arguments should accept an object type (dict), not just string
+        assert args_schema.get("type") in ("object", None) or "anyOf" in args_schema
+
+    @pytest.mark.anyio
+    async def test_run_tool_no_arguments(self):
+        """run_tool works with no arguments parameter."""
+        server = self._make_dynamic_server()
+        # list_companies with no args should attempt the API call
+        # (will fail since no mock, but that's fine - we're testing the dispatch)
+        result = await server.call_tool("run_tool", {"tool_name": "nonexistent_tool"})
+        text = self._extract_text(result)
+        parsed = json.loads(text)
+        assert "error" in parsed

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,140 @@
+"""Tests for workflow composite tools."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from mcp_server_check.tools.workflows import (
+    diagnose_payment,
+    get_company_overview,
+    get_employee_snapshot,
+)
+
+
+def _list_response(results):
+    """Helper to build a paginated list response."""
+    return {"next": None, "previous": None, "results": results}
+
+
+@pytest.mark.anyio
+async def test_get_company_overview_full(mock_api, ctx):
+    mock_api.get("/companies/com_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_001", "legal_name": "Acme"})
+    )
+    mock_api.get("/employees").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "emp_001", "first_name": "Jane"}])
+        )
+    )
+    mock_api.get("/payrolls").mock(
+        return_value=httpx.Response(200, json=_list_response([{"id": "prl_001"}]))
+    )
+    mock_api.get("/bank_accounts").mock(
+        return_value=httpx.Response(200, json=_list_response([{"id": "bnk_001"}]))
+    )
+
+    result = await get_company_overview(ctx, company_id="com_001")
+
+    assert result["company"]["id"] == "com_001"
+    assert result["employees"]["results"][0]["id"] == "emp_001"
+    assert result["payrolls"]["results"][0]["id"] == "prl_001"
+    assert result["bank_accounts"]["results"][0]["id"] == "bnk_001"
+
+
+@pytest.mark.anyio
+async def test_get_company_overview_minimal(mock_api, ctx):
+    mock_api.get("/companies/com_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_001"})
+    )
+
+    result = await get_company_overview(
+        ctx,
+        company_id="com_001",
+        include_employees=False,
+        include_payrolls=False,
+        include_bank_accounts=False,
+    )
+
+    assert result["company"]["id"] == "com_001"
+    assert "employees" not in result
+    assert "payrolls" not in result
+    assert "bank_accounts" not in result
+
+
+@pytest.mark.anyio
+async def test_get_employee_snapshot_full(mock_api, ctx):
+    mock_api.get("/employees/emp_001").mock(
+        return_value=httpx.Response(
+            200, json={"id": "emp_001", "first_name": "Jane", "last_name": "Doe"}
+        )
+    )
+    mock_api.get("/employee_tax_params/emp_001").mock(
+        return_value=httpx.Response(200, json={"id": "emp_001", "params": []})
+    )
+    mock_api.get("/employees/emp_001/paystubs").mock(
+        return_value=httpx.Response(200, json=_list_response([{"id": "stub_001"}]))
+    )
+
+    result = await get_employee_snapshot(ctx, employee_id="emp_001")
+
+    assert result["employee"]["id"] == "emp_001"
+    assert "tax_params" in result
+    assert result["paystubs"]["results"][0]["id"] == "stub_001"
+
+
+@pytest.mark.anyio
+async def test_get_employee_snapshot_minimal(mock_api, ctx):
+    mock_api.get("/employees/emp_001").mock(
+        return_value=httpx.Response(200, json={"id": "emp_001"})
+    )
+
+    result = await get_employee_snapshot(
+        ctx, employee_id="emp_001", include_tax_params=False, include_paystubs=False
+    )
+
+    assert result["employee"]["id"] == "emp_001"
+    assert "tax_params" not in result
+    assert "paystubs" not in result
+
+
+@pytest.mark.anyio
+async def test_diagnose_payment_with_payroll_item(mock_api, ctx):
+    mock_api.get("/payments/pmt_001").mock(
+        return_value=httpx.Response(
+            200,
+            json={"id": "pmt_001", "status": "failed", "payroll_item": "pit_001"},
+        )
+    )
+    mock_api.get("/payments/pmt_001/payment_attempts").mock(
+        return_value=httpx.Response(
+            200,
+            json=_list_response([{"id": "att_001", "status": "failed"}]),
+        )
+    )
+    mock_api.get("/payroll_items/pit_001").mock(
+        return_value=httpx.Response(200, json={"id": "pit_001", "employee": "emp_001"})
+    )
+
+    result = await diagnose_payment(ctx, payment_id="pmt_001")
+
+    assert result["payment"]["id"] == "pmt_001"
+    assert result["payment_attempts"]["results"][0]["id"] == "att_001"
+    assert result["payroll_item"]["id"] == "pit_001"
+
+
+@pytest.mark.anyio
+async def test_diagnose_payment_without_payroll_item(mock_api, ctx):
+    mock_api.get("/payments/pmt_002").mock(
+        return_value=httpx.Response(200, json={"id": "pmt_002", "status": "completed"})
+    )
+    mock_api.get("/payments/pmt_002/payment_attempts").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "att_002", "status": "completed"}])
+        )
+    )
+
+    result = await diagnose_payment(ctx, payment_id="pmt_002")
+
+    assert result["payment"]["id"] == "pmt_002"
+    assert result["payment_attempts"]["results"][0]["id"] == "att_002"
+    assert "payroll_item" not in result


### PR DESCRIPTION
- Collapse 35 component tools into 2 generic tools (create_component + list_component_types)
- Consolidate 8 company report tools into 1 (get_company_report with report_type param)
- Default to dynamic mode (3 meta-tools) instead of exposing all tools individually
- Add synonym expansion to search (e.g. "pay" finds payroll tools)
- Add list_toolsets meta-tool for browsing available API categories
- Change run_tool to accept arguments as dict instead of JSON string
- Add "Did you mean?" suggestions for unknown tool names
- Add 3 workflow power tools (get_company_overview, get_employee_snapshot, diagnose_payment)
- Add 13 MCP resources for enum values and toolset reference
- Add toolset descriptions to search overview