### PR TITLE
Default to max page limits on supported list endpoints

### DIFF
--- a/src/mcp_server_check/tool_factory.py
+++ b/src/mcp_server_check/tool_factory.py
@@ -76,6 +76,9 @@ class Resource:
         list_filters: Names of query-parameter fields for list filtering
             (e.g. ["company", "employee"]).
         has_delete: Whether to generate a delete tool. Default True.
+        default_limit: Default page size for the list tool. When set, the
+            generated list function uses this as the default value for ``limit``
+            instead of ``None``, reducing pagination round-trips.
         list_doc: Custom docstring for the list tool.
         get_doc: Custom docstring for the get tool.
         create_doc: Custom docstring for the create tool.
@@ -91,6 +94,7 @@ class Resource:
     fields: list[Field] = dataclass_field(default_factory=list)
     list_filters: list[str] = dataclass_field(default_factory=list)
     has_delete: bool = True
+    default_limit: int | None = None
     list_doc: str | None = None
     get_doc: str | None = None
     create_doc: str | None = None
@@ -286,11 +290,19 @@ def _create_list_function(res: Resource, filter_fields: list[str]):
         else:
             filter_docs[fname] = f'Filter by {fname} (e.g. "{fname}_xxxxx").'
 
-    annotations["limit"] = int | None
+    limit_default = res.default_limit
+    if limit_default is not None:
+        annotations["limit"] = int
+        defaults["limit"] = limit_default
+        filter_docs["limit"] = (
+            f"Maximum number of results to return (max {limit_default}, default {limit_default})."
+        )
+    else:
+        annotations["limit"] = int | None
+        defaults["limit"] = None
+        filter_docs["limit"] = "Maximum number of results to return."
     annotations["cursor"] = str | None
-    defaults["limit"] = None
     defaults["cursor"] = None
-    filter_docs["limit"] = "Maximum number of results to return."
     filter_docs["cursor"] = "Pagination cursor from a previous response."
 
     path = res.path
@@ -325,14 +337,24 @@ def _create_list_function(res: Resource, filter_fields: list[str]):
                 annotation=str | None,
             )
         )
-    params_list.append(
-        inspect.Parameter(
-            "limit",
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            default=None,
-            annotation=int | None,
+    if limit_default is not None:
+        params_list.append(
+            inspect.Parameter(
+                "limit",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=limit_default,
+                annotation=int,
+            )
         )
-    )
+    else:
+        params_list.append(
+            inspect.Parameter(
+                "limit",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+                annotation=int | None,
+            )
+        )
     params_list.append(
         inspect.Parameter(
             "cursor",

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -308,6 +308,7 @@ _earning_rates = Resource(
     description="earning rates",
     list_filters=["company", "employee"],
     has_delete=False,
+    default_limit=500,
     fields=[
         Field(
             "employee",

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -16,7 +16,7 @@ from mcp_server_check.helpers import (
 async def list_employees(
     ctx: Ctx,
     company: str | None = None,
-    limit: int | None = None,
+    limit: int = 100,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
@@ -24,15 +24,14 @@ async def list_employees(
 
     Args:
         company: Filter to employees belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return (default 10, max 100).
+        limit: Maximum number of results to return (max 100, default 100).
         ids: Filter to specific employee IDs.
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
     if company is not None:
         params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if ids:
         params["ids"] = ",".join(ids)
     if cursor:

--- a/src/mcp_server_check/tools/payroll_items.py
+++ b/src/mcp_server_check/tools/payroll_items.py
@@ -19,7 +19,7 @@ async def list_payroll_items(
     company: str | None = None,
     employee: str | None = None,
     payroll: str | None = None,
-    limit: int | None = None,
+    limit: int = 500,
     ids: list[str] | None = None,
     cursor: str | None = None,
 ) -> dict:
@@ -29,7 +29,7 @@ async def list_payroll_items(
         company: Filter to payroll items belonging to this Check company ID (e.g. "com_xxxxx").
         employee: Filter to payroll items for this Check employee ID (e.g. "emp_xxxxx").
         payroll: Filter to payroll items for this Check payroll ID (e.g. "prl_xxxxx").
-        limit: Maximum number of results to return (default 10, max 100).
+        limit: Maximum number of results to return (max 500, default 500).
         ids: Filter to specific payroll item IDs.
         cursor: Pagination cursor from a previous response.
     """
@@ -40,8 +40,7 @@ async def list_payroll_items(
         params["employee"] = employee
     if payroll is not None:
         params["payroll"] = payroll
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if ids:
         params["ids"] = ",".join(ids)
     if cursor:

--- a/src/mcp_server_check/tools/workplaces.py
+++ b/src/mcp_server_check/tools/workplaces.py
@@ -16,21 +16,20 @@ from mcp_server_check.helpers import (
 async def list_workplaces(
     ctx: Ctx,
     company: str | None = None,
-    limit: int | None = None,
+    limit: int = 500,
     cursor: str | None = None,
 ) -> dict:
     """List workplaces, optionally filtered by company.
 
     Args:
         company: Filter to workplaces belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return (default 10, max 100).
+        limit: Maximum number of results to return (max 500, default 500).
         cursor: Pagination cursor from a previous response.
     """
     params: dict = {}
     if company is not None:
         params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
     return await check_api_list(ctx, "/workplaces", params=params or None)


### PR DESCRIPTION
## Summary
- Defaults list endpoints to their max supported page size instead of the API default of 10, reducing pagination round-trips
- Adds `default_limit` field to the `Resource` dataclass in `tool_factory.py` so declarative resources can also specify a default
- Affected endpoints: `list_workplaces` (500), `list_employees` (100), `list_payroll_items` (500), `list_earning_rates` (500)

## Test plan
- [x] `uv run pytest tests/ -v` — all 360 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)