### PR TITLE
Add tool factory, response shaping, confirmation tier, and workflow tools

### DIFF
--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Sequence
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -18,6 +19,55 @@ class CheckContext:
 
 Ctx = Context[ServerSession, CheckContext]
 
+# Default max results for list endpoints to avoid blowing context windows.
+DEFAULT_LIST_LIMIT = 10
+
+# Fields to keep in summary mode per entity type (by ID prefix or path hint).
+# When a list response contains many records, only these fields are returned
+# unless the caller explicitly requests full details.
+_SUMMARY_FIELDS: dict[str, Sequence[str]] = {
+    "com_": ("id", "legal_name", "trade_name", "status", "pay_frequency"),
+    "emp_": ("id", "first_name", "last_name", "email", "status", "start_date"),
+    "ctr_": ("id", "first_name", "last_name", "business_name", "type", "status"),
+    "prl_": ("id", "status", "payday", "period_start", "period_end", "type", "approval_status"),
+    "pit_": ("id", "employee", "payment_method", "status"),
+    "pmt_": ("id", "status", "amount", "payment_method", "direction"),
+    "bnk_": ("id", "institution_name", "subtype", "status", "last_four"),
+    "wrk_": ("id", "name", "active", "address"),
+    "ben_": ("id", "benefit", "description", "employee", "effective_start", "effective_end"),
+    "nps_": ("id", "employee", "contractor", "is_default"),
+    "psc_": ("id", "name", "pay_frequency", "company"),
+}
+
+
+def _detect_entity_prefix(results: list[dict]) -> str | None:
+    """Detect the entity type prefix from the first result's ID."""
+    if not results:
+        return None
+    first_id = results[0].get("id", "")
+    if isinstance(first_id, str) and "_" in first_id:
+        prefix = first_id.split("_")[0] + "_"
+        return prefix
+    return None
+
+
+def _summarize_record(record: dict, fields: Sequence[str]) -> dict:
+    """Return only the specified fields from a record."""
+    return {k: v for k, v in record.items() if k in fields}
+
+
+def _summarize_results(results: list[dict]) -> list[dict]:
+    """Return summary views of list results to reduce context size.
+
+    If the entity type is recognized (by ID prefix), only key fields are kept.
+    Unrecognized entities are returned as-is.
+    """
+    prefix = _detect_entity_prefix(results)
+    if prefix and prefix in _SUMMARY_FIELDS:
+        fields = _SUMMARY_FIELDS[prefix]
+        return [_summarize_record(r, fields) for r in results]
+    return results
+
 
 def _extract_cursor(url: str | None) -> str | None:
     """Extract the cursor parameter from a Check API pagination URL."""
@@ -28,10 +78,18 @@ def _extract_cursor(url: str | None) -> str | None:
     return cursor_values[0] if cursor_values else None
 
 
-def _format_list_response(data: dict) -> dict:
-    """Normalize a paginated Check API response."""
+def _format_list_response(data: dict, *, summarize: bool = True) -> dict:
+    """Normalize a paginated Check API response.
+
+    Args:
+        data: Raw API response dict with results, next, previous.
+        summarize: If True, return only key fields per entity to save context.
+    """
+    results = data.get("results", [])
+    formatted_results = _summarize_results(results) if summarize else results
     return {
-        "results": data.get("results", []),
+        "results": formatted_results,
+        "result_count": len(results),
         "next_cursor": _extract_cursor(data.get("next")),
         "previous_cursor": _extract_cursor(data.get("previous")),
     }
@@ -93,9 +151,22 @@ async def check_api_delete(ctx: Ctx, path: str, params: dict | None = None) -> d
     return await _check_api_request(ctx, "DELETE", path, params=params)
 
 
-async def check_api_list(ctx: Ctx, path: str, params: dict | None = None) -> dict:
-    """GET a list endpoint and return a normalized paginated response."""
+async def check_api_list(
+    ctx: Ctx,
+    path: str,
+    params: dict | None = None,
+    *,
+    summarize: bool = True,
+) -> dict:
+    """GET a list endpoint and return a normalized paginated response.
+
+    Args:
+        ctx: MCP context.
+        path: API path.
+        params: Query parameters.
+        summarize: If True (default), return summary views of results.
+    """
     data = await check_api_get(ctx, path, params=params)
     if "error" in data:
         return data
-    return _format_list_response(data)
+    return _format_list_response(data, summarize=summarize)

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -21,6 +21,63 @@ from mcp_server_check.tools import register_all
 
 DEFAULT_BASE_URL = "https://sandbox.checkhq.com"
 
+SERVER_INSTRUCTIONS = """\
+You are connected to the Check Payroll API — a payroll infrastructure platform \
+that lets you manage companies, employees, contractors, payrolls, tax filings, \
+and payments programmatically.
+
+## Entity Model
+- **Company** → has Workplaces, Employees, Contractors, Pay Schedules, Bank Accounts
+- **Employee** (W-2) → has Earning Rates, Benefits, Post-Tax Deductions, Tax Params, Forms
+- **Contractor** (1099) → has Contractor Payments
+- **Payroll** → has Payroll Items (one per employee) and Contractor Payments
+- **Payroll Item** → has Earnings, Reimbursements, Benefit/Deduction overrides
+- **Payment** → tracks actual money movement (ACH/wire), has Payment Attempts
+
+## Key Workflows
+
+### Creating a payroll (most common workflow):
+1. Ensure the company has at least one Workplace and one Bank Account
+2. Create the Payroll with period_start, period_end, and payday dates
+3. Add Payroll Items (one per employee being paid), each with earnings
+4. Add Contractor Payments for any 1099 contractors
+5. Call preview_payroll to see calculated taxes and net pay
+6. Call approve_payroll to submit for processing
+
+### Onboarding a new company:
+1. create_company with legal_name and address
+2. create_workplace for each work location
+3. create_employee / create_contractor for each worker
+4. Set up bank_accounts for funding
+5. Configure tax params and benefits
+6. Call onboard_company when setup is complete
+
+## Important Concepts
+- **Payroll** is the batch container; **Payroll Item** is a single employee's pay stub within it
+- **Earning Rate** defines an employee's pay rate; **Earning Code** defines the type of earning (regular, overtime, bonus, etc.)
+- **Benefits** are pre-tax deductions (401k, health insurance); **Post-Tax Deductions** are after-tax (garnishments, Roth 401k)
+- **Tax Params** control withholding (W-4 info, state elections); they use `spa_*` IDs
+- Payrolls must be **approved** before they process — approval triggers real money movement
+- All IDs use prefixes: `com_` (company), `emp_` (employee), `ctr_` (contractor), `prl_` (payroll), `pit_` (payroll item), `pmt_` (payment), `wrk_` (workplace), `bnk_` (bank account)
+
+## Composite Tools (Use These First)
+Prefer the workflow tools when they fit — they combine multiple API calls in one round-trip:
+- **get_company_overview**: Company + employees + payrolls + bank accounts
+- **get_employee_snapshot**: Employee + tax params + paystubs
+- **diagnose_payment**: Payment + attempts + originating payroll item
+- **get_payroll_details**: Payroll + all items + contractor payments
+- **get_contractor_snapshot**: Contractor + payments + forms
+- **get_company_tax_overview**: Company tax params + elections + filings
+- **get_onboarding_status**: Company + workplaces + employees + bank accounts + setup requirements
+
+## Common Gotchas
+- You need a Workplace before you can add earnings to a payroll item
+- Payroll period dates must not overlap with existing payrolls
+- Bank accounts require verification before they can fund payrolls
+- Employee SSNs are write-once; after setting, only last 4 digits are readable
+- Tax parameter updates require the `spa_*` setting ID, not the parameter name
+"""
+
 
 @asynccontextmanager
 async def lifespan(server: FastMCP) -> AsyncIterator[CheckContext]:
@@ -125,11 +182,15 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
         results = index.search("", tool_filter=tf)
         return json.dumps(results, indent=2)
 
+    # Track tools that have been confirmed for execution in this session
+    _confirmed_tools: set[str] = set()
+
     @server.tool()
     async def run_tool(
         ctx: Context,
         tool_name: str,
         arguments: str | dict | None = None,
+        confirm: bool = False,
     ) -> str:
         """Execute an API tool by name with the given arguments.
 
@@ -138,6 +199,9 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
         tool_name: The exact tool name (e.g. "list_companies", "get_employee").
         arguments: Tool arguments as a JSON string or dict (e.g. '{"company_id": "com_xxx"}'
             or {"company_id": "com_xxx"}).
+        confirm: Set to true to confirm execution of a destructive tool (approve,
+            delete, simulate, refund, cancel). Required when CHECK_CONFIRM_DESTRUCTIVE
+            is enabled and the tool is destructive.
         """
         tf = server._get_active_filter()
         parsed_args: dict = {}
@@ -154,6 +218,21 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
             else:
                 return json.dumps({"error": "Arguments must be a JSON string or object"})
 
+        # Check if this destructive tool needs confirmation
+        call_key = f"{tool_name}:{json.dumps(parsed_args, sort_keys=True)}"
+        if tf.requires_confirmation(tool_name) and not confirm:
+            if call_key not in _confirmed_tools:
+                return json.dumps({
+                    "confirmation_required": True,
+                    "tool_name": tool_name,
+                    "arguments": parsed_args,
+                    "message": (
+                        f"⚠️  '{tool_name}' is a destructive operation that may "
+                        f"trigger irreversible effects (money movement, data deletion, "
+                        f"etc.). Call run_tool again with confirm=true to proceed."
+                    ),
+                })
+
         try:
             result = await index.run(
                 name=tool_name,
@@ -163,6 +242,10 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
             )
         except ValueError as e:
             return json.dumps({"error": str(e)})
+
+        # Track confirmation so repeated identical calls don't re-prompt
+        if tf.requires_confirmation(tool_name):
+            _confirmed_tools.add(call_key)
 
         return json.dumps(result) if isinstance(result, dict) else str(result)
 
@@ -269,7 +352,9 @@ def _register_resources(server: CheckMCP) -> None:
 
 def _create_server() -> CheckMCP:
     """Create and configure the MCP server based on CHECK_TOOL_MODE."""
-    server = CheckMCP("Check Payroll API", lifespan=lifespan)
+    server = CheckMCP(
+        "Check Payroll API", instructions=SERVER_INSTRUCTIONS, lifespan=lifespan
+    )
     tool_mode = os.environ.get("CHECK_TOOL_MODE", "dynamic").lower()
     if tool_mode == "all":
         register_all(server, registry=server._registry)

--- a/src/mcp_server_check/tool_factory.py
+++ b/src/mcp_server_check/tool_factory.py
@@ -1,0 +1,449 @@
+"""Declarative tool factory for generating CRUD tools from resource definitions.
+
+Eliminates the repeated `if field is not None: body["field"] = field` boilerplate
+by generating list/get/create/update/delete tool functions from a compact schema.
+
+Usage:
+    from mcp_server_check.tool_factory import Resource, Field, generate_tools
+
+    resource = Resource(
+        name="benefits",
+        path="/benefits",
+        id_param="benefit_id",
+        id_description="The Check benefit ID.",
+        description="employee benefits",
+        list_filters=["company", "employee"],
+        fields=[
+            Field("employee", str, required_for="create", doc="The Check employee ID."),
+            Field("company_benefit", str, required_for="create", doc="The company benefit ID."),
+            Field("description", str, doc="Benefit description."),
+            Field("effective_start", str, doc="Start date (YYYY-MM-DD)."),
+        ],
+    )
+
+    tools = generate_tools(resource)
+    # tools.list_fn, tools.get_fn, tools.create_fn, tools.update_fn, tools.delete_fn
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any
+
+from mcp_server_check.helpers import (
+    Ctx,
+    check_api_delete,
+    check_api_get,
+    check_api_list,
+    check_api_patch,
+    check_api_post,
+)
+
+
+@dataclass
+class Field:
+    """A field in a resource schema.
+
+    Attributes:
+        name: API field name (e.g. "employee", "description").
+        type: Python type annotation (str, int, float, bool, dict, list[str], etc.).
+        required_for: If "create", this field is required in the create tool.
+            If None, the field is optional for both create and update.
+        doc: Documentation string for this field.
+        create_only: If True, this field only appears on create, not update.
+        update_only: If True, this field only appears on update, not create.
+    """
+
+    name: str
+    type: type = str
+    required_for: str | None = None
+    doc: str = ""
+    create_only: bool = False
+    update_only: bool = False
+
+
+@dataclass
+class Resource:
+    """Declarative definition of a Check API resource.
+
+    Attributes:
+        name: Resource name in plural form (e.g. "benefits", "pay_schedules").
+        path: API path prefix (e.g. "/benefits", "/pay_schedules").
+        id_param: Name of the ID parameter (e.g. "benefit_id").
+        id_description: Doc string for the ID parameter.
+        description: Human-readable description of what this resource is.
+        fields: List of Field definitions.
+        list_filters: Names of query-parameter fields for list filtering
+            (e.g. ["company", "employee"]).
+        has_delete: Whether to generate a delete tool. Default True.
+        list_doc: Custom docstring for the list tool.
+        get_doc: Custom docstring for the get tool.
+        create_doc: Custom docstring for the create tool.
+        update_doc: Custom docstring for the update tool.
+        delete_doc: Custom docstring for the delete tool.
+    """
+
+    name: str
+    path: str
+    id_param: str
+    id_description: str = ""
+    description: str = ""
+    fields: list[Field] = dataclass_field(default_factory=list)
+    list_filters: list[str] = dataclass_field(default_factory=list)
+    has_delete: bool = True
+    list_doc: str | None = None
+    get_doc: str | None = None
+    create_doc: str | None = None
+    update_doc: str | None = None
+    delete_doc: str | None = None
+
+
+@dataclass
+class GeneratedTools:
+    """Container for generated tool functions."""
+
+    list_fn: Any = None
+    get_fn: Any = None
+    create_fn: Any = None
+    update_fn: Any = None
+    delete_fn: Any = None
+
+    def all_read(self) -> list:
+        """Return all read-only tool functions."""
+        return [fn for fn in [self.list_fn, self.get_fn] if fn is not None]
+
+    def all_write(self) -> list:
+        """Return all write tool functions."""
+        return [
+            fn
+            for fn in [self.create_fn, self.update_fn, self.delete_fn]
+            if fn is not None
+        ]
+
+    def all(self) -> list:
+        """Return all tool functions."""
+        return self.all_read() + self.all_write()
+
+
+def _build_body(fields: list[Field], kwargs: dict, *, is_create: bool) -> dict:
+    """Build a request body from field definitions and keyword arguments.
+
+    For create: includes required fields unconditionally, optional fields if not None.
+    For update: includes all non-None fields.
+    """
+    body: dict = {}
+    for f in fields:
+        if is_create and f.update_only:
+            continue
+        if not is_create and f.create_only:
+            continue
+        val = kwargs.get(f.name)
+        if is_create and f.required_for == "create":
+            body[f.name] = val
+        elif val is not None:
+            body[f.name] = val
+    return body
+
+
+def _build_params(filter_names: list[str], kwargs: dict) -> dict | None:
+    """Build query parameters from filter field names and keyword arguments."""
+    params: dict = {}
+    for name in filter_names:
+        val = kwargs.get(name)
+        if val is not None:
+            if isinstance(val, list):
+                params[name] = ",".join(val)
+            elif isinstance(val, bool):
+                params[name] = str(val).lower()
+            else:
+                params[name] = val
+    # Standard pagination params
+    if kwargs.get("limit") is not None:
+        params["limit"] = kwargs["limit"]
+    if kwargs.get("cursor"):
+        params["cursor"] = kwargs["cursor"]
+    return params or None
+
+
+def _make_list_docstring(res: Resource) -> str:
+    """Generate a docstring for a list tool."""
+    if res.list_doc:
+        return res.list_doc
+    filters = ", ".join(res.list_filters) if res.list_filters else "no filters"
+    return f"List {res.description}, optionally filtered by {filters}."
+
+
+def _make_get_docstring(res: Resource) -> str:
+    if res.get_doc:
+        return res.get_doc
+    return f"Get details for a specific {res.description.rstrip('s')}."
+
+
+def _make_create_docstring(res: Resource) -> str:
+    if res.create_doc:
+        return res.create_doc
+    return f"Create a new {res.description.rstrip('s')}."
+
+
+def _make_update_docstring(res: Resource) -> str:
+    if res.update_doc:
+        return res.update_doc
+    return f"Update an existing {res.description.rstrip('s')}."
+
+
+def _make_delete_docstring(res: Resource) -> str:
+    if res.delete_doc:
+        return res.delete_doc
+    return f"Delete a {res.description.rstrip('s')}."
+
+
+def _build_args_doc(fields: list[Field], extra: dict[str, str] | None = None) -> str:
+    """Build the Args: section of a docstring from field definitions."""
+    lines = []
+    if extra:
+        for name, doc in extra.items():
+            lines.append(f"    {name}: {doc}")
+    for f in fields:
+        if f.doc:
+            lines.append(f"    {f.name}: {f.doc}")
+    return "\n".join(lines)
+
+
+def generate_tools(res: Resource) -> GeneratedTools:
+    """Generate list/get/create/update/delete tool functions from a Resource definition."""
+    tools = GeneratedTools()
+
+    # --- list ---
+    filter_fields = res.list_filters
+
+    async def _list_fn(
+        ctx: Ctx,
+        limit: int | None = None,
+        cursor: str | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        params = _build_params(filter_fields, {**kwargs, "limit": limit, "cursor": cursor})
+        return await check_api_list(ctx, res.path, params=params)
+
+    # Build the actual function with proper parameter annotations
+    # We need to dynamically create functions with the right signatures
+    # for FastMCP's introspection to work properly
+    list_fn = _create_list_function(res, filter_fields)
+    list_fn.__name__ = f"list_{res.name}"
+    list_fn.__qualname__ = f"list_{res.name}"
+    tools.list_fn = list_fn
+
+    # --- get ---
+    async def _get_fn(ctx: Ctx, **kwargs: Any) -> dict:
+        id_val = kwargs[res.id_param]
+        return await check_api_get(ctx, f"{res.path}/{id_val}")
+
+    get_fn = _create_get_function(res)
+    get_fn.__name__ = f"get_{res.name.rstrip('s')}"
+    get_fn.__qualname__ = f"get_{res.name.rstrip('s')}"
+    tools.get_fn = get_fn
+
+    # --- create ---
+    create_fields = [f for f in res.fields if not f.update_only]
+    create_fn = _create_create_function(res, create_fields)
+    create_fn.__name__ = f"create_{res.name.rstrip('s')}"
+    create_fn.__qualname__ = f"create_{res.name.rstrip('s')}"
+    tools.create_fn = create_fn
+
+    # --- update ---
+    update_fields = [f for f in res.fields if not f.create_only]
+    update_fn = _create_update_function(res, update_fields)
+    update_fn.__name__ = f"update_{res.name.rstrip('s')}"
+    update_fn.__qualname__ = f"update_{res.name.rstrip('s')}"
+    tools.update_fn = update_fn
+
+    # --- delete ---
+    if res.has_delete:
+        delete_fn = _create_delete_function(res)
+        delete_fn.__name__ = f"delete_{res.name.rstrip('s')}"
+        delete_fn.__qualname__ = f"delete_{res.name.rstrip('s')}"
+        tools.delete_fn = delete_fn
+
+    return tools
+
+
+def _create_list_function(res: Resource, filter_fields: list[str]):
+    """Create a list function with proper type annotations for FastMCP."""
+    # Build parameter annotations dict
+    annotations: dict[str, Any] = {"ctx": Ctx, "return": dict}
+    defaults: dict[str, Any] = {}
+    filter_docs: dict[str, str] = {}
+
+    for fname in filter_fields:
+        # Find the field doc from resource fields
+        field_def = next((f for f in res.fields if f.name == fname), None)
+        annotations[fname] = str | None
+        defaults[fname] = None
+        if field_def and field_def.doc:
+            filter_docs[fname] = field_def.doc
+        else:
+            filter_docs[fname] = f'Filter by {fname} (e.g. "{fname}_xxxxx").'
+
+    annotations["limit"] = int | None
+    annotations["cursor"] = str | None
+    defaults["limit"] = None
+    defaults["cursor"] = None
+    filter_docs["limit"] = "Maximum number of results to return."
+    filter_docs["cursor"] = "Pagination cursor from a previous response."
+
+    path = res.path
+
+    async def list_fn(ctx: Ctx, **kwargs: Any) -> dict:
+        params = _build_params(filter_fields, kwargs)
+        return await check_api_list(ctx, path, params=params)
+
+    # Apply annotations and docstring
+    list_fn.__annotations__ = annotations
+    list_fn.__doc__ = _make_list_docstring(res)
+    args_doc = _build_args_doc([], filter_docs)
+    if args_doc:
+        list_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
+
+    # Set defaults via __defaults__ and __kwdefaults__
+    # FastMCP uses inspect.signature, so we need proper defaults
+    import inspect
+
+    # Build new parameter list
+    params_list = [inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx)]
+    for pname in filter_fields:
+        params_list.append(
+            inspect.Parameter(
+                pname,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+                annotation=str | None,
+            )
+        )
+    params_list.append(
+        inspect.Parameter("limit", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None, annotation=int | None)
+    )
+    params_list.append(
+        inspect.Parameter("cursor", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None, annotation=str | None)
+    )
+    list_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+
+    return list_fn
+
+
+def _create_get_function(res: Resource):
+    """Create a get function with proper type annotations."""
+    import inspect
+
+    path = res.path
+    id_param = res.id_param
+
+    async def get_fn(ctx: Ctx, **kwargs: Any) -> dict:
+        return await check_api_get(ctx, f"{path}/{kwargs[id_param]}")
+
+    get_fn.__doc__ = _make_get_docstring(res)
+    args_doc = f"    {id_param}: {res.id_description}"
+    get_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
+
+    params_list = [
+        inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx),
+        inspect.Parameter(id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+    ]
+    get_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    return get_fn
+
+
+def _create_create_function(res: Resource, fields: list[Field]):
+    """Create a create function with proper type annotations."""
+    import inspect
+
+    path = res.path
+    field_list = fields  # Capture for closure
+
+    async def create_fn(ctx: Ctx, **kwargs: Any) -> dict:
+        body = _build_body(field_list, kwargs, is_create=True)
+        return await check_api_post(ctx, path, data=body)
+
+    create_fn.__doc__ = _make_create_docstring(res)
+    args_doc = _build_args_doc(fields)
+    if args_doc:
+        create_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
+
+    params_list = [inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx)]
+    for f in fields:
+        if f.required_for == "create":
+            params_list.append(
+                inspect.Parameter(
+                    f.name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=f.type,
+                )
+            )
+        else:
+            params_list.append(
+                inspect.Parameter(
+                    f.name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    default=None,
+                    annotation=f.type | None,
+                )
+            )
+    create_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    return create_fn
+
+
+def _create_update_function(res: Resource, fields: list[Field]):
+    """Create an update function with proper type annotations."""
+    import inspect
+
+    path = res.path
+    id_param = res.id_param
+    field_list = fields
+
+    async def update_fn(ctx: Ctx, **kwargs: Any) -> dict:
+        id_val = kwargs.pop(id_param)
+        body = _build_body(field_list, kwargs, is_create=False)
+        return await check_api_patch(ctx, f"{path}/{id_val}", data=body)
+
+    update_fn.__doc__ = _make_update_docstring(res)
+    extra = {id_param: res.id_description}
+    args_doc = _build_args_doc(fields, extra)
+    if args_doc:
+        update_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
+
+    params_list = [
+        inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx),
+        inspect.Parameter(id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+    ]
+    for f in fields:
+        params_list.append(
+            inspect.Parameter(
+                f.name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+                annotation=f.type | None,
+            )
+        )
+    update_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    return update_fn
+
+
+def _create_delete_function(res: Resource):
+    """Create a delete function with proper type annotations."""
+    import inspect
+
+    path = res.path
+    id_param = res.id_param
+
+    async def delete_fn(ctx: Ctx, **kwargs: Any) -> dict:
+        return await check_api_delete(ctx, f"{path}/{kwargs[id_param]}")
+
+    delete_fn.__doc__ = _make_delete_docstring(res)
+    args_doc = f"    {id_param}: {res.id_description}"
+    delete_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
+
+    params_list = [
+        inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx),
+        inspect.Parameter(id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+    ]
+    delete_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    return delete_fn

--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -64,12 +64,40 @@ _WRITE_KEYWORDS = (
     "request_tax_",
 )
 
+# Tools that trigger irreversible real-world effects (money movement, deletion).
+# These require explicit confirmation when CHECK_CONFIRM_DESTRUCTIVE is enabled.
+_DESTRUCTIVE_PREFIXES = (
+    "approve_",
+    "delete_",
+    "bulk_delete_",
+    "simulate_",
+    "refund_",
+    "cancel_",
+)
+_DESTRUCTIVE_EXACT = frozenset(
+    {
+        "start_implementation",
+        "cancel_implementation",
+    }
+)
+
 
 def is_write_tool(name: str) -> bool:
     """Return True if the tool name matches a write/mutating pattern."""
     return any(name.startswith(p) for p in _WRITE_PREFIXES) or any(
         name.startswith(k) for k in _WRITE_KEYWORDS
     )
+
+
+def is_destructive_tool(name: str) -> bool:
+    """Return True if the tool triggers irreversible effects (money movement, deletion).
+
+    These tools should require explicit confirmation when the confirmation
+    tier is enabled.
+    """
+    if name in _DESTRUCTIVE_EXACT:
+        return True
+    return any(name.startswith(p) for p in _DESTRUCTIVE_PREFIXES)
 
 
 def _parse_comma_set(value: str | None) -> frozenset[str] | None:
@@ -100,6 +128,7 @@ class ToolFilter:
     tools: frozenset[str] | None = None
     exclude_tools: frozenset[str] = frozenset()
     read_only: bool = False
+    confirm_destructive: bool = False
 
     def __post_init__(self) -> None:
         if self.toolsets is not None:
@@ -130,6 +159,10 @@ class ToolFilter:
 
         return True
 
+    def requires_confirmation(self, tool_name: str) -> bool:
+        """Return True if this tool requires explicit confirmation before execution."""
+        return self.confirm_destructive and is_destructive_tool(tool_name)
+
     @classmethod
     def from_env(cls) -> ToolFilter:
         """Build a ToolFilter from environment variables."""
@@ -139,6 +172,9 @@ class ToolFilter:
             exclude_tools=_parse_comma_set(os.environ.get("CHECK_EXCLUDE_TOOLS"))
             or frozenset(),
             read_only=_parse_bool(os.environ.get("CHECK_READ_ONLY")),
+            confirm_destructive=_parse_bool(
+                os.environ.get("CHECK_CONFIRM_DESTRUCTIVE")
+            ),
         )
 
     @classmethod
@@ -156,4 +192,5 @@ class ToolFilter:
             tools=_parse_comma_set(get("x-mcp-tools")),
             exclude_tools=_parse_comma_set(get("x-mcp-exclude-tools")) or frozenset(),
             read_only=_parse_bool(get("x-mcp-readonly")),
+            confirm_destructive=_parse_bool(get("x-mcp-confirm-destructive")),
         )

--- a/src/mcp_server_check/tool_index.py
+++ b/src/mcp_server_check/tool_index.py
@@ -99,7 +99,7 @@ _TOOLSET_DESCRIPTIONS: dict[str, str] = {
     "platform": "Platform-level tools: notifications, communications, usage, integrations, accounting, setups, and requirements.",
     "tax": "Manage company and employee tax parameters, elections, filings, exemptions, and tax statements.",
     "webhooks": "Create, update, delete, and test webhook configurations.",
-    "workflows": "Composite tools that combine multiple API calls: company overview, employee snapshot, payment diagnostics.",
+    "workflows": "Composite tools that combine multiple API calls: company overview, employee snapshot, contractor snapshot, payroll details, payment diagnostics, tax overview, onboarding status.",
     "workplaces": "Create, update, and view company workplace locations.",
 }
 

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -1,139 +1,51 @@
-"""Compensation tools for the Check API (pay schedules, benefits, deductions, etc.)."""
+"""Compensation tools for the Check API (pay schedules, benefits, deductions, etc.).
+
+Uses the declarative tool factory for standard CRUD operations,
+with manual functions for non-standard endpoints.
+"""
 
 from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from mcp_server_check.helpers import (
-    Ctx,
-    check_api_delete,
-    check_api_get,
-    check_api_list,
-    check_api_patch,
-    check_api_post,
+from mcp_server_check.helpers import Ctx, check_api_get, check_api_post
+from mcp_server_check.tool_factory import Field, Resource, generate_tools
+
+# ---------------------------------------------------------------------------
+# Pay Schedules
+# ---------------------------------------------------------------------------
+
+_pay_schedules = Resource(
+    name="pay_schedules",
+    path="/pay_schedules",
+    id_param="pay_schedule_id",
+    id_description="The Check pay schedule ID.",
+    description="pay schedules",
+    list_filters=["company"],
+    fields=[
+        Field("company", str, required_for="create", doc="The Check company ID."),
+        Field("pay_frequency", str, required_for="create",
+              doc='Pay frequency — "weekly", "biweekly", "semimonthly", "monthly", "quarterly", or "annually".'),
+        Field("first_payday", str, required_for="create",
+              doc="Payday date of the first payroll on this schedule (YYYY-MM-DD)."),
+        Field("first_period_end", str, required_for="create",
+              doc="Period end date of the first payroll on this schedule (YYYY-MM-DD)."),
+        Field("second_payday", str,
+              doc="Second payday date (semimonthly only; must be between one day and one month after first_payday)."),
+        Field("name", str, doc="Human-readable name for the pay schedule."),
+        Field("metadata", str, doc="Additional JSON metadata string."),
+    ],
 )
+_pay_schedule_tools = generate_tools(_pay_schedules)
+
+list_pay_schedules = _pay_schedule_tools.list_fn
+get_pay_schedule = _pay_schedule_tools.get_fn
+create_pay_schedule = _pay_schedule_tools.create_fn
+update_pay_schedule = _pay_schedule_tools.update_fn
+delete_pay_schedule = _pay_schedule_tools.delete_fn
 
 
-# --- Pay Schedules ---
-
-
-async def list_pay_schedules(
-    ctx: Ctx,
-    company: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List pay schedules, optionally filtered by company.
-
-    Args:
-        company: Filter to pay schedules belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    params: dict = {}
-    if company is not None:
-        params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
-    if cursor:
-        params["cursor"] = cursor
-    return await check_api_list(ctx, "/pay_schedules", params=params or None)
-
-
-async def get_pay_schedule(ctx: Ctx, pay_schedule_id: str) -> dict:
-    """Get details for a specific pay schedule.
-
-    Args:
-        pay_schedule_id: The Check pay schedule ID.
-    """
-    return await check_api_get(ctx, f"/pay_schedules/{pay_schedule_id}")
-
-
-async def create_pay_schedule(
-    ctx: Ctx,
-    company: str,
-    pay_frequency: str,
-    first_payday: str,
-    first_period_end: str,
-    second_payday: str | None = None,
-    name: str | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Create a new pay schedule.
-
-    Args:
-        company: The Check company ID.
-        pay_frequency: Pay frequency — "weekly", "biweekly", "semimonthly", "monthly",
-            "quarterly", or "annually".
-        first_payday: Payday date of the first payroll on this schedule (YYYY-MM-DD).
-        first_period_end: Period end date of the first payroll on this schedule (YYYY-MM-DD).
-        second_payday: Second payday date (semimonthly only; must be between one day and
-            one month after first_payday).
-        name: Human-readable name for the pay schedule.
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {
-        "company": company,
-        "pay_frequency": pay_frequency,
-        "first_payday": first_payday,
-        "first_period_end": first_period_end,
-    }
-    if second_payday is not None:
-        body["second_payday"] = second_payday
-    if name is not None:
-        body["name"] = name
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_post(ctx, "/pay_schedules", data=body)
-
-
-async def update_pay_schedule(
-    ctx: Ctx,
-    pay_schedule_id: str,
-    pay_frequency: str | None = None,
-    first_payday: str | None = None,
-    first_period_end: str | None = None,
-    second_payday: str | None = None,
-    name: str | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Update a pay schedule.
-
-    Args:
-        pay_schedule_id: The Check pay schedule ID.
-        pay_frequency: Pay frequency — "weekly", "biweekly", "semimonthly", "monthly",
-            "quarterly", or "annually".
-        first_payday: Payday date of the first payroll on this schedule (YYYY-MM-DD).
-        first_period_end: Period end date of the first payroll (YYYY-MM-DD).
-        second_payday: Second payday date (semimonthly only).
-        name: Human-readable name for the pay schedule.
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {}
-    if pay_frequency is not None:
-        body["pay_frequency"] = pay_frequency
-    if first_payday is not None:
-        body["first_payday"] = first_payday
-    if first_period_end is not None:
-        body["first_period_end"] = first_period_end
-    if second_payday is not None:
-        body["second_payday"] = second_payday
-    if name is not None:
-        body["name"] = name
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_patch(ctx, f"/pay_schedules/{pay_schedule_id}", data=body)
-
-
-async def delete_pay_schedule(ctx: Ctx, pay_schedule_id: str) -> dict:
-    """Delete a pay schedule.
-
-    Args:
-        pay_schedule_id: The Check pay schedule ID.
-    """
-    return await check_api_delete(ctx, f"/pay_schedules/{pay_schedule_id}")
-
-
+# Custom: get_pay_schedule_paydays is not a standard CRUD endpoint
 async def get_pay_schedule_paydays(
     ctx: Ctx,
     pay_schedule_id: str,
@@ -157,742 +69,208 @@ async def get_pay_schedule_paydays(
     )
 
 
-# --- Benefits ---
-
-
-async def list_benefits(
-    ctx: Ctx,
-    company: str | None = None,
-    employee: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List employee benefits, optionally filtered by company or employee.
-
-    Args:
-        company: Filter to benefits belonging to this Check company ID (e.g. "com_xxxxx").
-        employee: Filter to benefits for this Check employee ID (e.g. "emp_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    params: dict = {}
-    if company is not None:
-        params["company"] = company
-    if employee is not None:
-        params["employee"] = employee
-    if limit is not None:
-        params["limit"] = limit
-    if cursor:
-        params["cursor"] = cursor
-    return await check_api_list(ctx, "/benefits", params=params or None)
-
-
-async def get_benefit(ctx: Ctx, benefit_id: str) -> dict:
-    """Get details for a specific benefit.
-
-    Args:
-        benefit_id: The Check benefit ID.
-    """
-    return await check_api_get(ctx, f"/benefits/{benefit_id}")
-
-
-async def create_benefit(
-    ctx: Ctx,
-    employee: str,
-    company_benefit: str,
-    benefit: str | None = None,
-    period: str | None = None,
-    description: str | None = None,
-    company_contribution_amount: str | None = None,
-    company_contribution_percent: float | None = None,
-    company_period_amount: str | None = None,
-    employee_contribution_amount: str | None = None,
-    employee_contribution_percent: float | None = None,
-    employee_period_amount: str | None = None,
-    effective_start: str | None = None,
-    effective_end: str | None = None,
-    hsa_contribution_limit: str | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Create a new employee benefit.
-
-    Args:
-        employee: The Check employee ID.
-        company_benefit: The Check company benefit ID.
-        benefit: Type of supported benefit.
-        period: Period over which a period amount is distributed — "monthly" or null.
-        description: Description to distinguish the benefit within a plan (max 255 chars).
-        company_contribution_amount: Company contribution amount per payroll.
-        company_contribution_percent: Company contribution as percent of gross pay (0-100).
-        company_period_amount: Company contribution over the period.
-        employee_contribution_amount: Employee contribution amount per payroll.
-        employee_contribution_percent: Employee contribution as percent of gross pay (0-100).
-        employee_period_amount: Employee contribution over the period.
-        effective_start: Start date for the benefit (YYYY-MM-DD).
-        effective_end: End date for the benefit (YYYY-MM-DD).
-        hsa_contribution_limit: HSA contribution limit.
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {"employee": employee, "company_benefit": company_benefit}
-    if benefit is not None:
-        body["benefit"] = benefit
-    if period is not None:
-        body["period"] = period
-    if description is not None:
-        body["description"] = description
-    if company_contribution_amount is not None:
-        body["company_contribution_amount"] = company_contribution_amount
-    if company_contribution_percent is not None:
-        body["company_contribution_percent"] = company_contribution_percent
-    if company_period_amount is not None:
-        body["company_period_amount"] = company_period_amount
-    if employee_contribution_amount is not None:
-        body["employee_contribution_amount"] = employee_contribution_amount
-    if employee_contribution_percent is not None:
-        body["employee_contribution_percent"] = employee_contribution_percent
-    if employee_period_amount is not None:
-        body["employee_period_amount"] = employee_period_amount
-    if effective_start is not None:
-        body["effective_start"] = effective_start
-    if effective_end is not None:
-        body["effective_end"] = effective_end
-    if hsa_contribution_limit is not None:
-        body["hsa_contribution_limit"] = hsa_contribution_limit
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_post(ctx, "/benefits", data=body)
-
-
-async def update_benefit(
-    ctx: Ctx,
-    benefit_id: str,
-    benefit: str | None = None,
-    period: str | None = None,
-    description: str | None = None,
-    company_contribution_amount: str | None = None,
-    company_contribution_percent: float | None = None,
-    company_period_amount: str | None = None,
-    employee_contribution_amount: str | None = None,
-    employee_contribution_percent: float | None = None,
-    employee_period_amount: str | None = None,
-    effective_start: str | None = None,
-    effective_end: str | None = None,
-    hsa_contribution_limit: str | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Update a benefit.
-
-    Args:
-        benefit_id: The Check benefit ID.
-        benefit: Type of supported benefit.
-        period: Period over which a period amount is distributed — "monthly" or null.
-        description: Description to distinguish the benefit (max 255 chars).
-        company_contribution_amount: Company contribution amount per payroll.
-        company_contribution_percent: Company contribution as percent of gross pay (0-100).
-        company_period_amount: Company contribution over the period.
-        employee_contribution_amount: Employee contribution amount per payroll.
-        employee_contribution_percent: Employee contribution as percent of gross pay (0-100).
-        employee_period_amount: Employee contribution over the period.
-        effective_start: Start date for the benefit (YYYY-MM-DD).
-        effective_end: End date for the benefit (YYYY-MM-DD).
-        hsa_contribution_limit: HSA contribution limit.
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {}
-    if benefit is not None:
-        body["benefit"] = benefit
-    if period is not None:
-        body["period"] = period
-    if description is not None:
-        body["description"] = description
-    if company_contribution_amount is not None:
-        body["company_contribution_amount"] = company_contribution_amount
-    if company_contribution_percent is not None:
-        body["company_contribution_percent"] = company_contribution_percent
-    if company_period_amount is not None:
-        body["company_period_amount"] = company_period_amount
-    if employee_contribution_amount is not None:
-        body["employee_contribution_amount"] = employee_contribution_amount
-    if employee_contribution_percent is not None:
-        body["employee_contribution_percent"] = employee_contribution_percent
-    if employee_period_amount is not None:
-        body["employee_period_amount"] = employee_period_amount
-    if effective_start is not None:
-        body["effective_start"] = effective_start
-    if effective_end is not None:
-        body["effective_end"] = effective_end
-    if hsa_contribution_limit is not None:
-        body["hsa_contribution_limit"] = hsa_contribution_limit
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_patch(ctx, f"/benefits/{benefit_id}", data=body)
-
-
-async def delete_benefit(ctx: Ctx, benefit_id: str) -> dict:
-    """Delete a benefit.
-
-    Args:
-        benefit_id: The Check benefit ID.
-    """
-    return await check_api_delete(ctx, f"/benefits/{benefit_id}")
-
-
-# --- Post-Tax Deductions ---
-
-
-async def list_post_tax_deductions(
-    ctx: Ctx,
-    company: str | None = None,
-    employee: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List post-tax deductions, optionally filtered by company or employee.
-
-    Args:
-        company: Filter to post-tax deductions belonging to this Check company ID (e.g. "com_xxxxx").
-        employee: Filter to post-tax deductions for this Check employee ID (e.g. "emp_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    params: dict = {}
-    if company is not None:
-        params["company"] = company
-    if employee is not None:
-        params["employee"] = employee
-    if limit is not None:
-        params["limit"] = limit
-    if cursor:
-        params["cursor"] = cursor
-    return await check_api_list(ctx, "/post_tax_deductions", params=params or None)
-
-
-async def get_post_tax_deduction(ctx: Ctx, deduction_id: str) -> dict:
-    """Get details for a specific post-tax deduction.
-
-    Args:
-        deduction_id: The Check post-tax deduction ID.
-    """
-    return await check_api_get(ctx, f"/post_tax_deductions/{deduction_id}")
-
-
-async def create_post_tax_deduction(
-    ctx: Ctx,
-    employee: str,
-    type: str,
-    description: str,
-    effective_start: str,
-    effective_end: str | None = None,
-    miscellaneous: dict | None = None,
-    child_support: dict | None = None,
-    miscellaneous_garnishment: dict | None = None,
-    metadata: str | None = None,
-    managed: bool | None = None,
-) -> dict:
-    """Create a new post-tax deduction.
-
-    Args:
-        employee: The Check employee ID.
-        type: Deduction type — "miscellaneous", "child_support", or
-            "miscellaneous_garnishment".
-        description: Description of the deduction (max 255 chars).
-        effective_start: Start date for the deduction (YYYY-MM-DD).
-        effective_end: End date for the deduction (YYYY-MM-DD).
-        miscellaneous: Config dict for miscellaneous type with keys: total_amount,
-            amount, percent, annual_limit.
-        child_support: Config dict for child_support type with keys: external_id,
-            agency, fips_code, issue_date, amount, max_percent.
-        miscellaneous_garnishment: Config dict for miscellaneous_garnishment type with
-            keys: amount, percent, total_amount, annual_limit, priority, max_percent.
-        metadata: Additional JSON metadata string.
-        managed: Whether the deduction should be remitted by Check (child support only).
-    """
-    body: dict = {
-        "employee": employee,
-        "type": type,
-        "description": description,
-        "effective_start": effective_start,
-    }
-    if effective_end is not None:
-        body["effective_end"] = effective_end
-    if miscellaneous is not None:
-        body["miscellaneous"] = miscellaneous
-    if child_support is not None:
-        body["child_support"] = child_support
-    if miscellaneous_garnishment is not None:
-        body["miscellaneous_garnishment"] = miscellaneous_garnishment
-    if metadata is not None:
-        body["metadata"] = metadata
-    if managed is not None:
-        body["managed"] = managed
-    return await check_api_post(ctx, "/post_tax_deductions", data=body)
-
-
-async def update_post_tax_deduction(
-    ctx: Ctx,
-    deduction_id: str,
-    description: str | None = None,
-    effective_start: str | None = None,
-    effective_end: str | None = None,
-    miscellaneous: dict | None = None,
-    child_support: dict | None = None,
-    miscellaneous_garnishment: dict | None = None,
-    metadata: str | None = None,
-    managed: bool | None = None,
-) -> dict:
-    """Update a post-tax deduction.
-
-    Args:
-        deduction_id: The Check post-tax deduction ID.
-        description: Description of the deduction (max 255 chars).
-        effective_start: Start date for the deduction (YYYY-MM-DD).
-        effective_end: End date for the deduction (YYYY-MM-DD).
-        miscellaneous: Config dict for miscellaneous type (see create_post_tax_deduction).
-        child_support: Config dict for child_support type (see create_post_tax_deduction).
-        miscellaneous_garnishment: Config dict for miscellaneous_garnishment type
-            (see create_post_tax_deduction).
-        metadata: Additional JSON metadata string.
-        managed: Whether the deduction should be remitted by Check (child support only).
-    """
-    body: dict = {}
-    if description is not None:
-        body["description"] = description
-    if effective_start is not None:
-        body["effective_start"] = effective_start
-    if effective_end is not None:
-        body["effective_end"] = effective_end
-    if miscellaneous is not None:
-        body["miscellaneous"] = miscellaneous
-    if child_support is not None:
-        body["child_support"] = child_support
-    if miscellaneous_garnishment is not None:
-        body["miscellaneous_garnishment"] = miscellaneous_garnishment
-    if metadata is not None:
-        body["metadata"] = metadata
-    if managed is not None:
-        body["managed"] = managed
-    return await check_api_patch(ctx, f"/post_tax_deductions/{deduction_id}", data=body)
-
-
-async def delete_post_tax_deduction(ctx: Ctx, deduction_id: str) -> dict:
-    """Delete a post-tax deduction.
-
-    Args:
-        deduction_id: The Check post-tax deduction ID.
-    """
-    return await check_api_delete(ctx, f"/post_tax_deductions/{deduction_id}")
-
-
-# --- Company Benefits ---
-
-
-async def list_company_benefits(
-    ctx: Ctx,
-    company: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List company-level benefits, optionally filtered by company.
-
-    Args:
-        company: Filter to company benefits belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    params: dict = {}
-    if company is not None:
-        params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
-    if cursor:
-        params["cursor"] = cursor
-    return await check_api_list(ctx, "/company_benefits", params=params or None)
-
-
-async def get_company_benefit(ctx: Ctx, company_benefit_id: str) -> dict:
-    """Get details for a specific company benefit.
-
-    Args:
-        company_benefit_id: The Check company benefit ID.
-    """
-    return await check_api_get(ctx, f"/company_benefits/{company_benefit_id}")
-
-
-async def create_company_benefit(
-    ctx: Ctx,
-    company: str,
-    benefit: str,
-    description: str,
-    period: str | None = None,
-    company_contribution_amount: str | None = None,
-    company_contribution_percent: str | None = None,
-    company_period_amount: str | None = None,
-    employee_contribution_amount: str | None = None,
-    employee_contribution_percent: str | None = None,
-    employee_period_amount: str | None = None,
-    effective_start: str | None = None,
-    effective_end: str | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Create a new company benefit.
-
-    Args:
-        company: The Check company ID.
-        benefit: Type of supported benefit.
-        description: Description to distinguish the benefit (max 255 chars).
-        period: Period over which a period amount is distributed — "monthly" or null.
-        company_contribution_amount: Default company contribution per payroll.
-        company_contribution_percent: Default company contribution as percent of gross (0-100).
-        company_period_amount: Default company contribution over the period.
-        employee_contribution_amount: Default employee contribution per payroll.
-        employee_contribution_percent: Default employee contribution as percent of gross (0-100).
-        employee_period_amount: Default employee contribution over the period.
-        effective_start: Start date for the benefit (YYYY-MM-DD).
-        effective_end: End date for the benefit (YYYY-MM-DD).
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {
-        "company": company,
-        "benefit": benefit,
-        "description": description,
-    }
-    if period is not None:
-        body["period"] = period
-    if company_contribution_amount is not None:
-        body["company_contribution_amount"] = company_contribution_amount
-    if company_contribution_percent is not None:
-        body["company_contribution_percent"] = company_contribution_percent
-    if company_period_amount is not None:
-        body["company_period_amount"] = company_period_amount
-    if employee_contribution_amount is not None:
-        body["employee_contribution_amount"] = employee_contribution_amount
-    if employee_contribution_percent is not None:
-        body["employee_contribution_percent"] = employee_contribution_percent
-    if employee_period_amount is not None:
-        body["employee_period_amount"] = employee_period_amount
-    if effective_start is not None:
-        body["effective_start"] = effective_start
-    if effective_end is not None:
-        body["effective_end"] = effective_end
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_post(ctx, "/company_benefits", data=body)
-
-
-async def update_company_benefit(
-    ctx: Ctx,
-    company_benefit_id: str,
-    benefit: str | None = None,
-    description: str | None = None,
-    period: str | None = None,
-    company_contribution_amount: str | None = None,
-    company_contribution_percent: str | None = None,
-    company_period_amount: str | None = None,
-    employee_contribution_amount: str | None = None,
-    employee_contribution_percent: str | None = None,
-    employee_period_amount: str | None = None,
-    effective_start: str | None = None,
-    effective_end: str | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Update a company benefit.
-
-    Args:
-        company_benefit_id: The Check company benefit ID.
-        benefit: Type of supported benefit.
-        description: Description to distinguish the benefit (max 255 chars).
-        period: Period over which a period amount is distributed — "monthly" or null.
-        company_contribution_amount: Default company contribution per payroll.
-        company_contribution_percent: Default company contribution as percent of gross (0-100).
-        company_period_amount: Default company contribution over the period.
-        employee_contribution_amount: Default employee contribution per payroll.
-        employee_contribution_percent: Default employee contribution as percent of gross (0-100).
-        employee_period_amount: Default employee contribution over the period.
-        effective_start: Start date for the benefit (YYYY-MM-DD).
-        effective_end: End date for the benefit (YYYY-MM-DD).
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {}
-    if benefit is not None:
-        body["benefit"] = benefit
-    if description is not None:
-        body["description"] = description
-    if period is not None:
-        body["period"] = period
-    if company_contribution_amount is not None:
-        body["company_contribution_amount"] = company_contribution_amount
-    if company_contribution_percent is not None:
-        body["company_contribution_percent"] = company_contribution_percent
-    if company_period_amount is not None:
-        body["company_period_amount"] = company_period_amount
-    if employee_contribution_amount is not None:
-        body["employee_contribution_amount"] = employee_contribution_amount
-    if employee_contribution_percent is not None:
-        body["employee_contribution_percent"] = employee_contribution_percent
-    if employee_period_amount is not None:
-        body["employee_period_amount"] = employee_period_amount
-    if effective_start is not None:
-        body["effective_start"] = effective_start
-    if effective_end is not None:
-        body["effective_end"] = effective_end
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_patch(
-        ctx, f"/company_benefits/{company_benefit_id}", data=body
-    )
-
-
-async def delete_company_benefit(ctx: Ctx, company_benefit_id: str) -> dict:
-    """Delete a company benefit.
-
-    Args:
-        company_benefit_id: The Check company benefit ID.
-    """
-    return await check_api_delete(ctx, f"/company_benefits/{company_benefit_id}")
-
-
-# --- Earning Rates ---
-
-
-async def list_earning_rates(
-    ctx: Ctx,
-    company: str | None = None,
-    employee: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List earning rates, optionally filtered by company or employee.
-
-    Args:
-        company: Filter to earning rates belonging to this Check company ID (e.g. "com_xxxxx").
-        employee: Filter to earning rates for this Check employee ID (e.g. "emp_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    params: dict = {}
-    if company is not None:
-        params["company"] = company
-    if employee is not None:
-        params["employee"] = employee
-    if limit is not None:
-        params["limit"] = limit
-    if cursor:
-        params["cursor"] = cursor
-    return await check_api_list(ctx, "/earning_rates", params=params or None)
-
-
-async def get_earning_rate(ctx: Ctx, earning_rate_id: str) -> dict:
-    """Get details for a specific earning rate.
-
-    Args:
-        earning_rate_id: The Check earning rate ID.
-    """
-    return await check_api_get(ctx, f"/earning_rates/{earning_rate_id}")
-
-
-async def create_earning_rate(
-    ctx: Ctx,
-    employee: str,
-    amount: str,
-    period: str,
-    name: str | None = None,
-    workweek_hours: float | None = None,
-) -> dict:
-    """Create a new earning rate.
-
-    Args:
-        employee: The Check employee ID.
-        amount: The earning rate amount (e.g. "25.00" or "52000.00").
-        period: Period type — "hourly", "annually", or "piece".
-        name: Name of the earning rate.
-        workweek_hours: Hours per week the employee works. Default: 40.
-    """
-    body: dict = {"employee": employee, "amount": amount, "period": period}
-    if name is not None:
-        body["name"] = name
-    if workweek_hours is not None:
-        body["workweek_hours"] = workweek_hours
-    return await check_api_post(ctx, "/earning_rates", data=body)
-
-
-async def update_earning_rate(
-    ctx: Ctx,
-    earning_rate_id: str,
-    name: str | None = None,
-    active: bool | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Update an earning rate.
-
-    Args:
-        earning_rate_id: The Check earning rate ID.
-        name: Name of the earning rate.
-        active: Whether the earning rate is active.
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {}
-    if name is not None:
-        body["name"] = name
-    if active is not None:
-        body["active"] = active
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_patch(ctx, f"/earning_rates/{earning_rate_id}", data=body)
-
-
-# --- Earning Codes ---
-
-
-async def list_earning_codes(
-    ctx: Ctx,
-    company: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List earning codes, optionally filtered by company.
-
-    Args:
-        company: Filter to earning codes belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    params: dict = {}
-    if company is not None:
-        params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
-    if cursor:
-        params["cursor"] = cursor
-    return await check_api_list(ctx, "/earning_codes", params=params or None)
-
-
-async def get_earning_code(ctx: Ctx, earning_code_id: str) -> dict:
-    """Get details for a specific earning code.
-
-    Args:
-        earning_code_id: The Check earning code ID.
-    """
-    return await check_api_get(ctx, f"/earning_codes/{earning_code_id}")
-
-
-async def create_earning_code(
-    ctx: Ctx,
-    company: str,
-    name: str,
-    type: str,
-    active: bool | None = None,
-    calculation_overrides: dict | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Create a new earning code.
-
-    Args:
-        company: The Check company ID.
-        name: Name of the earning code.
-        type: Type of earning code.
-        active: Whether the code is active (true for ongoing, false for historical).
-            Default: true.
-        calculation_overrides: Tax calculation overrides dict. May include
-            "wa_risk_class_code" (format "####-##" for WA L&I).
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {"company": company, "name": name, "type": type}
-    if active is not None:
-        body["active"] = active
-    if calculation_overrides is not None:
-        body["calculation_overrides"] = calculation_overrides
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_post(ctx, "/earning_codes", data=body)
-
-
-async def update_earning_code(
-    ctx: Ctx,
-    earning_code_id: str,
-    active: bool | None = None,
-    metadata: str | None = None,
-) -> dict:
-    """Update an earning code.
-
-    Args:
-        earning_code_id: The Check earning code ID.
-        active: Whether the earning code is active.
-        metadata: Additional JSON metadata string.
-    """
-    body: dict = {}
-    if active is not None:
-        body["active"] = active
-    if metadata is not None:
-        body["metadata"] = metadata
-    return await check_api_patch(ctx, f"/earning_codes/{earning_code_id}", data=body)
-
-
-# --- Net Pay Splits ---
-
-
-async def list_net_pay_splits(
-    ctx: Ctx,
-    company: str | None = None,
-    employee: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List net pay splits, optionally filtered by company or employee.
-
-    Args:
-        company: Filter to net pay splits belonging to this Check company ID (e.g. "com_xxxxx").
-        employee: Filter to net pay splits for this Check employee ID (e.g. "emp_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    params: dict = {}
-    if company is not None:
-        params["company"] = company
-    if employee is not None:
-        params["employee"] = employee
-    if limit is not None:
-        params["limit"] = limit
-    if cursor:
-        params["cursor"] = cursor
-    return await check_api_list(ctx, "/net_pay_splits", params=params or None)
-
-
-async def get_net_pay_split(ctx: Ctx, net_pay_split_id: str) -> dict:
-    """Get details for a specific net pay split.
-
-    Args:
-        net_pay_split_id: The Check net pay split ID.
-    """
-    return await check_api_get(ctx, f"/net_pay_splits/{net_pay_split_id}")
-
-
-async def create_net_pay_split(
-    ctx: Ctx,
-    splits: list[dict],
-    employee: str | None = None,
-    contractor: str | None = None,
-    is_default: bool | None = None,
-) -> dict:
-    """Create a new net pay split.
-
-    Provide either employee or contractor to indicate who owns the split.
-
-    Args:
-        splits: Prioritized list of split dicts. Each may include "bank_account",
-            "priority" (int, default 1), "amount" (max amount for this account),
-            "percentage" (percent of net pay).
-        employee: The Check employee ID.
-        contractor: The Check contractor ID.
-        is_default: Whether this is the default net pay split. Default: false.
-    """
-    body: dict = {"splits": splits}
-    if employee is not None:
-        body["employee"] = employee
-    if contractor is not None:
-        body["contractor"] = contractor
-    if is_default is not None:
-        body["is_default"] = is_default
-    return await check_api_post(ctx, "/net_pay_splits", data=body)
+# ---------------------------------------------------------------------------
+# Benefits (employee-level)
+# ---------------------------------------------------------------------------
+
+_benefits = Resource(
+    name="benefits",
+    path="/benefits",
+    id_param="benefit_id",
+    id_description="The Check benefit ID.",
+    description="employee benefits",
+    list_filters=["company", "employee"],
+    fields=[
+        Field("employee", str, required_for="create", doc="The Check employee ID."),
+        Field("company_benefit", str, required_for="create", doc="The Check company benefit ID.", create_only=True),
+        Field("benefit", str, doc="Type of supported benefit."),
+        Field("period", str, doc='Period over which a period amount is distributed — "monthly" or null.'),
+        Field("description", str, doc="Description to distinguish the benefit within a plan (max 255 chars)."),
+        Field("company_contribution_amount", str, doc="Company contribution amount per payroll."),
+        Field("company_contribution_percent", float, doc="Company contribution as percent of gross pay (0-100)."),
+        Field("company_period_amount", str, doc="Company contribution over the period."),
+        Field("employee_contribution_amount", str, doc="Employee contribution amount per payroll."),
+        Field("employee_contribution_percent", float, doc="Employee contribution as percent of gross pay (0-100)."),
+        Field("employee_period_amount", str, doc="Employee contribution over the period."),
+        Field("effective_start", str, doc="Start date for the benefit (YYYY-MM-DD)."),
+        Field("effective_end", str, doc="End date for the benefit (YYYY-MM-DD)."),
+        Field("hsa_contribution_limit", str, doc="HSA contribution limit."),
+        Field("metadata", str, doc="Additional JSON metadata string."),
+    ],
+)
+_benefit_tools = generate_tools(_benefits)
+
+list_benefits = _benefit_tools.list_fn
+get_benefit = _benefit_tools.get_fn
+create_benefit = _benefit_tools.create_fn
+update_benefit = _benefit_tools.update_fn
+delete_benefit = _benefit_tools.delete_fn
+
+
+# ---------------------------------------------------------------------------
+# Post-Tax Deductions
+# ---------------------------------------------------------------------------
+
+_post_tax_deductions = Resource(
+    name="post_tax_deductions",
+    path="/post_tax_deductions",
+    id_param="deduction_id",
+    id_description="The Check post-tax deduction ID.",
+    description="post-tax deductions",
+    list_filters=["company", "employee"],
+    fields=[
+        Field("employee", str, required_for="create", doc="The Check employee ID."),
+        Field("type", str, required_for="create",
+              doc='Deduction type — "miscellaneous", "child_support", or "miscellaneous_garnishment".', create_only=True),
+        Field("description", str, required_for="create", doc="Description of the deduction (max 255 chars)."),
+        Field("effective_start", str, required_for="create", doc="Start date for the deduction (YYYY-MM-DD)."),
+        Field("effective_end", str, doc="End date for the deduction (YYYY-MM-DD)."),
+        Field("miscellaneous", dict,
+              doc="Config dict for miscellaneous type with keys: total_amount, amount, percent, annual_limit."),
+        Field("child_support", dict,
+              doc="Config dict for child_support type with keys: external_id, agency, fips_code, issue_date, amount, max_percent."),
+        Field("miscellaneous_garnishment", dict,
+              doc="Config dict for miscellaneous_garnishment type with keys: amount, percent, total_amount, annual_limit, priority, max_percent."),
+        Field("metadata", str, doc="Additional JSON metadata string."),
+        Field("managed", bool, doc="Whether the deduction should be remitted by Check (child support only)."),
+    ],
+)
+_post_tax_deduction_tools = generate_tools(_post_tax_deductions)
+
+list_post_tax_deductions = _post_tax_deduction_tools.list_fn
+get_post_tax_deduction = _post_tax_deduction_tools.get_fn
+create_post_tax_deduction = _post_tax_deduction_tools.create_fn
+update_post_tax_deduction = _post_tax_deduction_tools.update_fn
+delete_post_tax_deduction = _post_tax_deduction_tools.delete_fn
+
+
+# ---------------------------------------------------------------------------
+# Company Benefits
+# ---------------------------------------------------------------------------
+
+_company_benefits = Resource(
+    name="company_benefits",
+    path="/company_benefits",
+    id_param="company_benefit_id",
+    id_description="The Check company benefit ID.",
+    description="company-level benefits",
+    list_filters=["company"],
+    fields=[
+        Field("company", str, required_for="create", doc="The Check company ID.", create_only=True),
+        Field("benefit", str, required_for="create", doc="Type of supported benefit."),
+        Field("description", str, required_for="create", doc="Description to distinguish the benefit (max 255 chars)."),
+        Field("period", str, doc='Period over which a period amount is distributed — "monthly" or null.'),
+        Field("company_contribution_amount", str, doc="Default company contribution per payroll."),
+        Field("company_contribution_percent", str, doc="Default company contribution as percent of gross (0-100)."),
+        Field("company_period_amount", str, doc="Default company contribution over the period."),
+        Field("employee_contribution_amount", str, doc="Default employee contribution per payroll."),
+        Field("employee_contribution_percent", str, doc="Default employee contribution as percent of gross (0-100)."),
+        Field("employee_period_amount", str, doc="Default employee contribution over the period."),
+        Field("effective_start", str, doc="Start date for the benefit (YYYY-MM-DD)."),
+        Field("effective_end", str, doc="End date for the benefit (YYYY-MM-DD)."),
+        Field("metadata", str, doc="Additional JSON metadata string."),
+    ],
+)
+_company_benefit_tools = generate_tools(_company_benefits)
+
+list_company_benefits = _company_benefit_tools.list_fn
+get_company_benefit = _company_benefit_tools.get_fn
+create_company_benefit = _company_benefit_tools.create_fn
+update_company_benefit = _company_benefit_tools.update_fn
+delete_company_benefit = _company_benefit_tools.delete_fn
+
+
+# ---------------------------------------------------------------------------
+# Earning Rates
+# ---------------------------------------------------------------------------
+
+_earning_rates = Resource(
+    name="earning_rates",
+    path="/earning_rates",
+    id_param="earning_rate_id",
+    id_description="The Check earning rate ID.",
+    description="earning rates",
+    list_filters=["company", "employee"],
+    has_delete=False,
+    fields=[
+        Field("employee", str, required_for="create", doc="The Check employee ID.", create_only=True),
+        Field("amount", str, required_for="create", doc='The earning rate amount (e.g. "25.00" or "52000.00").', create_only=True),
+        Field("period", str, required_for="create", doc='Period type — "hourly", "annually", or "piece".', create_only=True),
+        Field("name", str, doc="Name of the earning rate."),
+        Field("workweek_hours", float, doc="Hours per week the employee works. Default: 40.", create_only=True),
+        Field("active", bool, doc="Whether the earning rate is active.", update_only=True),
+        Field("metadata", str, doc="Additional JSON metadata string.", update_only=True),
+    ],
+)
+_earning_rate_tools = generate_tools(_earning_rates)
+
+list_earning_rates = _earning_rate_tools.list_fn
+get_earning_rate = _earning_rate_tools.get_fn
+create_earning_rate = _earning_rate_tools.create_fn
+update_earning_rate = _earning_rate_tools.update_fn
+
+
+# ---------------------------------------------------------------------------
+# Earning Codes
+# ---------------------------------------------------------------------------
+
+_earning_codes = Resource(
+    name="earning_codes",
+    path="/earning_codes",
+    id_param="earning_code_id",
+    id_description="The Check earning code ID.",
+    description="earning codes",
+    list_filters=["company"],
+    has_delete=False,
+    fields=[
+        Field("company", str, required_for="create", doc="The Check company ID.", create_only=True),
+        Field("name", str, required_for="create", doc="Name of the earning code.", create_only=True),
+        Field("type", str, required_for="create", doc="Type of earning code.", create_only=True),
+        Field("active", bool, doc="Whether the code is active."),
+        Field("calculation_overrides", dict,
+              doc='Tax calculation overrides dict. May include "wa_risk_class_code" (format "####-##" for WA L&I).',
+              create_only=True),
+        Field("metadata", str, doc="Additional JSON metadata string."),
+    ],
+)
+_earning_code_tools = generate_tools(_earning_codes)
+
+list_earning_codes = _earning_code_tools.list_fn
+get_earning_code = _earning_code_tools.get_fn
+create_earning_code = _earning_code_tools.create_fn
+update_earning_code = _earning_code_tools.update_fn
+
+
+# ---------------------------------------------------------------------------
+# Net Pay Splits
+# ---------------------------------------------------------------------------
+
+_net_pay_splits = Resource(
+    name="net_pay_splits",
+    path="/net_pay_splits",
+    id_param="net_pay_split_id",
+    id_description="The Check net pay split ID.",
+    description="net pay splits",
+    list_filters=["company", "employee"],
+    has_delete=False,
+    fields=[
+        Field("splits", list, required_for="create",
+              doc='Prioritized list of split dicts. Each may include "bank_account", "priority" (int), "amount", "percentage".'),
+        Field("employee", str, doc="The Check employee ID."),
+        Field("contractor", str, doc="The Check contractor ID."),
+        Field("is_default", bool, doc="Whether this is the default net pay split."),
+    ],
+)
+_net_pay_split_tools = generate_tools(_net_pay_splits)
+
+list_net_pay_splits = _net_pay_split_tools.list_fn
+get_net_pay_split = _net_pay_split_tools.get_fn
+create_net_pay_split = _net_pay_split_tools.create_fn
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:

--- a/src/mcp_server_check/tools/workflows.py
+++ b/src/mcp_server_check/tools/workflows.py
@@ -157,7 +157,227 @@ async def diagnose_payment(
     return result
 
 
+async def get_payroll_details(
+    ctx: Ctx,
+    payroll_id: str,
+    include_items: bool = True,
+    include_contractor_payments: bool = True,
+    item_limit: int = 50,
+) -> dict:
+    """Get a complete view of a payroll with its items and contractor payments.
+
+    Returns the payroll details along with all payroll items (employee pay stubs)
+    and contractor payments in a single call. This replaces 3 separate API calls.
+
+    Args:
+        payroll_id: The Check payroll ID (e.g. "prl_xxxxx").
+        include_items: Include payroll items / employee stubs (default true).
+        include_contractor_payments: Include contractor payments (default true).
+        item_limit: Max payroll items to return (default 50).
+    """
+    tasks: dict[str, asyncio.Task] = {}
+    async with asyncio.TaskGroup() as tg:
+        tasks["payroll"] = tg.create_task(
+            check_api_get(ctx, f"/payrolls/{payroll_id}")
+        )
+        if include_items:
+            tasks["items"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    "/payroll_items",
+                    params={"payroll": payroll_id, "limit": item_limit},
+                )
+            )
+        if include_contractor_payments:
+            tasks["contractor_payments"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    "/contractor_payments",
+                    params={"payroll": payroll_id},
+                )
+            )
+
+    result: dict = {"payroll": tasks["payroll"].result()}
+    if "items" in tasks:
+        result["payroll_items"] = tasks["items"].result()
+    if "contractor_payments" in tasks:
+        result["contractor_payments"] = tasks["contractor_payments"].result()
+    return result
+
+
+async def get_contractor_snapshot(
+    ctx: Ctx,
+    contractor_id: str,
+    include_payments: bool = True,
+    include_forms: bool = True,
+    payment_limit: int = 10,
+) -> dict:
+    """Get a comprehensive snapshot of a contractor in a single call.
+
+    Returns contractor details along with their recent payments and forms.
+    This replaces 3 separate API calls.
+
+    Args:
+        contractor_id: The Check contractor ID (e.g. "ctr_xxxxx").
+        include_payments: Include recent contractor payments (default true).
+        include_forms: Include contractor forms (default true).
+        payment_limit: Max payments to return (default 10).
+    """
+    tasks: dict[str, asyncio.Task] = {}
+    async with asyncio.TaskGroup() as tg:
+        tasks["contractor"] = tg.create_task(
+            check_api_get(ctx, f"/contractors/{contractor_id}")
+        )
+        if include_payments:
+            tasks["payments"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    f"/contractors/{contractor_id}/payments",
+                    params={"limit": payment_limit},
+                )
+            )
+        if include_forms:
+            tasks["forms"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    f"/contractors/{contractor_id}/forms",
+                )
+            )
+
+    result: dict = {"contractor": tasks["contractor"].result()}
+    if "payments" in tasks:
+        result["payments"] = tasks["payments"].result()
+    if "forms" in tasks:
+        result["forms"] = tasks["forms"].result()
+    return result
+
+
+async def get_company_tax_overview(
+    ctx: Ctx,
+    company_id: str,
+    include_elections: bool = True,
+    include_filings: bool = True,
+    filing_limit: int = 10,
+) -> dict:
+    """Get a comprehensive tax overview for a company in a single call.
+
+    Returns company tax parameters, tax elections, and recent tax filings.
+    This replaces 3 separate API calls.
+
+    Args:
+        company_id: The Check company ID (e.g. "com_xxxxx").
+        include_elections: Include tax elections (default true).
+        include_filings: Include recent tax filings (default true).
+        filing_limit: Max tax filings to return (default 10).
+    """
+    tasks: dict[str, asyncio.Task] = {}
+    async with asyncio.TaskGroup() as tg:
+        tasks["tax_params"] = tg.create_task(
+            check_api_get(ctx, f"/company_tax_params/{company_id}")
+        )
+        if include_elections:
+            tasks["elections"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    f"/companies/{company_id}/tax_elections",
+                )
+            )
+        if include_filings:
+            tasks["filings"] = tg.create_task(
+                check_api_list(
+                    ctx,
+                    "/tax_filings",
+                    params={"company": company_id, "limit": filing_limit},
+                )
+            )
+
+    result: dict = {"tax_params": tasks["tax_params"].result()}
+    if "elections" in tasks:
+        result["tax_elections"] = tasks["elections"].result()
+    if "filings" in tasks:
+        result["tax_filings"] = tasks["filings"].result()
+    return result
+
+
+async def get_onboarding_status(
+    ctx: Ctx,
+    company_id: str,
+) -> dict:
+    """Check the onboarding readiness of a company.
+
+    Returns the company details, its workplaces, employees, bank accounts,
+    and any outstanding setup requirements. Useful for determining what
+    steps remain before a company can run payroll. This replaces 5 separate
+    API calls.
+
+    Args:
+        company_id: The Check company ID (e.g. "com_xxxxx").
+    """
+    tasks: dict[str, asyncio.Task] = {}
+    async with asyncio.TaskGroup() as tg:
+        tasks["company"] = tg.create_task(
+            check_api_get(ctx, f"/companies/{company_id}")
+        )
+        tasks["workplaces"] = tg.create_task(
+            check_api_list(
+                ctx, "/workplaces", params={"company": company_id}
+            )
+        )
+        tasks["employees"] = tg.create_task(
+            check_api_list(
+                ctx, "/employees", params={"company": company_id, "limit": 5}
+            )
+        )
+        tasks["bank_accounts"] = tg.create_task(
+            check_api_list(
+                ctx, "/bank_accounts", params={"company": company_id}
+            )
+        )
+        tasks["requirements"] = tg.create_task(
+            check_api_list(
+                ctx, "/requirements", params={"company": company_id}
+            )
+        )
+
+    company = tasks["company"].result()
+    workplaces = tasks["workplaces"].result()
+    employees = tasks["employees"].result()
+    bank_accounts = tasks["bank_accounts"].result()
+    requirements = tasks["requirements"].result()
+
+    # Build a readiness summary
+    readiness: dict = {
+        "has_workplaces": bool(workplaces.get("results")),
+        "has_employees": bool(employees.get("results")),
+        "has_bank_accounts": bool(bank_accounts.get("results")),
+    }
+    # Count outstanding requirements
+    req_results = requirements.get("results", [])
+    outstanding = [r for r in req_results if r.get("status") != "met"]
+    readiness["outstanding_requirements"] = len(outstanding)
+    readiness["total_requirements"] = len(req_results)
+    readiness["ready"] = (
+        readiness["has_workplaces"]
+        and readiness["has_employees"]
+        and readiness["has_bank_accounts"]
+        and readiness["outstanding_requirements"] == 0
+    )
+
+    return {
+        "company": company,
+        "readiness": readiness,
+        "workplaces": workplaces,
+        "employees": employees,
+        "bank_accounts": bank_accounts,
+        "requirements": requirements,
+    }
+
+
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(get_company_overview)
     mcp.add_tool(get_employee_snapshot)
     mcp.add_tool(diagnose_payment)
+    mcp.add_tool(get_payroll_details)
+    mcp.add_tool(get_contractor_snapshot)
+    mcp.add_tool(get_company_tax_overview)
+    mcp.add_tool(get_onboarding_status)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -69,6 +69,7 @@ class TestFormatListResponse:
         result = _format_list_response(data)
         assert result == {
             "results": [{"id": "com_1"}, {"id": "com_2"}],
+            "result_count": 2,
             "next_cursor": "next123",
             "previous_cursor": "prev456",
         }
@@ -82,6 +83,7 @@ class TestFormatListResponse:
         result = _format_list_response(data)
         assert result == {
             "results": [{"id": "com_1"}],
+            "result_count": 1,
             "next_cursor": None,
             "previous_cursor": None,
         }
@@ -90,9 +92,41 @@ class TestFormatListResponse:
         result = _format_list_response({})
         assert result == {
             "results": [],
+            "result_count": 0,
             "next_cursor": None,
             "previous_cursor": None,
         }
+
+    def test_summarizes_known_entities(self):
+        """Summary mode strips non-key fields from recognized entity types."""
+        data = {
+            "next": None,
+            "previous": None,
+            "results": [
+                {"id": "com_1", "legal_name": "Acme", "metadata": {"key": "val"}, "created_at": "2025-01-01"},
+                {"id": "com_2", "legal_name": "Widget", "metadata": {}, "ein": "12-3456789"},
+            ],
+        }
+        result = _format_list_response(data, summarize=True)
+        # Summarized results should only contain summary fields
+        for r in result["results"]:
+            assert "metadata" not in r
+            assert "created_at" not in r
+            assert "ein" not in r
+            assert "id" in r
+            assert "legal_name" in r
+
+    def test_no_summarize_returns_full(self):
+        """When summarize=False, all fields are preserved."""
+        data = {
+            "next": None,
+            "previous": None,
+            "results": [
+                {"id": "com_1", "legal_name": "Acme", "metadata": {"key": "val"}},
+            ],
+        }
+        result = _format_list_response(data, summarize=False)
+        assert result["results"][0]["metadata"] == {"key": "val"}
 
 
 # --- Integration tests calling tool functions directly ---

--- a/tests/test_tool_factory.py
+++ b/tests/test_tool_factory.py
@@ -1,0 +1,271 @@
+"""Tests for the declarative tool factory."""
+
+from __future__ import annotations
+
+import inspect
+
+import httpx
+import pytest
+
+from mcp_server_check.tool_factory import (
+    Field,
+    Resource,
+    _build_body,
+    generate_tools,
+)
+
+
+# --- Unit tests for _build_body ---
+
+
+class TestBuildBody:
+    def test_create_includes_required_fields(self):
+        fields = [
+            Field("name", str, required_for="create"),
+            Field("email", str),
+        ]
+        body = _build_body(fields, {"name": "Alice", "email": None}, is_create=True)
+        assert body == {"name": "Alice"}
+
+    def test_create_includes_optional_when_provided(self):
+        fields = [
+            Field("name", str, required_for="create"),
+            Field("email", str),
+        ]
+        body = _build_body(
+            fields, {"name": "Alice", "email": "a@b.com"}, is_create=True
+        )
+        assert body == {"name": "Alice", "email": "a@b.com"}
+
+    def test_update_skips_none_fields(self):
+        fields = [
+            Field("name", str),
+            Field("email", str),
+        ]
+        body = _build_body(fields, {"name": "Bob", "email": None}, is_create=False)
+        assert body == {"name": "Bob"}
+
+    def test_create_only_excluded_from_update(self):
+        fields = [
+            Field("company", str, required_for="create", create_only=True),
+            Field("name", str),
+        ]
+        body = _build_body(
+            fields, {"company": "com_1", "name": "Test"}, is_create=False
+        )
+        assert body == {"name": "Test"}
+
+    def test_update_only_excluded_from_create(self):
+        fields = [
+            Field("name", str, required_for="create"),
+            Field("active", bool, update_only=True),
+        ]
+        body = _build_body(
+            fields, {"name": "Test", "active": True}, is_create=True
+        )
+        assert body == {"name": "Test"}
+
+
+# --- Integration tests for generate_tools ---
+
+
+@pytest.fixture
+def simple_resource():
+    return Resource(
+        name="widgets",
+        path="/widgets",
+        id_param="widget_id",
+        id_description="The widget ID.",
+        description="widgets",
+        list_filters=["company"],
+        fields=[
+            Field("company", str, required_for="create", doc="Company ID."),
+            Field("name", str, required_for="create", doc="Widget name."),
+            Field("color", str, doc="Widget color."),
+        ],
+    )
+
+
+class TestGenerateTools:
+    def test_generates_all_crud_tools(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        assert tools.list_fn is not None
+        assert tools.get_fn is not None
+        assert tools.create_fn is not None
+        assert tools.update_fn is not None
+        assert tools.delete_fn is not None
+
+    def test_no_delete_when_has_delete_false(self):
+        res = Resource(
+            name="things",
+            path="/things",
+            id_param="thing_id",
+            has_delete=False,
+            fields=[],
+        )
+        tools = generate_tools(res)
+        assert tools.delete_fn is None
+
+    def test_function_names(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        assert tools.list_fn.__name__ == "list_widgets"
+        assert tools.get_fn.__name__ == "get_widget"
+        assert tools.create_fn.__name__ == "create_widget"
+        assert tools.update_fn.__name__ == "update_widget"
+        assert tools.delete_fn.__name__ == "delete_widget"
+
+    def test_list_has_proper_signature(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        sig = inspect.signature(tools.list_fn)
+        param_names = list(sig.parameters.keys())
+        assert "ctx" in param_names
+        assert "company" in param_names
+        assert "limit" in param_names
+        assert "cursor" in param_names
+
+    def test_get_has_proper_signature(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        sig = inspect.signature(tools.get_fn)
+        param_names = list(sig.parameters.keys())
+        assert "ctx" in param_names
+        assert "widget_id" in param_names
+
+    def test_create_has_proper_signature(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        sig = inspect.signature(tools.create_fn)
+        params = sig.parameters
+        assert "ctx" in params
+        assert "company" in params
+        assert "name" in params
+        assert "color" in params
+        # Required fields should not have defaults
+        assert params["company"].default is inspect.Parameter.empty
+        assert params["name"].default is inspect.Parameter.empty
+        # Optional fields should default to None
+        assert params["color"].default is None
+
+    def test_update_has_proper_signature(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        sig = inspect.signature(tools.update_fn)
+        params = sig.parameters
+        assert "ctx" in params
+        assert "widget_id" in params
+        assert "color" in params
+        # All update fields should default to None
+        assert params["color"].default is None
+
+    def test_functions_have_docstrings(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        for fn in tools.all():
+            assert fn.__doc__ is not None
+            assert len(fn.__doc__) > 10
+
+    def test_all_helpers(self, simple_resource):
+        tools = generate_tools(simple_resource)
+        assert len(tools.all_read()) == 2
+        assert len(tools.all_write()) == 3
+        assert len(tools.all()) == 5
+
+
+@pytest.mark.anyio
+async def test_generated_list_calls_api(mock_api, ctx):
+    """Generated list function makes the right API call."""
+    res = Resource(
+        name="widgets",
+        path="/widgets",
+        id_param="widget_id",
+        list_filters=["company"],
+        fields=[],
+    )
+    tools = generate_tools(res)
+    mock_api.get("/widgets").mock(
+        return_value=httpx.Response(
+            200, json={"next": None, "previous": None, "results": [{"id": "w_1"}]}
+        )
+    )
+    result = await tools.list_fn(ctx, company="com_1")
+    assert result["results"][0]["id"] == "w_1"
+
+
+@pytest.mark.anyio
+async def test_generated_get_calls_api(mock_api, ctx):
+    """Generated get function makes the right API call."""
+    res = Resource(
+        name="widgets",
+        path="/widgets",
+        id_param="widget_id",
+        fields=[],
+    )
+    tools = generate_tools(res)
+    mock_api.get("/widgets/w_1").mock(
+        return_value=httpx.Response(200, json={"id": "w_1", "name": "Foo"})
+    )
+    result = await tools.get_fn(ctx, widget_id="w_1")
+    assert result == {"id": "w_1", "name": "Foo"}
+
+
+@pytest.mark.anyio
+async def test_generated_create_calls_api(mock_api, ctx):
+    """Generated create function sends the right body."""
+    res = Resource(
+        name="widgets",
+        path="/widgets",
+        id_param="widget_id",
+        fields=[
+            Field("company", str, required_for="create"),
+            Field("name", str, required_for="create"),
+            Field("color", str),
+        ],
+    )
+    tools = generate_tools(res)
+    route = mock_api.post("/widgets").mock(
+        return_value=httpx.Response(201, json={"id": "w_new"})
+    )
+    result = await tools.create_fn(ctx, company="com_1", name="Foo", color="red")
+    assert result["id"] == "w_new"
+    # Verify the body was sent correctly
+    import json
+
+    sent_body = json.loads(route.calls[0].request.content)
+    assert sent_body == {"company": "com_1", "name": "Foo", "color": "red"}
+
+
+@pytest.mark.anyio
+async def test_generated_update_calls_api(mock_api, ctx):
+    """Generated update function sends only non-None fields."""
+    res = Resource(
+        name="widgets",
+        path="/widgets",
+        id_param="widget_id",
+        fields=[
+            Field("name", str),
+            Field("color", str),
+        ],
+    )
+    tools = generate_tools(res)
+    route = mock_api.patch("/widgets/w_1").mock(
+        return_value=httpx.Response(200, json={"id": "w_1", "color": "blue"})
+    )
+    result = await tools.update_fn(ctx, widget_id="w_1", color="blue")
+    assert result["id"] == "w_1"
+    import json
+
+    sent_body = json.loads(route.calls[0].request.content)
+    assert sent_body == {"color": "blue"}
+
+
+@pytest.mark.anyio
+async def test_generated_delete_calls_api(mock_api, ctx):
+    """Generated delete function makes the right API call."""
+    res = Resource(
+        name="widgets",
+        path="/widgets",
+        id_param="widget_id",
+        fields=[],
+    )
+    tools = generate_tools(res)
+    mock_api.delete("/widgets/w_1").mock(
+        return_value=httpx.Response(204)
+    )
+    result = await tools.delete_fn(ctx, widget_id="w_1")
+    assert result == {"success": True}

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -9,6 +9,7 @@ import pytest
 from mcp_server_check.tool_filter import (
     TOOLSETS,
     ToolFilter,
+    is_destructive_tool,
     is_write_tool,
 )
 
@@ -231,6 +232,73 @@ class TestInvalidToolsets:
 
 
 # --- TOOLSETS constant ---
+
+
+# --- is_destructive_tool ---
+
+
+class TestIsDestructiveTool:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "approve_payroll",
+            "delete_payroll",
+            "delete_company",
+            "bulk_delete_payroll_items",
+            "simulate_start_processing",
+            "simulate_complete_funding",
+            "refund_payment",
+            "cancel_payment",
+            "start_implementation",
+            "cancel_implementation",
+        ],
+    )
+    def test_destructive_detected(self, name):
+        assert is_destructive_tool(name), f"{name} should be destructive"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "list_companies",
+            "get_employee",
+            "create_company",
+            "update_employee",
+            "preview_payroll",
+            "onboard_company",
+            "submit_employee_form",
+        ],
+    )
+    def test_non_destructive(self, name):
+        assert not is_destructive_tool(name), f"{name} should NOT be destructive"
+
+
+# --- requires_confirmation ---
+
+
+class TestRequiresConfirmation:
+    def test_no_confirmation_by_default(self):
+        tf = ToolFilter()
+        assert tf.requires_confirmation("approve_payroll") is False
+
+    def test_confirmation_when_enabled(self):
+        tf = ToolFilter(confirm_destructive=True)
+        assert tf.requires_confirmation("approve_payroll") is True
+        assert tf.requires_confirmation("delete_payroll") is True
+
+    def test_no_confirmation_for_safe_tools(self):
+        tf = ToolFilter(confirm_destructive=True)
+        assert tf.requires_confirmation("list_companies") is False
+        assert tf.requires_confirmation("create_company") is False
+
+    def test_from_env_confirm_destructive(self):
+        with mock.patch.dict(os.environ, {"CHECK_CONFIRM_DESTRUCTIVE": "true"}):
+            tf = ToolFilter.from_env()
+        assert tf.confirm_destructive is True
+
+    def test_from_headers_confirm_destructive(self):
+        headers = {"x-mcp-confirm-destructive": "1"}
+        tf = ToolFilter.from_headers(headers)
+        assert tf.confirm_destructive is True
 
 
 class TestToolsets:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -7,7 +7,11 @@ import pytest
 from mcp_server_check.tools.workflows import (
     diagnose_payment,
     get_company_overview,
+    get_company_tax_overview,
+    get_contractor_snapshot,
     get_employee_snapshot,
+    get_onboarding_status,
+    get_payroll_details,
 )
 
 
@@ -138,3 +142,163 @@ async def test_diagnose_payment_without_payroll_item(mock_api, ctx):
     assert result["payment"]["id"] == "pmt_002"
     assert result["payment_attempts"]["results"][0]["id"] == "att_002"
     assert "payroll_item" not in result
+
+
+# --- New workflow tools ---
+
+
+@pytest.mark.anyio
+async def test_get_payroll_details_full(mock_api, ctx):
+    mock_api.get("/payrolls/prl_001").mock(
+        return_value=httpx.Response(200, json={"id": "prl_001", "status": "draft"})
+    )
+    mock_api.get("/payroll_items").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "pit_001", "employee": "emp_001"}])
+        )
+    )
+    mock_api.get("/contractor_payments").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "cpm_001", "contractor": "ctr_001"}])
+        )
+    )
+
+    result = await get_payroll_details(ctx, payroll_id="prl_001")
+
+    assert result["payroll"]["id"] == "prl_001"
+    assert result["payroll_items"]["results"][0]["id"] == "pit_001"
+    assert result["contractor_payments"]["results"][0]["id"] == "cpm_001"
+
+
+@pytest.mark.anyio
+async def test_get_payroll_details_minimal(mock_api, ctx):
+    mock_api.get("/payrolls/prl_001").mock(
+        return_value=httpx.Response(200, json={"id": "prl_001"})
+    )
+
+    result = await get_payroll_details(
+        ctx,
+        payroll_id="prl_001",
+        include_items=False,
+        include_contractor_payments=False,
+    )
+
+    assert result["payroll"]["id"] == "prl_001"
+    assert "payroll_items" not in result
+    assert "contractor_payments" not in result
+
+
+@pytest.mark.anyio
+async def test_get_contractor_snapshot(mock_api, ctx):
+    mock_api.get("/contractors/ctr_001").mock(
+        return_value=httpx.Response(
+            200, json={"id": "ctr_001", "first_name": "Bob", "last_name": "Smith"}
+        )
+    )
+    mock_api.get("/contractors/ctr_001/payments").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "cpm_001", "amount": "1000.00"}])
+        )
+    )
+    mock_api.get("/contractors/ctr_001/forms").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "frm_001", "type": "w9"}])
+        )
+    )
+
+    result = await get_contractor_snapshot(ctx, contractor_id="ctr_001")
+
+    assert result["contractor"]["id"] == "ctr_001"
+    assert result["payments"]["results"][0]["id"] == "cpm_001"
+    assert result["forms"]["results"][0]["id"] == "frm_001"
+
+
+@pytest.mark.anyio
+async def test_get_company_tax_overview(mock_api, ctx):
+    mock_api.get("/company_tax_params/com_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_001", "params": []})
+    )
+    mock_api.get("/companies/com_001/tax_elections").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "ele_001"}])
+        )
+    )
+    mock_api.get("/tax_filings").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "fil_001", "status": "filed"}])
+        )
+    )
+
+    result = await get_company_tax_overview(ctx, company_id="com_001")
+
+    assert result["tax_params"]["id"] == "com_001"
+    assert result["tax_elections"]["results"][0]["id"] == "ele_001"
+    assert result["tax_filings"]["results"][0]["id"] == "fil_001"
+
+
+@pytest.mark.anyio
+async def test_get_onboarding_status_ready(mock_api, ctx):
+    mock_api.get("/companies/com_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_001", "status": "active"})
+    )
+    mock_api.get("/workplaces").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "wrk_001"}])
+        )
+    )
+    mock_api.get("/employees").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "emp_001", "first_name": "Jane"}])
+        )
+    )
+    mock_api.get("/bank_accounts").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "bnk_001"}])
+        )
+    )
+    mock_api.get("/requirements").mock(
+        return_value=httpx.Response(
+            200, json=_list_response([{"id": "req_001", "status": "met"}])
+        )
+    )
+
+    result = await get_onboarding_status(ctx, company_id="com_001")
+
+    assert result["company"]["id"] == "com_001"
+    assert result["readiness"]["ready"] is True
+    assert result["readiness"]["has_workplaces"] is True
+    assert result["readiness"]["has_employees"] is True
+    assert result["readiness"]["has_bank_accounts"] is True
+    assert result["readiness"]["outstanding_requirements"] == 0
+
+
+@pytest.mark.anyio
+async def test_get_onboarding_status_not_ready(mock_api, ctx):
+    mock_api.get("/companies/com_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_001", "status": "setup"})
+    )
+    mock_api.get("/workplaces").mock(
+        return_value=httpx.Response(200, json=_list_response([]))
+    )
+    mock_api.get("/employees").mock(
+        return_value=httpx.Response(200, json=_list_response([]))
+    )
+    mock_api.get("/bank_accounts").mock(
+        return_value=httpx.Response(200, json=_list_response([]))
+    )
+    mock_api.get("/requirements").mock(
+        return_value=httpx.Response(
+            200,
+            json=_list_response([
+                {"id": "req_001", "status": "unmet"},
+                {"id": "req_002", "status": "met"},
+            ]),
+        )
+    )
+
+    result = await get_onboarding_status(ctx, company_id="com_001")
+
+    assert result["readiness"]["ready"] is False
+    assert result["readiness"]["has_workplaces"] is False
+    assert result["readiness"]["outstanding_requirements"] == 1
+    assert result["readiness"]["total_requirements"] == 2


### PR DESCRIPTION
## Summary

This PR introduces several architectural improvements to the MCP server that reduce boilerplate, improve context efficiency for LLM consumers, add safety guardrails for destructive operations, and expand the composite workflow toolset.

### 1. Declarative Tool Factory (`tool_factory.py`) — New file

Introduces a `Resource` / `Field` declarative system that generates standard CRUD tool functions (list, get, create, update, delete) from a schema definition. This eliminates hundreds of lines of repetitive hand-written boilerplate per resource.

**Key components:**
- `Field` dataclass — declares a field's name, type, required/optional status, and which operations it applies to (`create_only`, `update_only`)
- `Resource` dataclass — declares an API resource's path, ID parameter, list filters, available operations (`has_delete`, etc.)
- `generate_tools(resource)` — produces a `GeneratedTools` named tuple containing the 5 CRUD functions with proper signatures, docstrings, and type annotations

**Impact:** `compensation.py` was converted from **945 lines** down to **323 lines** (66% reduction) while preserving identical behavior and tool signatures. Other tool files can be converted incrementally.

### 2. Response Shaping for List Endpoints (`helpers.py`)

List endpoints often return full entity payloads that consume excessive context window space. This adds automatic summarization:

- `_SUMMARY_FIELDS` — a mapping of entity ID prefixes (e.g., `com_`, `emp_`, `prl_`) to the key fields worth surfacing in list views
- `_summarize_results()` — detects entity type by ID prefix and strips non-essential fields
- `_format_list_response()` now accepts `summarize=True` (default) and includes `result_count` in the response
- `check_api_list()` passes through the `summarize` flag so callers can opt out

This means listing 50 employees returns only `id, first_name, last_name, email, status, start_date` per record instead of full payloads with addresses, SSN masks, metadata, etc.

### 3. Destructive Tool Confirmation Tier (`tool_filter.py`, `server.py`)

Adds a safety layer for operations that trigger irreversible real-world effects (money movement, data deletion):

**`tool_filter.py`:**
- `_DESTRUCTIVE_PREFIXES` — `approve_`, `delete_`, `bulk_delete_`, `simulate_`, `refund_`, `cancel_`
- `_DESTRUCTIVE_EXACT` — `start_implementation`, `cancel_implementation`
- `is_destructive_tool()` — classification function
- `ToolFilter.confirm_destructive` field + `requires_confirmation()` method
- Configurable via `CHECK_CONFIRM_DESTRUCTIVE` env var or `x-mcp-confirm-destructive` header

**`server.py`:**
- `run_tool()` gains a `confirm: bool` parameter
- When confirmation is enabled and the tool is destructive, returns a `confirmation_required` JSON response with a warning message
- Session-level `_confirmed_tools` set prevents re-prompting for identical calls

### 4. Server Instructions (`server.py`)

Adds a ~60-line `SERVER_INSTRUCTIONS` block passed as `instructions=` to the FastMCP server constructor. This provides the consuming LLM with structured context about:

- **Entity model** — Company → Employee/Contractor → Payroll → Items hierarchy
- **Key workflows** — Creating payrolls (6 steps), onboarding companies (6 steps)
- **Important concepts** — Payroll vs Payroll Item, Earning Rate vs Earning Code, Benefits vs Post-Tax Deductions, Tax Params
- **Composite tools** — Directs the LLM to prefer workflow tools over individual API calls
- **Common gotchas** — Workplace requirements, date overlaps, bank verification, SSN write-once behavior

### 5. Four New Composite Workflow Tools (`workflows.py`)

Adds 4 new workflow tools that combine multiple API calls into single round-trips, bringing the total from 3 to 7:

- **`get_payroll_details`** — Payroll + payroll items + contractor payments (replaces 3 calls)
- **`get_contractor_snapshot`** — Contractor + payments + forms (replaces 3 calls)
- **`get_company_tax_overview`** — Tax params + elections + filings (replaces 3 calls)
- **`get_onboarding_status`** — Company + workplaces + employees + bank accounts + requirements (replaces 5 calls), includes a computed `readiness` summary with boolean flags and requirement counts

All use `asyncio.TaskGroup` for concurrent execution and accept boolean flags to include/exclude sub-resources.

### 6. Updated Toolset Description (`tool_index.py`)

The `workflows` toolset description now lists all 7 composite tools so they surface correctly in dynamic mode search.

## Test Plan

- [x] `test_tool_factory.py` — Tests for Resource/Field declaration, all 5 generated CRUD functions, `create_only`/`update_only`/`has_delete` behavior, docstring generation
- [x] `test_server.py` — Tests for summary mode in `_format_list_response` (summarized vs full, `result_count` field)
- [x] `test_tool_filter.py` — Tests for `is_destructive_tool`, `requires_confirmation`, env var parsing, header parsing
- [x] `test_workflows.py` — Tests for all 4 new workflow tools (full + minimal flags, ready + not-ready onboarding scenarios)
- [ ] Run full test suite: `uv run pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)