### PR TITLE
Remove reveal endpoints for sensitive data

### DIFF
--- a/src/mcp_server_check/tools/bank_accounts.py
+++ b/src/mcp_server_check/tools/bank_accounts.py
@@ -117,19 +117,9 @@ async def delete_bank_account(ctx: Ctx, bank_account_id: str) -> dict:
     return await check_api_delete(ctx, f"/bank_accounts/{bank_account_id}")
 
 
-async def reveal_bank_account_number(ctx: Ctx, bank_account_id: str) -> dict:
-    """Reveal the full account number for a bank account.
-
-    Args:
-        bank_account_id: The Check bank account ID.
-    """
-    return await check_api_get(ctx, f"/bank_accounts/{bank_account_id}/reveal")
-
-
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_bank_accounts)
     mcp.add_tool(get_bank_account)
-    mcp.add_tool(reveal_bank_account_number)
     if not read_only:
         mcp.add_tool(create_bank_account)
         mcp.add_tool(update_bank_account)

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -302,22 +302,12 @@ async def submit_contractor_form(
     )
 
 
-async def reveal_contractor_ssn(ctx: Ctx, contractor_id: str) -> dict:
-    """Reveal the SSN/EIN for a contractor.
-
-    Args:
-        contractor_id: The Check contractor ID.
-    """
-    return await check_api_get(ctx, f"/contractors/{contractor_id}/reveal")
-
-
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(list_contractors)
     mcp.add_tool(get_contractor)
     mcp.add_tool(list_contractor_payments_for_contractor)
     mcp.add_tool(get_contractor_payment_for_payroll)
     mcp.add_tool(list_contractor_forms)
-    mcp.add_tool(reveal_contractor_ssn)
     if not read_only:
         mcp.add_tool(create_contractor)
         mcp.add_tool(update_contractor)

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -369,15 +369,6 @@ async def update_employee_reciprocity_elections(
 # --- Other ---
 
 
-async def reveal_employee_ssn(ctx: Ctx, employee_id: str) -> dict:
-    """Reveal the SSN for an employee.
-
-    Args:
-        employee_id: The Check employee ID.
-    """
-    return await check_api_get(ctx, f"/employees/{employee_id}/reveal")
-
-
 async def authorize_employee_partner(
     ctx: Ctx, employee_id: str, data: dict | None = None
 ) -> dict:
@@ -401,7 +392,6 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     mcp.add_tool(get_employee_form)
     mcp.add_tool(get_employee_company_defined_attributes)
     mcp.add_tool(get_employee_reciprocity_elections)
-    mcp.add_tool(reveal_employee_ssn)
     if not read_only:
         mcp.add_tool(create_employee)
         mcp.add_tool(update_employee)

--- a/tests/test_bank_accounts.py
+++ b/tests/test_bank_accounts.py
@@ -9,7 +9,6 @@ from mcp_server_check.tools.bank_accounts import (
     create_bank_account,
     delete_bank_account,
     list_bank_accounts,
-    reveal_bank_account_number,
 )
 
 
@@ -46,12 +45,3 @@ async def test_delete_bank_account(mock_api, ctx):
     mock_api.delete("/bank_accounts/bnk_001").mock(return_value=httpx.Response(204))
     result = await delete_bank_account(ctx, bank_account_id="bnk_001")
     assert result == {"success": True}
-
-
-@pytest.mark.anyio
-async def test_reveal_bank_account_number(mock_api, ctx):
-    mock_api.get("/bank_accounts/bnk_001/reveal").mock(
-        return_value=httpx.Response(200, json={"raw_account_number": "123456789"})
-    )
-    result = await reveal_bank_account_number(ctx, bank_account_id="bnk_001")
-    assert result["raw_account_number"] == "123456789"

--- a/tests/test_cli_codegen.py
+++ b/tests/test_cli_codegen.py
@@ -99,12 +99,6 @@ class TestMakeCommandName:
     def test_get_bank_account(self):
         assert _make_command_name("get_bank_account", "bank_accounts") == "get"
 
-    def test_reveal_bank_account_numbers(self):
-        assert (
-            _make_command_name("reveal_bank_account_numbers", "bank_accounts")
-            == "reveal-numbers"
-        )
-
     def test_list_contractor_payments(self):
         assert (
             _make_command_name("list_contractor_payments", "contractor_payments")

--- a/tests/test_employees.py
+++ b/tests/test_employees.py
@@ -11,7 +11,6 @@ from mcp_server_check.tools.employees import (
     list_employee_forms,
     list_employee_paystubs,
     onboard_employee,
-    reveal_employee_ssn,
     submit_employee_form,
     update_employee,
 )
@@ -93,12 +92,3 @@ async def test_submit_employee_form(mock_api, ctx):
     )
     result = await submit_employee_form(ctx, employee_id="emp_001", form_id="frm_001")
     assert result["status"] == "submitted"
-
-
-@pytest.mark.anyio
-async def test_reveal_employee_ssn(mock_api, ctx):
-    mock_api.get("/employees/emp_001/reveal").mock(
-        return_value=httpx.Response(200, json={"ssn": "123-45-6789"})
-    )
-    result = await reveal_employee_ssn(ctx, employee_id="emp_001")
-    assert result["ssn"] == "123-45-6789"

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -60,7 +60,6 @@ class TestIsWriteTool:
             "download_company_tax_document",
             "validate_address",
             "list_webhook_configs",
-            "reveal_employee_ssn",
             "get_enrollment_profile",
         ],
     )
@@ -362,7 +361,7 @@ class TestMerge:
         env = ToolFilter(
             toolsets=frozenset({"companies"}),
             read_only=True,
-            exclude_tools=frozenset({"reveal_employee_ssn"}),
+            exclude_tools=frozenset({"some_sensitive_tool"}),
         )
         header = ToolFilter(
             toolsets=frozenset({"companies", "employees"}),
@@ -371,7 +370,7 @@ class TestMerge:
         merged = env.merge(header)
         assert merged.toolsets == frozenset({"companies"})
         assert merged.read_only is True
-        assert merged.exclude_tools == frozenset({"reveal_employee_ssn"})
+        assert merged.exclude_tools == frozenset({"some_sensitive_tool"})
 
 
 class TestToolsets:


### PR DESCRIPTION
## Summary
- Remove `reveal_bank_account_number`, `reveal_employee_ssn`, and `reveal_contractor_ssn` tools
- These endpoints expose highly sensitive PII (SSNs, full bank account numbers) and should not be included in the standard MCP/CLI implementation

## Test plan
- [x] All 366 tests pass after removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)