### PR TITLE
Migrate from mcp to fastmcp v3 and add hosted deployment support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  PYTHON_VERSION: "3.10"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - run: uv sync --frozen
+
+      - name: Ruff check
+        run: uv run ruff check src/ tests/
+
+      - name: Ruff format
+        run: uv run ruff format --check src/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - run: uv sync --frozen
+
+      - name: Run tests
+        run: uv run pytest tests/ -v --tb=short

--- a/.github/workflows/notify-hosted.yml
+++ b/.github/workflows/notify-hosted.yml
@@ -1,0 +1,17 @@
+name: Notify hosted repo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  trigger-hosted-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger mcp-server-check-hosted rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOSTED_REPO_PAT }}
+          repository: check-technologies/mcp-server-check-hosted
+          event-type: upstream-updated
+          client-payload: '{"ref": "${{ github.sha }}", "ref_name": "${{ github.ref_name }}"}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.0.0",
+    "fastmcp>=2.0.0",
     "httpx>=0.27.0",
     "click>=8.0.0",
 ]
@@ -24,6 +24,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "respx>=0.22",
+    "ruff>=0.15.6",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mcp_server_check/cli/__init__.py
+++ b/src/mcp_server_check/cli/__init__.py
@@ -85,7 +85,9 @@ class _MainCLI(click.Group):
     ):
         super().__init__(*args, **kwargs)
         # cli_group_name -> toolset_name
-        self.toolset_names: dict[str, str] = toolset_names if toolset_names is not None else {}
+        self.toolset_names: dict[str, str] = (
+            toolset_names if toolset_names is not None else {}
+        )
 
     def list_commands(self, ctx: click.Context) -> list[str]:
         tf = _build_filter(ctx)

--- a/src/mcp_server_check/cli/codegen.py
+++ b/src/mcp_server_check/cli/codegen.py
@@ -213,16 +213,12 @@ def _build_params(func: Callable) -> list[click.Parameter]:
 
         # list[str] → CSV list
         if typing.get_origin(base_type) is list:
-            params.append(
-                click.Option([f"--{cli_name}"], type=CSVList(), **opt_kwargs)
-            )
+            params.append(click.Option([f"--{cli_name}"], type=CSVList(), **opt_kwargs))
             continue
 
         # int
         if base_type is int:
-            params.append(
-                click.Option([f"--{cli_name}"], type=click.INT, **opt_kwargs)
-            )
+            params.append(click.Option([f"--{cli_name}"], type=click.INT, **opt_kwargs))
             continue
 
         # float
@@ -233,9 +229,7 @@ def _build_params(func: Callable) -> list[click.Parameter]:
             continue
 
         # Default: string
-        params.append(
-            click.Option([f"--{cli_name}"], type=click.STRING, **opt_kwargs)
-        )
+        params.append(click.Option([f"--{cli_name}"], type=click.STRING, **opt_kwargs))
 
     return params
 
@@ -297,9 +291,7 @@ def _make_callback(func: Callable) -> Callable:
 # ---------------------------------------------------------------------------
 
 
-def build_command(
-    func: Callable, toolset_name: str
-) -> tuple[str, click.Command, str]:
+def build_command(func: Callable, toolset_name: str) -> tuple[str, click.Command, str]:
     """Build a click Command from *func*.
 
     Returns ``(command_name, click_command, tool_function_name)``.

--- a/src/mcp_server_check/cli/output.py
+++ b/src/mcp_server_check/cli/output.py
@@ -48,7 +48,7 @@ def _format_rows(rows: list[dict]) -> str:
     lines = [header, separator]
     for row in rows:
         line = "  ".join(
-            str(row.get(col, ""))[:widths[col]].ljust(widths[col]) for col in columns
+            str(row.get(col, ""))[: widths[col]].ljust(widths[col]) for col in columns
         )
         lines.append(line)
     return "\n".join(lines)

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -2,22 +2,23 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Sequence
 from urllib.parse import parse_qs, urlparse
 
 import httpx
-from mcp.server.fastmcp import Context
-from mcp.server.session import ServerSession
+from fastmcp import Context
 
 
 @dataclass
 class CheckContext:
     client: httpx.AsyncClient
     base_url: str
+    token_resolver: Callable[[], str] | None = field(default=None, repr=False)
 
 
-Ctx = Context[ServerSession, CheckContext]
+Ctx = Context
 
 # Default max results for list endpoints to avoid blowing context windows.
 DEFAULT_LIST_LIMIT = 10
@@ -29,12 +30,27 @@ _SUMMARY_FIELDS: dict[str, Sequence[str]] = {
     "com_": ("id", "legal_name", "trade_name", "status", "pay_frequency"),
     "emp_": ("id", "first_name", "last_name", "email", "status", "start_date"),
     "ctr_": ("id", "first_name", "last_name", "business_name", "type", "status"),
-    "prl_": ("id", "status", "payday", "period_start", "period_end", "type", "approval_status"),
+    "prl_": (
+        "id",
+        "status",
+        "payday",
+        "period_start",
+        "period_end",
+        "type",
+        "approval_status",
+    ),
     "pit_": ("id", "employee", "payment_method", "status"),
     "pmt_": ("id", "status", "amount", "payment_method", "direction"),
     "bnk_": ("id", "institution_name", "subtype", "status", "last_four"),
     "wrk_": ("id", "name", "active", "address"),
-    "ben_": ("id", "benefit", "description", "employee", "effective_start", "effective_end"),
+    "ben_": (
+        "id",
+        "benefit",
+        "description",
+        "employee",
+        "effective_start",
+        "effective_end",
+    ),
     "nps_": ("id", "employee", "contractor", "is_default"),
     "psc_": ("id", "name", "pay_frequency", "company"),
 }
@@ -104,9 +120,12 @@ async def _check_api_request(
 ) -> dict:
     """Make a request to the Check API with shared error handling."""
     check_ctx = ctx.request_context.lifespan_context
+    headers: dict[str, str] = {}
+    if check_ctx.token_resolver is not None:
+        headers["Authorization"] = f"Bearer {check_ctx.token_resolver()}"
     try:
         response = await check_ctx.client.request(
-            method, path, params=params, json=data
+            method, path, params=params, json=data, headers=headers or None
         )
         response.raise_for_status()
         if response.status_code == 204:

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -10,9 +10,9 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.types import Tool as MCPTool
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import FunctionTool
 
 from mcp_server_check.helpers import CheckContext
 from mcp_server_check.tool_filter import ToolFilter
@@ -110,18 +110,16 @@ class CheckMCP(FastMCP):
             request = self._mcp_server.request_context.request
             if request is not None and hasattr(request, "headers"):
                 header_filter = ToolFilter.from_headers(request.headers)
-                # If headers provide any configuration, use it; otherwise fall back
                 if header_filter != ToolFilter():
                     return header_filter
-        except LookupError:
+        except Exception:
             pass
         return self._static_filter
 
-    async def list_tools(self) -> list[MCPTool]:
+    async def list_tools(self, **kwargs: Any) -> Sequence[FunctionTool]:
         """List tools, filtered by the active configuration."""
-        all_tools = await super().list_tools()
+        all_tools = await super().list_tools(**kwargs)
         if self._tool_index is not None:
-            # Dynamic mode: the 3 meta-tools are always visible
             return all_tools
         tf = self._get_active_filter()
         return [
@@ -130,18 +128,19 @@ class CheckMCP(FastMCP):
             if tf.is_tool_allowed(t.name, self._registry.get(t.name, ""))
         ]
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Sequence[Any]:
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any] | None = None, **kwargs: Any
+    ) -> Any:
         """Call a tool, blocking if it's filtered out."""
         if self._tool_index is not None:
-            # Dynamic mode: meta-tools handle their own filtering
-            return await super().call_tool(name, arguments)
+            return await super().call_tool(name, arguments, **kwargs)
         tf = self._get_active_filter()
         toolset = self._registry.get(name, "")
         if not tf.is_tool_allowed(name, toolset):
             raise ToolError(
                 f"Tool '{name}' is not available in the current configuration"
             )
-        return await super().call_tool(name, arguments)
+        return await super().call_tool(name, arguments, **kwargs)
 
 
 def _setup_dynamic_mode(server: CheckMCP) -> None:
@@ -216,28 +215,31 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
             elif isinstance(arguments, dict):
                 parsed_args = arguments
             else:
-                return json.dumps({"error": "Arguments must be a JSON string or object"})
+                return json.dumps(
+                    {"error": "Arguments must be a JSON string or object"}
+                )
 
         # Check if this destructive tool needs confirmation
         call_key = f"{tool_name}:{json.dumps(parsed_args, sort_keys=True)}"
         if tf.requires_confirmation(tool_name) and not confirm:
             if call_key not in _confirmed_tools:
-                return json.dumps({
-                    "confirmation_required": True,
-                    "tool_name": tool_name,
-                    "arguments": parsed_args,
-                    "message": (
-                        f"⚠️  '{tool_name}' is a destructive operation that may "
-                        f"trigger irreversible effects (money movement, data deletion, "
-                        f"etc.). Call run_tool again with confirm=true to proceed."
-                    ),
-                })
+                return json.dumps(
+                    {
+                        "confirmation_required": True,
+                        "tool_name": tool_name,
+                        "arguments": parsed_args,
+                        "message": (
+                            f"⚠️  '{tool_name}' is a destructive operation that may "
+                            f"trigger irreversible effects (money movement, data deletion, "
+                            f"etc.). Call run_tool again with confirm=true to proceed."
+                        ),
+                    }
+                )
 
         try:
             result = await index.run(
                 name=tool_name,
                 arguments=parsed_args,
-                context=ctx,
                 tool_filter=tf,
             )
         except ValueError as e:
@@ -350,17 +352,27 @@ def _register_resources(server: CheckMCP) -> None:
         return json.dumps(_TOOLSET_DESCRIPTIONS, indent=2)
 
 
+def setup_tools(server: CheckMCP, tool_mode: str = "dynamic") -> None:
+    """Register tools, resources, and dynamic mode on a CheckMCP instance.
+
+    This is the public entry point for configuring a CheckMCP server with
+    all Check API tools.  The ``mcp-server-check-hosted`` package calls
+    this on its own server instance to reuse the tool definitions.
+    """
+    if tool_mode == "all":
+        register_all(server, registry=server._registry)
+    else:
+        _setup_dynamic_mode(server)
+    _register_resources(server)
+
+
 def _create_server() -> CheckMCP:
     """Create and configure the MCP server based on CHECK_TOOL_MODE."""
     server = CheckMCP(
         "Check Payroll API", instructions=SERVER_INSTRUCTIONS, lifespan=lifespan
     )
     tool_mode = os.environ.get("CHECK_TOOL_MODE", "dynamic").lower()
-    if tool_mode == "all":
-        register_all(server, registry=server._registry)
-    else:
-        _setup_dynamic_mode(server)
-    _register_resources(server)
+    setup_tools(server, tool_mode)
     return server
 
 

--- a/src/mcp_server_check/tool_factory.py
+++ b/src/mcp_server_check/tool_factory.py
@@ -222,7 +222,9 @@ def generate_tools(res: Resource) -> GeneratedTools:
         cursor: str | None = None,
         **kwargs: Any,
     ) -> dict:
-        params = _build_params(filter_fields, {**kwargs, "limit": limit, "cursor": cursor})
+        params = _build_params(
+            filter_fields, {**kwargs, "limit": limit, "cursor": cursor}
+        )
         return await check_api_list(ctx, res.path, params=params)
 
     # Build the actual function with proper parameter annotations
@@ -309,7 +311,11 @@ def _create_list_function(res: Resource, filter_fields: list[str]):
     import inspect
 
     # Build new parameter list
-    params_list = [inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx)]
+    params_list = [
+        inspect.Parameter(
+            "ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx
+        )
+    ]
     for pname in filter_fields:
         params_list.append(
             inspect.Parameter(
@@ -320,10 +326,20 @@ def _create_list_function(res: Resource, filter_fields: list[str]):
             )
         )
     params_list.append(
-        inspect.Parameter("limit", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None, annotation=int | None)
+        inspect.Parameter(
+            "limit",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            default=None,
+            annotation=int | None,
+        )
     )
     params_list.append(
-        inspect.Parameter("cursor", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None, annotation=str | None)
+        inspect.Parameter(
+            "cursor",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            default=None,
+            annotation=str | None,
+        )
     )
     list_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
 
@@ -345,10 +361,15 @@ def _create_get_function(res: Resource):
     get_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
 
     params_list = [
-        inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx),
-        inspect.Parameter(id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+        inspect.Parameter(
+            "ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx
+        ),
+        inspect.Parameter(
+            id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str
+        ),
     ]
     get_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    get_fn.__annotations__ = {"ctx": Ctx, id_param: str, "return": dict}
     return get_fn
 
 
@@ -368,7 +389,12 @@ def _create_create_function(res: Resource, fields: list[Field]):
     if args_doc:
         create_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
 
-    params_list = [inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx)]
+    params_list = [
+        inspect.Parameter(
+            "ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx
+        )
+    ]
+    ann: dict[str, Any] = {"ctx": Ctx, "return": dict}
     for f in fields:
         if f.required_for == "create":
             params_list.append(
@@ -378,6 +404,7 @@ def _create_create_function(res: Resource, fields: list[Field]):
                     annotation=f.type,
                 )
             )
+            ann[f.name] = f.type
         else:
             params_list.append(
                 inspect.Parameter(
@@ -387,7 +414,9 @@ def _create_create_function(res: Resource, fields: list[Field]):
                     annotation=f.type | None,
                 )
             )
+            ann[f.name] = f.type | None
     create_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    create_fn.__annotations__ = ann
     return create_fn
 
 
@@ -411,9 +440,14 @@ def _create_update_function(res: Resource, fields: list[Field]):
         update_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
 
     params_list = [
-        inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx),
-        inspect.Parameter(id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+        inspect.Parameter(
+            "ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx
+        ),
+        inspect.Parameter(
+            id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str
+        ),
     ]
+    ann: dict[str, Any] = {"ctx": Ctx, id_param: str, "return": dict}
     for f in fields:
         params_list.append(
             inspect.Parameter(
@@ -423,7 +457,9 @@ def _create_update_function(res: Resource, fields: list[Field]):
                 annotation=f.type | None,
             )
         )
+        ann[f.name] = f.type | None
     update_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    update_fn.__annotations__ = ann
     return update_fn
 
 
@@ -442,8 +478,13 @@ def _create_delete_function(res: Resource):
     delete_fn.__doc__ += f"\n\nArgs:\n{args_doc}"
 
     params_list = [
-        inspect.Parameter("ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx),
-        inspect.Parameter(id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
+        inspect.Parameter(
+            "ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Ctx
+        ),
+        inspect.Parameter(
+            id_param, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str
+        ),
     ]
     delete_fn.__signature__ = inspect.Signature(params_list, return_annotation=dict)
+    delete_fn.__annotations__ = {"ctx": Ctx, id_param: str, "return": dict}
     return delete_fn

--- a/src/mcp_server_check/tool_index.py
+++ b/src/mcp_server_check/tool_index.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from mcp.server.fastmcp.tools.base import Tool
+from fastmcp.tools import FunctionTool as Tool
 
 from mcp_server_check.tool_filter import ToolFilter, is_write_tool
 from mcp_server_check.tools import collect_all_tools
@@ -248,15 +248,15 @@ class ToolIndex:
         self,
         name: str,
         arguments: dict[str, Any],
-        context: Any,
         tool_filter: ToolFilter,
     ) -> Any:
         """Look up and execute a tool by name.
 
+        Context is injected automatically by fastmcp's dependency system.
+
         Args:
             name: Tool name to execute.
             arguments: Tool arguments dict.
-            context: MCP Context object to inject.
             tool_filter: Active ToolFilter for authorization.
 
         Returns:
@@ -276,7 +276,15 @@ class ToolIndex:
             raise ValueError(
                 f"Tool '{name}' is not available in the current configuration"
             )
-        return await entry.tool.run(arguments, context=context)
+        result = await entry.tool.run(arguments)
+        if (
+            hasattr(result, "structured_content")
+            and result.structured_content is not None
+        ):
+            return result.structured_content
+        if hasattr(result, "content") and result.content:
+            return result.content[0].text
+        return result
 
     def _suggest_tool(self, name: str) -> str | None:
         """Find the closest matching tool name for error messages."""

--- a/src/mcp_server_check/tools/__init__.py
+++ b/src/mcp_server_check/tools/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from . import (
     bank_accounts,

--- a/src/mcp_server_check/tools/bank_accounts.py
+++ b/src/mcp_server_check/tools/bank_accounts.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -6,9 +6,9 @@ with manual functions for non-standard endpoints.
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
-from mcp_server_check.helpers import Ctx, check_api_get, check_api_post
+from mcp_server_check.helpers import Ctx, check_api_get
 from mcp_server_check.tool_factory import Field, Resource, generate_tools
 
 # ---------------------------------------------------------------------------
@@ -24,14 +24,29 @@ _pay_schedules = Resource(
     list_filters=["company"],
     fields=[
         Field("company", str, required_for="create", doc="The Check company ID."),
-        Field("pay_frequency", str, required_for="create",
-              doc='Pay frequency — "weekly", "biweekly", "semimonthly", "monthly", "quarterly", or "annually".'),
-        Field("first_payday", str, required_for="create",
-              doc="Payday date of the first payroll on this schedule (YYYY-MM-DD)."),
-        Field("first_period_end", str, required_for="create",
-              doc="Period end date of the first payroll on this schedule (YYYY-MM-DD)."),
-        Field("second_payday", str,
-              doc="Second payday date (semimonthly only; must be between one day and one month after first_payday)."),
+        Field(
+            "pay_frequency",
+            str,
+            required_for="create",
+            doc='Pay frequency — "weekly", "biweekly", "semimonthly", "monthly", "quarterly", or "annually".',
+        ),
+        Field(
+            "first_payday",
+            str,
+            required_for="create",
+            doc="Payday date of the first payroll on this schedule (YYYY-MM-DD).",
+        ),
+        Field(
+            "first_period_end",
+            str,
+            required_for="create",
+            doc="Period end date of the first payroll on this schedule (YYYY-MM-DD).",
+        ),
+        Field(
+            "second_payday",
+            str,
+            doc="Second payday date (semimonthly only; must be between one day and one month after first_payday).",
+        ),
         Field("name", str, doc="Human-readable name for the pay schedule."),
         Field("metadata", str, doc="Additional JSON metadata string."),
     ],
@@ -82,16 +97,50 @@ _benefits = Resource(
     list_filters=["company", "employee"],
     fields=[
         Field("employee", str, required_for="create", doc="The Check employee ID."),
-        Field("company_benefit", str, required_for="create", doc="The Check company benefit ID.", create_only=True),
+        Field(
+            "company_benefit",
+            str,
+            required_for="create",
+            doc="The Check company benefit ID.",
+            create_only=True,
+        ),
         Field("benefit", str, doc="Type of supported benefit."),
-        Field("period", str, doc='Period over which a period amount is distributed — "monthly" or null.'),
-        Field("description", str, doc="Description to distinguish the benefit within a plan (max 255 chars)."),
-        Field("company_contribution_amount", str, doc="Company contribution amount per payroll."),
-        Field("company_contribution_percent", float, doc="Company contribution as percent of gross pay (0-100)."),
-        Field("company_period_amount", str, doc="Company contribution over the period."),
-        Field("employee_contribution_amount", str, doc="Employee contribution amount per payroll."),
-        Field("employee_contribution_percent", float, doc="Employee contribution as percent of gross pay (0-100)."),
-        Field("employee_period_amount", str, doc="Employee contribution over the period."),
+        Field(
+            "period",
+            str,
+            doc='Period over which a period amount is distributed — "monthly" or null.',
+        ),
+        Field(
+            "description",
+            str,
+            doc="Description to distinguish the benefit within a plan (max 255 chars).",
+        ),
+        Field(
+            "company_contribution_amount",
+            str,
+            doc="Company contribution amount per payroll.",
+        ),
+        Field(
+            "company_contribution_percent",
+            float,
+            doc="Company contribution as percent of gross pay (0-100).",
+        ),
+        Field(
+            "company_period_amount", str, doc="Company contribution over the period."
+        ),
+        Field(
+            "employee_contribution_amount",
+            str,
+            doc="Employee contribution amount per payroll.",
+        ),
+        Field(
+            "employee_contribution_percent",
+            float,
+            doc="Employee contribution as percent of gross pay (0-100).",
+        ),
+        Field(
+            "employee_period_amount", str, doc="Employee contribution over the period."
+        ),
         Field("effective_start", str, doc="Start date for the benefit (YYYY-MM-DD)."),
         Field("effective_end", str, doc="End date for the benefit (YYYY-MM-DD)."),
         Field("hsa_contribution_limit", str, doc="HSA contribution limit."),
@@ -120,19 +169,47 @@ _post_tax_deductions = Resource(
     list_filters=["company", "employee"],
     fields=[
         Field("employee", str, required_for="create", doc="The Check employee ID."),
-        Field("type", str, required_for="create",
-              doc='Deduction type — "miscellaneous", "child_support", or "miscellaneous_garnishment".', create_only=True),
-        Field("description", str, required_for="create", doc="Description of the deduction (max 255 chars)."),
-        Field("effective_start", str, required_for="create", doc="Start date for the deduction (YYYY-MM-DD)."),
+        Field(
+            "type",
+            str,
+            required_for="create",
+            doc='Deduction type — "miscellaneous", "child_support", or "miscellaneous_garnishment".',
+            create_only=True,
+        ),
+        Field(
+            "description",
+            str,
+            required_for="create",
+            doc="Description of the deduction (max 255 chars).",
+        ),
+        Field(
+            "effective_start",
+            str,
+            required_for="create",
+            doc="Start date for the deduction (YYYY-MM-DD).",
+        ),
         Field("effective_end", str, doc="End date for the deduction (YYYY-MM-DD)."),
-        Field("miscellaneous", dict,
-              doc="Config dict for miscellaneous type with keys: total_amount, amount, percent, annual_limit."),
-        Field("child_support", dict,
-              doc="Config dict for child_support type with keys: external_id, agency, fips_code, issue_date, amount, max_percent."),
-        Field("miscellaneous_garnishment", dict,
-              doc="Config dict for miscellaneous_garnishment type with keys: amount, percent, total_amount, annual_limit, priority, max_percent."),
+        Field(
+            "miscellaneous",
+            dict,
+            doc="Config dict for miscellaneous type with keys: total_amount, amount, percent, annual_limit.",
+        ),
+        Field(
+            "child_support",
+            dict,
+            doc="Config dict for child_support type with keys: external_id, agency, fips_code, issue_date, amount, max_percent.",
+        ),
+        Field(
+            "miscellaneous_garnishment",
+            dict,
+            doc="Config dict for miscellaneous_garnishment type with keys: amount, percent, total_amount, annual_limit, priority, max_percent.",
+        ),
         Field("metadata", str, doc="Additional JSON metadata string."),
-        Field("managed", bool, doc="Whether the deduction should be remitted by Check (child support only)."),
+        Field(
+            "managed",
+            bool,
+            doc="Whether the deduction should be remitted by Check (child support only).",
+        ),
     ],
 )
 _post_tax_deduction_tools = generate_tools(_post_tax_deductions)
@@ -156,16 +233,55 @@ _company_benefits = Resource(
     description="company-level benefits",
     list_filters=["company"],
     fields=[
-        Field("company", str, required_for="create", doc="The Check company ID.", create_only=True),
+        Field(
+            "company",
+            str,
+            required_for="create",
+            doc="The Check company ID.",
+            create_only=True,
+        ),
         Field("benefit", str, required_for="create", doc="Type of supported benefit."),
-        Field("description", str, required_for="create", doc="Description to distinguish the benefit (max 255 chars)."),
-        Field("period", str, doc='Period over which a period amount is distributed — "monthly" or null.'),
-        Field("company_contribution_amount", str, doc="Default company contribution per payroll."),
-        Field("company_contribution_percent", str, doc="Default company contribution as percent of gross (0-100)."),
-        Field("company_period_amount", str, doc="Default company contribution over the period."),
-        Field("employee_contribution_amount", str, doc="Default employee contribution per payroll."),
-        Field("employee_contribution_percent", str, doc="Default employee contribution as percent of gross (0-100)."),
-        Field("employee_period_amount", str, doc="Default employee contribution over the period."),
+        Field(
+            "description",
+            str,
+            required_for="create",
+            doc="Description to distinguish the benefit (max 255 chars).",
+        ),
+        Field(
+            "period",
+            str,
+            doc='Period over which a period amount is distributed — "monthly" or null.',
+        ),
+        Field(
+            "company_contribution_amount",
+            str,
+            doc="Default company contribution per payroll.",
+        ),
+        Field(
+            "company_contribution_percent",
+            str,
+            doc="Default company contribution as percent of gross (0-100).",
+        ),
+        Field(
+            "company_period_amount",
+            str,
+            doc="Default company contribution over the period.",
+        ),
+        Field(
+            "employee_contribution_amount",
+            str,
+            doc="Default employee contribution per payroll.",
+        ),
+        Field(
+            "employee_contribution_percent",
+            str,
+            doc="Default employee contribution as percent of gross (0-100).",
+        ),
+        Field(
+            "employee_period_amount",
+            str,
+            doc="Default employee contribution over the period.",
+        ),
         Field("effective_start", str, doc="Start date for the benefit (YYYY-MM-DD)."),
         Field("effective_end", str, doc="End date for the benefit (YYYY-MM-DD)."),
         Field("metadata", str, doc="Additional JSON metadata string."),
@@ -193,13 +309,40 @@ _earning_rates = Resource(
     list_filters=["company", "employee"],
     has_delete=False,
     fields=[
-        Field("employee", str, required_for="create", doc="The Check employee ID.", create_only=True),
-        Field("amount", str, required_for="create", doc='The earning rate amount (e.g. "25.00" or "52000.00").', create_only=True),
-        Field("period", str, required_for="create", doc='Period type — "hourly", "annually", or "piece".', create_only=True),
+        Field(
+            "employee",
+            str,
+            required_for="create",
+            doc="The Check employee ID.",
+            create_only=True,
+        ),
+        Field(
+            "amount",
+            str,
+            required_for="create",
+            doc='The earning rate amount (e.g. "25.00" or "52000.00").',
+            create_only=True,
+        ),
+        Field(
+            "period",
+            str,
+            required_for="create",
+            doc='Period type — "hourly", "annually", or "piece".',
+            create_only=True,
+        ),
         Field("name", str, doc="Name of the earning rate."),
-        Field("workweek_hours", float, doc="Hours per week the employee works. Default: 40.", create_only=True),
-        Field("active", bool, doc="Whether the earning rate is active.", update_only=True),
-        Field("metadata", str, doc="Additional JSON metadata string.", update_only=True),
+        Field(
+            "workweek_hours",
+            float,
+            doc="Hours per week the employee works. Default: 40.",
+            create_only=True,
+        ),
+        Field(
+            "active", bool, doc="Whether the earning rate is active.", update_only=True
+        ),
+        Field(
+            "metadata", str, doc="Additional JSON metadata string.", update_only=True
+        ),
     ],
 )
 _earning_rate_tools = generate_tools(_earning_rates)
@@ -223,13 +366,34 @@ _earning_codes = Resource(
     list_filters=["company"],
     has_delete=False,
     fields=[
-        Field("company", str, required_for="create", doc="The Check company ID.", create_only=True),
-        Field("name", str, required_for="create", doc="Name of the earning code.", create_only=True),
-        Field("type", str, required_for="create", doc="Type of earning code.", create_only=True),
+        Field(
+            "company",
+            str,
+            required_for="create",
+            doc="The Check company ID.",
+            create_only=True,
+        ),
+        Field(
+            "name",
+            str,
+            required_for="create",
+            doc="Name of the earning code.",
+            create_only=True,
+        ),
+        Field(
+            "type",
+            str,
+            required_for="create",
+            doc="Type of earning code.",
+            create_only=True,
+        ),
         Field("active", bool, doc="Whether the code is active."),
-        Field("calculation_overrides", dict,
-              doc='Tax calculation overrides dict. May include "wa_risk_class_code" (format "####-##" for WA L&I).',
-              create_only=True),
+        Field(
+            "calculation_overrides",
+            dict,
+            doc='Tax calculation overrides dict. May include "wa_risk_class_code" (format "####-##" for WA L&I).',
+            create_only=True,
+        ),
         Field("metadata", str, doc="Additional JSON metadata string."),
     ],
 )
@@ -254,8 +418,12 @@ _net_pay_splits = Resource(
     list_filters=["company", "employee"],
     has_delete=False,
     fields=[
-        Field("splits", list, required_for="create",
-              doc='Prioritized list of split dicts. Each may include "bank_account", "priority" (int), "amount", "percentage".'),
+        Field(
+            "splits",
+            list,
+            required_for="create",
+            doc='Prioritized list of split dicts. Each may include "bank_account", "priority" (int), "amount", "percentage".',
+        ),
         Field("employee", str, doc="The Check employee ID."),
         Field("contractor", str, doc="The Check contractor ID."),
         Field("is_default", bool, doc="Whether this is the default net pay split."),

--- a/src/mcp_server_check/tools/components.py
+++ b/src/mcp_server_check/tools/components.py
@@ -7,7 +7,7 @@ Replaces 35 individual component tools with 2 generic tools:
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import Ctx, check_api_post
 

--- a/src/mcp_server_check/tools/contractor_payments.py
+++ b/src/mcp_server_check/tools/contractor_payments.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/documents.py
+++ b/src/mcp_server_check/tools/documents.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,
@@ -81,9 +81,7 @@ async def get_company_authorization_document(ctx: Ctx, document_id: str) -> dict
     return await check_api_get(ctx, f"/company_authorization_documents/{document_id}")
 
 
-async def download_company_authorization_document(
-    ctx: Ctx, document_id: str
-) -> dict:
+async def download_company_authorization_document(ctx: Ctx, document_id: str) -> dict:
     """Download a company authorization document.
 
     Args:
@@ -149,9 +147,7 @@ async def list_contractor_tax_documents(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
-    return await check_api_list(
-        ctx, "/contractor_tax_documents", params=params or None
-    )
+    return await check_api_list(ctx, "/contractor_tax_documents", params=params or None)
 
 
 async def get_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
@@ -169,9 +165,7 @@ async def download_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(
-        ctx, f"/contractor_tax_documents/{document_id}/download"
-    )
+    return await check_api_get(ctx, f"/contractor_tax_documents/{document_id}/download")
 
 
 # --- Setup Documents ---

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/external_payrolls.py
+++ b/src/mcp_server_check/tools/external_payrolls.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/forms.py
+++ b/src/mcp_server_check/tools/forms.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/payments.py
+++ b/src/mcp_server_check/tools/payments.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/payroll_items.py
+++ b/src/mcp_server_check/tools/payroll_items.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,
@@ -163,9 +163,7 @@ async def delete_payroll_item(ctx: Ctx, payroll_item_id: str) -> dict:
     return await check_api_delete(ctx, f"/payroll_items/{payroll_item_id}")
 
 
-async def bulk_delete_payroll_items(
-    ctx: Ctx, ids: list[str]
-) -> dict:
+async def bulk_delete_payroll_items(ctx: Ctx, ids: list[str]) -> dict:
     """Bulk delete payroll items.
 
     Args:

--- a/src/mcp_server_check/tools/payrolls.py
+++ b/src/mcp_server_check/tools/payrolls.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,
@@ -239,9 +239,7 @@ async def get_payroll_cash_requirement_report(ctx: Ctx, payroll_id: str) -> dict
     Args:
         payroll_id: The Check payroll ID.
     """
-    return await check_api_get(
-        ctx, f"/payrolls/{payroll_id}/reports/cash_requirement"
-    )
+    return await check_api_get(ctx, f"/payrolls/{payroll_id}/reports/cash_requirement")
 
 
 async def get_payroll_paper_checks_report(ctx: Ctx, payroll_id: str) -> dict:
@@ -250,9 +248,7 @@ async def get_payroll_paper_checks_report(ctx: Ctx, payroll_id: str) -> dict:
     Args:
         payroll_id: The Check payroll ID.
     """
-    return await check_api_get(
-        ctx, f"/payrolls/{payroll_id}/reports/paper_checks"
-    )
+    return await check_api_get(ctx, f"/payrolls/{payroll_id}/reports/paper_checks")
 
 
 # --- Simulation ---
@@ -286,9 +282,7 @@ async def simulate_fail_funding(ctx: Ctx, payroll_id: str) -> dict:
     Args:
         payroll_id: The Check payroll ID.
     """
-    return await check_api_post(
-        ctx, f"/payrolls/{payroll_id}/simulate/fail_funding"
-    )
+    return await check_api_post(ctx, f"/payrolls/{payroll_id}/simulate/fail_funding")
 
 
 async def simulate_complete_disbursements(ctx: Ctx, payroll_id: str) -> dict:

--- a/src/mcp_server_check/tools/platform.py
+++ b/src/mcp_server_check/tools/platform.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,
@@ -200,9 +200,7 @@ async def list_integration_permissions(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
-    return await check_api_list(
-        ctx, "/integration_permissions", params=params or None
-    )
+    return await check_api_list(ctx, "/integration_permissions", params=params or None)
 
 
 async def get_integration_permission(ctx: Ctx, permission_id: str) -> dict:
@@ -274,9 +272,7 @@ async def get_accounting_mappings(ctx: Ctx, company_id: str) -> dict:
     return await check_api_get(ctx, f"/companies/{company_id}/accounting_mappings")
 
 
-async def update_accounting_mappings(
-    ctx: Ctx, company_id: str, data: dict
-) -> dict:
+async def update_accounting_mappings(ctx: Ctx, company_id: str, data: dict) -> dict:
     """Update accounting mappings for a company.
 
     The payload is a complex structure — pass the full request body as a dict.
@@ -290,9 +286,7 @@ async def update_accounting_mappings(
     )
 
 
-async def toggle_accounting_mappings(
-    ctx: Ctx, company_id: str, data: dict
-) -> dict:
+async def toggle_accounting_mappings(ctx: Ctx, company_id: str, data: dict) -> dict:
     """Toggle accounting mappings for a company.
 
     The payload is a complex structure — pass the full request body as a dict.

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,
@@ -163,9 +163,7 @@ async def update_employee_tax_params(
         employee_id: The Check employee ID.
         data: List of tax parameter update objects, each with ``id`` and ``value``.
     """
-    return await check_api_patch(
-        ctx, f"/employee_tax_params/{employee_id}", data=data
-    )
+    return await check_api_patch(ctx, f"/employee_tax_params/{employee_id}", data=data)
 
 
 async def list_employee_tax_param_settings(
@@ -236,9 +234,7 @@ async def bulk_get_employee_tax_param_settings(ctx: Ctx, data: dict) -> dict:
     Args:
         data: Bulk request payload with employee IDs or filters.
     """
-    return await check_api_post(
-        ctx, "/employee_tax_param_settings/bulk_get", data=data
-    )
+    return await check_api_post(ctx, "/employee_tax_param_settings/bulk_get", data=data)
 
 
 async def bulk_update_employee_tax_param_settings(ctx: Ctx, data: dict) -> dict:
@@ -280,9 +276,7 @@ async def list_company_tax_elections(
     )
 
 
-async def create_company_tax_elections(
-    ctx: Ctx, company_id: str, data: dict
-) -> dict:
+async def create_company_tax_elections(ctx: Ctx, company_id: str, data: dict) -> dict:
     """Create tax elections for a company.
 
     The payload is a complex nested structure — pass the full request body as a dict.
@@ -296,9 +290,7 @@ async def create_company_tax_elections(
     )
 
 
-async def update_company_tax_elections(
-    ctx: Ctx, company_id: str, data: dict
-) -> dict:
+async def update_company_tax_elections(ctx: Ctx, company_id: str, data: dict) -> dict:
     """Update tax elections for a company.
 
     The payload is a complex nested structure — pass the full request body as a dict.
@@ -338,9 +330,7 @@ async def list_employee_tax_elections(
     )
 
 
-async def update_employee_tax_elections(
-    ctx: Ctx, employee_id: str, data: dict
-) -> dict:
+async def update_employee_tax_elections(ctx: Ctx, employee_id: str, data: dict) -> dict:
     """Update tax elections for an employee.
 
     The payload is a complex nested structure — pass the full request body as a dict.
@@ -508,9 +498,7 @@ async def list_employee_tax_statements(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
-    return await check_api_list(
-        ctx, "/employee_tax_statements", params=params or None
-    )
+    return await check_api_list(ctx, "/employee_tax_statements", params=params or None)
 
 
 async def get_employee_tax_statement(ctx: Ctx, statement_id: str) -> dict:

--- a/src/mcp_server_check/tools/webhooks.py
+++ b/src/mcp_server_check/tools/webhooks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/src/mcp_server_check/tools/workflows.py
+++ b/src/mcp_server_check/tools/workflows.py
@@ -7,10 +7,24 @@ These tools compose multiple API calls server-side, saving the LLM
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Coroutine
+from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import Ctx, check_api_get, check_api_list
+
+
+async def _gather_named(
+    calls: dict[str, Coroutine[Any, Any, Any]],
+) -> dict[str, Any]:
+    """Run named coroutines concurrently, returning {name: result}.
+
+    Python 3.10-compatible alternative to asyncio.TaskGroup.
+    """
+    keys = list(calls.keys())
+    results = await asyncio.gather(*calls.values())
+    return dict(zip(keys, results))
 
 
 async def get_company_overview(
@@ -35,45 +49,29 @@ async def get_company_overview(
         employee_limit: Max employees to return (default 10).
         payroll_limit: Max payrolls to return (default 5).
     """
-    # Always fetch the company
-    tasks: dict[str, asyncio.Task] = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["company"] = tg.create_task(
-            check_api_get(ctx, f"/companies/{company_id}")
+    calls: dict[str, Coroutine[Any, Any, Any]] = {
+        "company": check_api_get(ctx, f"/companies/{company_id}"),
+    }
+    if include_employees:
+        calls["employees"] = check_api_list(
+            ctx,
+            "/employees",
+            params={"company": company_id, "limit": employee_limit},
         )
-        if include_employees:
-            tasks["employees"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    "/employees",
-                    params={"company": company_id, "limit": employee_limit},
-                )
-            )
-        if include_payrolls:
-            tasks["payrolls"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    "/payrolls",
-                    params={"company": company_id, "limit": payroll_limit},
-                )
-            )
-        if include_bank_accounts:
-            tasks["bank_accounts"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    "/bank_accounts",
-                    params={"company": company_id},
-                )
-            )
+    if include_payrolls:
+        calls["payrolls"] = check_api_list(
+            ctx,
+            "/payrolls",
+            params={"company": company_id, "limit": payroll_limit},
+        )
+    if include_bank_accounts:
+        calls["bank_accounts"] = check_api_list(
+            ctx,
+            "/bank_accounts",
+            params={"company": company_id},
+        )
 
-    result: dict = {"company": tasks["company"].result()}
-    if "employees" in tasks:
-        result["employees"] = tasks["employees"].result()
-    if "payrolls" in tasks:
-        result["payrolls"] = tasks["payrolls"].result()
-    if "bank_accounts" in tasks:
-        result["bank_accounts"] = tasks["bank_accounts"].result()
-    return result
+    return await _gather_named(calls)
 
 
 async def get_employee_snapshot(
@@ -94,30 +92,19 @@ async def get_employee_snapshot(
         include_paystubs: Include recent paystubs (default true).
         paystub_limit: Max paystubs to return (default 5).
     """
-    tasks: dict[str, asyncio.Task] = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["employee"] = tg.create_task(
-            check_api_get(ctx, f"/employees/{employee_id}")
+    calls: dict[str, Coroutine[Any, Any, Any]] = {
+        "employee": check_api_get(ctx, f"/employees/{employee_id}"),
+    }
+    if include_tax_params:
+        calls["tax_params"] = check_api_get(ctx, f"/employee_tax_params/{employee_id}")
+    if include_paystubs:
+        calls["paystubs"] = check_api_list(
+            ctx,
+            f"/employees/{employee_id}/paystubs",
+            params={"limit": paystub_limit},
         )
-        if include_tax_params:
-            tasks["tax_params"] = tg.create_task(
-                check_api_get(ctx, f"/employee_tax_params/{employee_id}")
-            )
-        if include_paystubs:
-            tasks["paystubs"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    f"/employees/{employee_id}/paystubs",
-                    params={"limit": paystub_limit},
-                )
-            )
 
-    result: dict = {"employee": tasks["employee"].result()}
-    if "tax_params" in tasks:
-        result["tax_params"] = tasks["tax_params"].result()
-    if "paystubs" in tasks:
-        result["paystubs"] = tasks["paystubs"].result()
-    return result
+    return await _gather_named(calls)
 
 
 async def diagnose_payment(
@@ -133,26 +120,28 @@ async def diagnose_payment(
     Args:
         payment_id: The Check payment ID (e.g. "pmt_xxxxx").
     """
-    tasks: dict[str, asyncio.Task] = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["payment"] = tg.create_task(check_api_get(ctx, f"/payments/{payment_id}"))
-        tasks["attempts"] = tg.create_task(
-            check_api_list(ctx, f"/payments/{payment_id}/payment_attempts")
-        )
+    fetched = await _gather_named(
+        {
+            "payment": check_api_get(ctx, f"/payments/{payment_id}"),
+            "payment_attempts": check_api_list(
+                ctx, f"/payments/{payment_id}/payment_attempts"
+            ),
+        }
+    )
 
-    payment = tasks["payment"].result()
+    payment = fetched["payment"]
     result: dict = {
         "payment": payment,
-        "payment_attempts": tasks["attempts"].result(),
+        "payment_attempts": fetched["payment_attempts"],
     }
 
-    # If the payment has a payroll_item, fetch it too
     payroll_item_id = None
     if isinstance(payment, dict) and "error" not in payment:
         payroll_item_id = payment.get("payroll_item")
     if payroll_item_id:
-        payroll_item = await check_api_get(ctx, f"/payroll_items/{payroll_item_id}")
-        result["payroll_item"] = payroll_item
+        result["payroll_item"] = await check_api_get(
+            ctx, f"/payroll_items/{payroll_item_id}"
+        )
 
     return result
 
@@ -175,34 +164,23 @@ async def get_payroll_details(
         include_contractor_payments: Include contractor payments (default true).
         item_limit: Max payroll items to return (default 50).
     """
-    tasks: dict[str, asyncio.Task] = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["payroll"] = tg.create_task(
-            check_api_get(ctx, f"/payrolls/{payroll_id}")
+    calls: dict[str, Coroutine[Any, Any, Any]] = {
+        "payroll": check_api_get(ctx, f"/payrolls/{payroll_id}"),
+    }
+    if include_items:
+        calls["payroll_items"] = check_api_list(
+            ctx,
+            "/payroll_items",
+            params={"payroll": payroll_id, "limit": item_limit},
         )
-        if include_items:
-            tasks["items"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    "/payroll_items",
-                    params={"payroll": payroll_id, "limit": item_limit},
-                )
-            )
-        if include_contractor_payments:
-            tasks["contractor_payments"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    "/contractor_payments",
-                    params={"payroll": payroll_id},
-                )
-            )
+    if include_contractor_payments:
+        calls["contractor_payments"] = check_api_list(
+            ctx,
+            "/contractor_payments",
+            params={"payroll": payroll_id},
+        )
 
-    result: dict = {"payroll": tasks["payroll"].result()}
-    if "items" in tasks:
-        result["payroll_items"] = tasks["items"].result()
-    if "contractor_payments" in tasks:
-        result["contractor_payments"] = tasks["contractor_payments"].result()
-    return result
+    return await _gather_named(calls)
 
 
 async def get_contractor_snapshot(
@@ -223,33 +201,22 @@ async def get_contractor_snapshot(
         include_forms: Include contractor forms (default true).
         payment_limit: Max payments to return (default 10).
     """
-    tasks: dict[str, asyncio.Task] = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["contractor"] = tg.create_task(
-            check_api_get(ctx, f"/contractors/{contractor_id}")
+    calls: dict[str, Coroutine[Any, Any, Any]] = {
+        "contractor": check_api_get(ctx, f"/contractors/{contractor_id}"),
+    }
+    if include_payments:
+        calls["payments"] = check_api_list(
+            ctx,
+            f"/contractors/{contractor_id}/payments",
+            params={"limit": payment_limit},
         )
-        if include_payments:
-            tasks["payments"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    f"/contractors/{contractor_id}/payments",
-                    params={"limit": payment_limit},
-                )
-            )
-        if include_forms:
-            tasks["forms"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    f"/contractors/{contractor_id}/forms",
-                )
-            )
+    if include_forms:
+        calls["forms"] = check_api_list(
+            ctx,
+            f"/contractors/{contractor_id}/forms",
+        )
 
-    result: dict = {"contractor": tasks["contractor"].result()}
-    if "payments" in tasks:
-        result["payments"] = tasks["payments"].result()
-    if "forms" in tasks:
-        result["forms"] = tasks["forms"].result()
-    return result
+    return await _gather_named(calls)
 
 
 async def get_company_tax_overview(
@@ -270,33 +237,22 @@ async def get_company_tax_overview(
         include_filings: Include recent tax filings (default true).
         filing_limit: Max tax filings to return (default 10).
     """
-    tasks: dict[str, asyncio.Task] = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["tax_params"] = tg.create_task(
-            check_api_get(ctx, f"/company_tax_params/{company_id}")
+    calls: dict[str, Coroutine[Any, Any, Any]] = {
+        "tax_params": check_api_get(ctx, f"/company_tax_params/{company_id}"),
+    }
+    if include_elections:
+        calls["tax_elections"] = check_api_list(
+            ctx,
+            f"/companies/{company_id}/tax_elections",
         )
-        if include_elections:
-            tasks["elections"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    f"/companies/{company_id}/tax_elections",
-                )
-            )
-        if include_filings:
-            tasks["filings"] = tg.create_task(
-                check_api_list(
-                    ctx,
-                    "/tax_filings",
-                    params={"company": company_id, "limit": filing_limit},
-                )
-            )
+    if include_filings:
+        calls["tax_filings"] = check_api_list(
+            ctx,
+            "/tax_filings",
+            params={"company": company_id, "limit": filing_limit},
+        )
 
-    result: dict = {"tax_params": tasks["tax_params"].result()}
-    if "elections" in tasks:
-        result["tax_elections"] = tasks["elections"].result()
-    if "filings" in tasks:
-        result["tax_filings"] = tasks["filings"].result()
-    return result
+    return await _gather_named(calls)
 
 
 async def get_onboarding_status(
@@ -313,49 +269,38 @@ async def get_onboarding_status(
     Args:
         company_id: The Check company ID (e.g. "com_xxxxx").
     """
-    tasks: dict[str, asyncio.Task] = {}
-    async with asyncio.TaskGroup() as tg:
-        tasks["company"] = tg.create_task(
-            check_api_get(ctx, f"/companies/{company_id}")
-        )
-        tasks["workplaces"] = tg.create_task(
-            check_api_list(
+    fetched = await _gather_named(
+        {
+            "company": check_api_get(ctx, f"/companies/{company_id}"),
+            "workplaces": check_api_list(
                 ctx, "/workplaces", params={"company": company_id}
-            )
-        )
-        tasks["employees"] = tg.create_task(
-            check_api_list(
+            ),
+            "employees": check_api_list(
                 ctx, "/employees", params={"company": company_id, "limit": 5}
-            )
-        )
-        tasks["bank_accounts"] = tg.create_task(
-            check_api_list(
+            ),
+            "bank_accounts": check_api_list(
                 ctx, "/bank_accounts", params={"company": company_id}
-            )
-        )
-        tasks["requirements"] = tg.create_task(
-            check_api_list(
+            ),
+            "requirements": check_api_list(
                 ctx, "/requirements", params={"company": company_id}
-            )
-        )
+            ),
+        }
+    )
 
-    company = tasks["company"].result()
-    workplaces = tasks["workplaces"].result()
-    employees = tasks["employees"].result()
-    bank_accounts = tasks["bank_accounts"].result()
-    requirements = tasks["requirements"].result()
+    workplaces = fetched["workplaces"]
+    employees = fetched["employees"]
+    bank_accounts = fetched["bank_accounts"]
+    requirements = fetched["requirements"]
 
-    # Build a readiness summary
+    req_results = requirements.get("results", [])
+    outstanding = [r for r in req_results if r.get("status") != "met"]
     readiness: dict = {
         "has_workplaces": bool(workplaces.get("results")),
         "has_employees": bool(employees.get("results")),
         "has_bank_accounts": bool(bank_accounts.get("results")),
+        "outstanding_requirements": len(outstanding),
+        "total_requirements": len(req_results),
     }
-    # Count outstanding requirements
-    req_results = requirements.get("results", [])
-    outstanding = [r for r in req_results if r.get("status") != "met"]
-    readiness["outstanding_requirements"] = len(outstanding)
-    readiness["total_requirements"] = len(req_results)
     readiness["ready"] = (
         readiness["has_workplaces"]
         and readiness["has_employees"]
@@ -364,7 +309,7 @@ async def get_onboarding_status(
     )
 
     return {
-        "company": company,
+        "company": fetched["company"],
         "readiness": readiness,
         "workplaces": workplaces,
         "employees": employees,

--- a/src/mcp_server_check/tools/workplaces.py
+++ b/src/mcp_server_check/tools/workplaces.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
     Ctx,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,9 @@ from dataclasses import dataclass
 import httpx
 import pytest
 import respx
+from fastmcp import Context, FastMCP
+from fastmcp.server.context import _current_context
+from mcp.server.lowlevel.server import request_ctx
 from mcp_server_check.helpers import CheckContext
 
 BASE_URL = "https://sandbox.checkhq.com"
@@ -15,12 +18,16 @@ BASE_URL = "https://sandbox.checkhq.com"
 @dataclass
 class FakeRequestContext:
     lifespan_context: CheckContext
+    request: None = None
 
 
 class FakeCtx:
-    """Minimal stand-in for mcp Context that provides lifespan_context."""
+    """Minimal stand-in for fastmcp Context that provides lifespan_context.
 
-    def __init__(self, check_ctx: CheckContext):
+    Used for direct tool function calls in tests.
+    """
+
+    def __init__(self, check_ctx: CheckContext) -> None:
         self.request_context = FakeRequestContext(lifespan_context=check_ctx)
 
 
@@ -32,11 +39,29 @@ def mock_api():
 
 @pytest.fixture
 def ctx(mock_api):
-    """Create a fake context with an httpx client routed through respx."""
+    """Create a fake context with an httpx client routed through respx.
+
+    Sets both the MCP request_ctx ContextVar (for lifespan_context access)
+    and the fastmcp _current_context ContextVar (for FunctionTool.run()
+    dependency injection).
+    """
     client = httpx.AsyncClient(
         base_url=BASE_URL,
         headers={"Authorization": "Bearer test-key"},
         timeout=30.0,
     )
     check_ctx = CheckContext(client=client, base_url=BASE_URL)
-    return FakeCtx(check_ctx)
+    fake_ctx = FakeCtx(check_ctx)
+
+    # Set MCP SDK ContextVar so ctx.request_context.lifespan_context works
+    rc_token = request_ctx.set(fake_ctx.request_context)
+
+    # Set fastmcp ContextVar so FunctionTool.run() can inject Context
+    _server = FastMCP("test")
+    real_context = Context(_server)
+    ctx_token = _current_context.set(real_context)
+
+    yield fake_ctx
+
+    _current_context.reset(ctx_token)
+    request_ctx.reset(rc_token)

--- a/tests/test_bank_accounts.py
+++ b/tests/test_bank_accounts.py
@@ -43,9 +43,7 @@ async def test_create_bank_account(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_delete_bank_account(mock_api, ctx):
-    mock_api.delete("/bank_accounts/bnk_001").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/bank_accounts/bnk_001").mock(return_value=httpx.Response(204))
     result = await delete_bank_account(ctx, bank_account_id="bnk_001")
     assert result == {"success": True}
 
@@ -53,9 +51,7 @@ async def test_delete_bank_account(mock_api, ctx):
 @pytest.mark.anyio
 async def test_reveal_bank_account_number(mock_api, ctx):
     mock_api.get("/bank_accounts/bnk_001/reveal").mock(
-        return_value=httpx.Response(
-            200, json={"raw_account_number": "123456789"}
-        )
+        return_value=httpx.Response(200, json={"raw_account_number": "123456789"})
     )
     result = await reveal_bank_account_number(ctx, bank_account_id="bnk_001")
     assert result["raw_account_number"] == "123456789"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,11 @@ def test_companies_list(respx_mock):
     respx_mock.get("/companies").mock(
         return_value=httpx.Response(
             200,
-            json={"results": [{"id": "com_001", "legal_name": "Acme"}], "next": None, "previous": None},
+            json={
+                "results": [{"id": "com_001", "legal_name": "Acme"}],
+                "next": None,
+                "previous": None,
+            },
         )
     )
     result = _invoke("companies", "list")

--- a/tests/test_compensation.py
+++ b/tests/test_compensation.py
@@ -9,7 +9,6 @@ from mcp_server_check.tools.compensation import (
     create_benefit,
     create_pay_schedule,
     delete_pay_schedule,
-    get_pay_schedule,
     list_company_benefits,
     list_earning_codes,
     list_pay_schedules,
@@ -45,9 +44,7 @@ async def test_create_pay_schedule(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_delete_pay_schedule(mock_api, ctx):
-    mock_api.delete("/pay_schedules/psc_001").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/pay_schedules/psc_001").mock(return_value=httpx.Response(204))
     result = await delete_pay_schedule(ctx, pay_schedule_id="psc_001")
     assert result == {"success": True}
 

--- a/tests/test_contractor_payments.py
+++ b/tests/test_contractor_payments.py
@@ -39,7 +39,9 @@ async def test_create_contractor_payment(mock_api, ctx):
     mock_api.post("/contractor_payments").mock(
         return_value=httpx.Response(201, json={"id": "cp_new"})
     )
-    result = await create_contractor_payment(ctx, contractor="ctr_001", payroll="prl_001")
+    result = await create_contractor_payment(
+        ctx, contractor="ctr_001", payroll="prl_001"
+    )
     assert result["id"] == "cp_new"
 
 

--- a/tests/test_employees.py
+++ b/tests/test_employees.py
@@ -36,22 +36,16 @@ async def test_create_employee(mock_api, ctx):
 @pytest.mark.anyio
 async def test_update_employee(mock_api, ctx):
     mock_api.patch("/employees/emp_001").mock(
-        return_value=httpx.Response(
-            200, json={"id": "emp_001", "first_name": "Janet"}
-        )
+        return_value=httpx.Response(200, json={"id": "emp_001", "first_name": "Janet"})
     )
-    result = await update_employee(
-        ctx, employee_id="emp_001", first_name="Janet"
-    )
+    result = await update_employee(ctx, employee_id="emp_001", first_name="Janet")
     assert result["first_name"] == "Janet"
 
 
 @pytest.mark.anyio
 async def test_onboard_employee(mock_api, ctx):
     mock_api.post("/employees/emp_001/onboard").mock(
-        return_value=httpx.Response(
-            200, json={"id": "emp_001", "onboard": "complete"}
-        )
+        return_value=httpx.Response(200, json={"id": "emp_001", "onboard": "complete"})
     )
     result = await onboard_employee(ctx, employee_id="emp_001")
     assert result["onboard"] == "complete"

--- a/tests/test_external_payrolls.py
+++ b/tests/test_external_payrolls.py
@@ -42,9 +42,7 @@ async def test_create_external_payroll(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_delete_external_payroll(mock_api, ctx):
-    mock_api.delete("/external_payrolls/ep_001").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/external_payrolls/ep_001").mock(return_value=httpx.Response(204))
     result = await delete_external_payroll(ctx, payroll_id="ep_001")
     assert result == {"success": True}
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,9 +17,7 @@ from mcp_server_check.helpers import (
 
 @pytest.mark.anyio
 async def test_check_api_get(mock_api, ctx):
-    mock_api.get("/test").mock(
-        return_value=httpx.Response(200, json={"id": "t_1"})
-    )
+    mock_api.get("/test").mock(return_value=httpx.Response(200, json={"id": "t_1"}))
     result = await check_api_get(ctx, "/test")
     assert result == {"id": "t_1"}
 
@@ -35,9 +33,7 @@ async def test_check_api_get_with_params(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_check_api_post(mock_api, ctx):
-    route = mock_api.post("/test").mock(
-        return_value=httpx.Response(201, json={"id": "t_new"})
-    )
+    mock_api.post("/test").mock(return_value=httpx.Response(201, json={"id": "t_new"}))
     result = await check_api_post(ctx, "/test", data={"name": "foo"})
     assert result == {"id": "t_new"}
 
@@ -62,9 +58,7 @@ async def test_check_api_put(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_check_api_delete(mock_api, ctx):
-    mock_api.delete("/test/t_1").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/test/t_1").mock(return_value=httpx.Response(204))
     result = await check_api_delete(ctx, "/test/t_1")
     assert result == {"success": True}
 

--- a/tests/test_payroll_items.py
+++ b/tests/test_payroll_items.py
@@ -49,14 +49,14 @@ async def test_update_payroll_item(mock_api, ctx):
     mock_api.patch("/payroll_items/pit_001").mock(
         return_value=httpx.Response(200, json={"id": "pit_001"})
     )
-    result = await update_payroll_item(ctx, payroll_item_id="pit_001", payment_method="direct_deposit")
+    result = await update_payroll_item(
+        ctx, payroll_item_id="pit_001", payment_method="direct_deposit"
+    )
     assert result["id"] == "pit_001"
 
 
 @pytest.mark.anyio
 async def test_delete_payroll_item(mock_api, ctx):
-    mock_api.delete("/payroll_items/pit_001").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/payroll_items/pit_001").mock(return_value=httpx.Response(204))
     result = await delete_payroll_item(ctx, payroll_item_id="pit_001")
     assert result == {"success": True}

--- a/tests/test_payrolls.py
+++ b/tests/test_payrolls.py
@@ -44,9 +44,7 @@ async def test_update_payroll(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_delete_payroll(mock_api, ctx):
-    mock_api.delete("/payrolls/prl_001").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/payrolls/prl_001").mock(return_value=httpx.Response(204))
     result = await delete_payroll(ctx, payroll_id="prl_001")
     assert result == {"success": True}
 
@@ -63,7 +61,9 @@ async def test_preview_payroll(mock_api, ctx):
 @pytest.mark.anyio
 async def test_approve_payroll(mock_api, ctx):
     mock_api.post("/payrolls/prl_001/approve").mock(
-        return_value=httpx.Response(200, json={"id": "prl_001", "approval_status": "approved"})
+        return_value=httpx.Response(
+            200, json={"id": "prl_001", "approval_status": "approved"}
+        )
     )
     result = await approve_payroll(ctx, payroll_id="prl_001")
     assert result["approval_status"] == "approved"
@@ -72,7 +72,9 @@ async def test_approve_payroll(mock_api, ctx):
 @pytest.mark.anyio
 async def test_reopen_payroll(mock_api, ctx):
     mock_api.post("/payrolls/prl_001/reopen").mock(
-        return_value=httpx.Response(200, json={"id": "prl_001", "approval_status": "draft"})
+        return_value=httpx.Response(
+            200, json={"id": "prl_001", "approval_status": "draft"}
+        )
     )
     result = await reopen_payroll(ctx, payroll_id="prl_001")
     assert result["approval_status"] == "draft"

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -52,7 +52,9 @@ async def test_validate_address(mock_api, ctx):
     mock_api.post("/addresses/validate").mock(
         return_value=httpx.Response(200, json={"valid": True})
     )
-    result = await validate_address(ctx, line1="123 Main St", city="Anytown", state="CA", postal_code="12345")
+    result = await validate_address(
+        ctx, line1="123 Main St", city="Anytown", state="CA", postal_code="12345"
+    )
     assert result["valid"] is True
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -103,8 +103,18 @@ class TestFormatListResponse:
             "next": None,
             "previous": None,
             "results": [
-                {"id": "com_1", "legal_name": "Acme", "metadata": {"key": "val"}, "created_at": "2025-01-01"},
-                {"id": "com_2", "legal_name": "Widget", "metadata": {}, "ein": "12-3456789"},
+                {
+                    "id": "com_1",
+                    "legal_name": "Acme",
+                    "metadata": {"key": "val"},
+                    "created_at": "2025-01-01",
+                },
+                {
+                    "id": "com_2",
+                    "legal_name": "Widget",
+                    "metadata": {},
+                    "ein": "12-3456789",
+                },
             ],
         }
         result = _format_list_response(data, summarize=True)

--- a/tests/test_tool_factory.py
+++ b/tests/test_tool_factory.py
@@ -60,9 +60,7 @@ class TestBuildBody:
             Field("name", str, required_for="create"),
             Field("active", bool, update_only=True),
         ]
-        body = _build_body(
-            fields, {"name": "Test", "active": True}, is_create=True
-        )
+        body = _build_body(fields, {"name": "Test", "active": True}, is_create=True)
         assert body == {"name": "Test"}
 
 
@@ -264,8 +262,6 @@ async def test_generated_delete_calls_api(mock_api, ctx):
         fields=[],
     )
     tools = generate_tools(res)
-    mock_api.delete("/widgets/w_1").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/widgets/w_1").mock(return_value=httpx.Response(204))
     result = await tools.delete_fn(ctx, widget_id="w_1")
     assert result == {"success": True}

--- a/tests/test_tool_index.py
+++ b/tests/test_tool_index.py
@@ -246,25 +246,25 @@ class TestToolIndexRun:
     @pytest.mark.anyio
     async def test_run_unknown_tool(self):
         with pytest.raises(ValueError, match="Unknown tool"):
-            await self.index.run("nonexistent_tool", {}, None, self.no_filter)
+            await self.index.run("nonexistent_tool", {}, self.no_filter)
 
     @pytest.mark.anyio
     async def test_run_unknown_tool_has_suggestion(self):
         """Error message for unknown tool includes a suggestion."""
         with pytest.raises(ValueError, match="Did you mean"):
-            await self.index.run("list_companie", {}, None, self.no_filter)
+            await self.index.run("list_companie", {}, self.no_filter)
 
     @pytest.mark.anyio
     async def test_run_blocked_by_filter(self):
         tf = ToolFilter(exclude_tools=frozenset({"list_companies"}))
         with pytest.raises(ValueError, match="not available"):
-            await self.index.run("list_companies", {}, None, tf)
+            await self.index.run("list_companies", {}, tf)
 
     @pytest.mark.anyio
     async def test_run_blocked_by_read_only(self):
         tf = ToolFilter(read_only=True)
         with pytest.raises(ValueError, match="not available"):
-            await self.index.run("create_company", {}, None, tf)
+            await self.index.run("create_company", {}, tf)
 
     @pytest.mark.anyio
     async def test_run_dispatches_correctly(self, mock_api, ctx):
@@ -281,7 +281,7 @@ class TestToolIndexRun:
                 },
             )
         )
-        result = await self.index.run("list_companies", {}, ctx, self.no_filter)
+        result = await self.index.run("list_companies", {}, self.no_filter)
         assert result["results"] == [{"id": "com_001"}]
 
     @pytest.mark.anyio
@@ -295,7 +295,7 @@ class TestToolIndexRun:
             )
         )
         result = await self.index.run(
-            "get_company", {"company_id": "com_001"}, ctx, self.no_filter
+            "get_company", {"company_id": "com_001"}, self.no_filter
         )
         assert result == {"id": "com_001", "legal_name": "Acme Corp"}
 
@@ -334,8 +334,8 @@ class TestDynamicModeServer:
         return server
 
     def _extract_text(self, result):
-        """Extract text from call_tool result (tuple of [TextContent, ...])."""
-        return result[0][0].text
+        """Extract text from call_tool ToolResult."""
+        return result.content[0].text
 
     @pytest.mark.anyio
     async def test_list_tools_returns_three(self):
@@ -390,7 +390,10 @@ class TestDynamicModeServer:
         server = self._make_dynamic_server()
         tools = await server.list_tools()
         run_tool_schema = next(t for t in tools if t.name == "run_tool")
-        props = run_tool_schema.inputSchema.get("properties", {})
+        schema = (
+            getattr(run_tool_schema, "inputSchema", None) or run_tool_schema.parameters
+        )
+        props = schema.get("properties", {})
         args_schema = props.get("arguments", {})
         # arguments should accept an object type (dict), not just string
         assert args_schema.get("type") in ("object", None) or "anyOf" in args_schema

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -36,9 +36,7 @@ async def test_create_webhook_config(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_delete_webhook_config(mock_api, ctx):
-    mock_api.delete("/webhook_configs/whc_001").mock(
-        return_value=httpx.Response(204)
-    )
+    mock_api.delete("/webhook_configs/whc_001").mock(return_value=httpx.Response(204))
     result = await delete_webhook_config(ctx, webhook_config_id="whc_001")
     assert result == {"success": True}
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -219,9 +219,7 @@ async def test_get_company_tax_overview(mock_api, ctx):
         return_value=httpx.Response(200, json={"id": "com_001", "params": []})
     )
     mock_api.get("/companies/com_001/tax_elections").mock(
-        return_value=httpx.Response(
-            200, json=_list_response([{"id": "ele_001"}])
-        )
+        return_value=httpx.Response(200, json=_list_response([{"id": "ele_001"}]))
     )
     mock_api.get("/tax_filings").mock(
         return_value=httpx.Response(
@@ -242,9 +240,7 @@ async def test_get_onboarding_status_ready(mock_api, ctx):
         return_value=httpx.Response(200, json={"id": "com_001", "status": "active"})
     )
     mock_api.get("/workplaces").mock(
-        return_value=httpx.Response(
-            200, json=_list_response([{"id": "wrk_001"}])
-        )
+        return_value=httpx.Response(200, json=_list_response([{"id": "wrk_001"}]))
     )
     mock_api.get("/employees").mock(
         return_value=httpx.Response(
@@ -252,9 +248,7 @@ async def test_get_onboarding_status_ready(mock_api, ctx):
         )
     )
     mock_api.get("/bank_accounts").mock(
-        return_value=httpx.Response(
-            200, json=_list_response([{"id": "bnk_001"}])
-        )
+        return_value=httpx.Response(200, json=_list_response([{"id": "bnk_001"}]))
     )
     mock_api.get("/requirements").mock(
         return_value=httpx.Response(
@@ -289,10 +283,12 @@ async def test_get_onboarding_status_not_ready(mock_api, ctx):
     mock_api.get("/requirements").mock(
         return_value=httpx.Response(
             200,
-            json=_list_response([
-                {"id": "req_001", "status": "unmet"},
-                {"id": "req_002", "status": "met"},
-            ]),
+            json=_list_response(
+                [
+                    {"id": "req_001", "status": "unmet"},
+                    {"id": "req_002", "status": "met"},
+                ]
+            ),
         )
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,18 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
+
+[[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -35,12 +47,80 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.6.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/dd/57fe3fdb6e65b25a5987fd2cdc7e22db0aef508b91634d2e57d22928d41b/cachetools-7.0.5.tar.gz", hash = "sha256:0cd042c24377200c1dcd225f8b7b12b0ca53cc2c961b43757e774ebe190fd990", size = 37367, upload-time = "2026-03-09T20:51:29.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/f3/39cf3367b8107baa44f861dc802cbf16263c945b62d8265d36034fc07bea/cachetools-7.0.5-py3-none-any.whl", hash = "sha256:46bc8ebefbe485407621d0a4264b23c080cedd913921bad7ac3ed2f26c183114", size = 13918, upload-time = "2026-03-09T20:51:27.33Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -216,6 +296,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/e7/3e26855c046ac527cf94d890f6698e703980337f22ea7097e02b35b910f9/cyclopts-4.10.0.tar.gz", hash = "sha256:0ae04a53274e200ef3477c8b54de63b019bc6cd0162d75c718bf40c9c3fb5268", size = 166394, upload-time = "2026-03-14T14:09:31.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/06/d68a5d5d292c2ad2bc6a02e5ca2cb1bb9c15e941ab02f004a06a342d7f0f/cyclopts-4.10.0-py3-none-any.whl", hash = "sha256:50f333382a60df8d40ec14aa2e627316b361c4f478598ada1f4169d959bf9ea7", size = 204097, upload-time = "2026-03-14T14:09:32.504Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -225,6 +362,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
 ]
 
 [[package]]
@@ -283,12 +452,78 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -307,6 +542,20 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/8a/7e6102f2b8bdc6705a9eb5294f8f6f9ccd3a8420e8e8e19671d1dd773251/jsonschema_path-0.4.5.tar.gz", hash = "sha256:c6cd7d577ae290c7defd4f4029e86fdb248ca1bd41a07557795b3c95e5144918", size = 15113, upload-time = "2026-03-03T09:56:46.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d5/4e96c44f6c1ea3d812cf5391d81a4f5abaa540abf8d04ecd7f66e0ed11df/jsonschema_path-0.4.5-py3-none-any.whl", hash = "sha256:7d77a2c3f3ec569a40efe5c5f942c44c1af2a6f96fe0866794c9ef5b8f87fd65", size = 19368, upload-time = "2026-03-03T09:56:45.39Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -316,6 +565,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
 [[package]]
@@ -349,8 +628,8 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "fastmcp" },
     { name = "httpx" },
-    { name = "mcp" },
 ]
 
 [package.dev-dependencies]
@@ -358,13 +637,14 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "respx" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
+    { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -372,6 +652,50 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "respx", specifier = ">=0.22" },
+    { name = "ruff", specifier = ">=0.15.6" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
 ]
 
 [[package]]
@@ -384,12 +708,55 @@ wheels = [
 ]
 
 [[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
 ]
 
 [[package]]
@@ -414,6 +781,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -572,6 +944,15 @@ crypto = [
 ]
 
 [[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -644,6 +1025,79 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +1121,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/7c/96bd0bc759cf009675ad1ee1f96535edcb11e9666b985717eb8c87192a95/respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91", size = 28439, upload-time = "2024-12-19T22:33:59.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/67/afbb0978d5399bc9ea200f1d4489a23c9a1dad4eee6376242b8182389c79/respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0", size = 25127, upload-time = "2024-12-19T22:33:57.837Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]
@@ -792,6 +1272,44 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
+    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
+    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -893,6 +1411,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/7c/b5b7d8136f872e3f13b0584e576886de0489d7213a12de6bebf29ff6ebfc/uncalled_for-0.2.0.tar.gz", hash = "sha256:b4f8fdbcec328c5a113807d653e041c5094473dd4afa7c34599ace69ccb7e69f", size = 49488, upload-time = "2026-02-27T17:40:58.137Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/7f/4320d9ce3be404e6310b915c3629fe27bf1e2f438a1a7a3cb0396e32e9a9/uncalled_for-0.2.0-py3-none-any.whl", hash = "sha256:2c0bd338faff5f930918f79e7eb9ff48290df2cb05fcc0b40a7f334e55d4d85f", size = 11351, upload-time = "2026-02-27T17:40:56.804Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -904,4 +1431,184 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
+    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
+    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
## Summary

Migrates the core MCP dependency from `mcp` (`mcp.server.fastmcp`) to `fastmcp` v3, which provides a cleaner API for tool registration, context injection via ContextVar, and better support for hosted OAuth deployments.

### What changed

- **Dependency**: `mcp>=1.0.0` → `fastmcp>=2.0.0` in `pyproject.toml`
- **Imports**: All `from mcp.server.fastmcp import ...` → `from fastmcp import ...` across 18 tool modules, server, helpers, and tool index
- **Server API**: `CheckMCP.list_tools`/`call_tool` adapted to fastmcp v3 signatures (`FunctionTool`, `Sequence`, `**kwargs`)
- **Hosted support**: Added `token_resolver` callback to `CheckContext` for hosted auth flows; exposed `setup_tools()` as public API for reuse by hosted server packages (e.g. `mcp-server-check-hosted`)
- **Tool factory**: Set explicit `__annotations__` on dynamically generated functions so Pydantic/fastmcp introspection works correctly
- **Python 3.10 compat**: Replaced `asyncio.TaskGroup` (3.11+) with `_gather_named()` using `asyncio.gather` in workflow tools
- **Test fixtures**: Updated `conftest.py` to set both `request_ctx` and `_current_context` ContextVars for fastmcp's dependency injection
- **Lint cleanup**: Fixed 3 pre-existing ruff violations; applied ruff formatting to all source and test files

### Why

This migration is a prerequisite for `mcp-server-check-hosted`, which builds on this package to provide a hosted Lambda deployment with Console OAuth. The fastmcp v3 API makes context injection, tool registration, and OAuth proxy integration significantly cleaner than the older `mcp` package.

## Test plan

- [x] All 360 tests pass (including previously-ignored `test_workflows.py` — 12 tests)
- [x] `ruff check` clean (0 errors)
- [x] `ruff format --check` clean (0 files to reformat)
- [x] Manual validation: server imports, tool registration (dynamic + all modes), ToolIndex search, FunctionTool introspection on factory-generated tools, CheckContext fields, workflows module loading

Made with [Cursor](https://cursor.com)