### PR TITLE
Add MCP Usage Terms (Beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > **⚠️ Early Access Beta** — This MCP server is currently in beta and available to select partners. APIs, tools, and behavior may change without notice. Please share feedback with your Check point of contact.
 
+> **Terms of Service** — By using this MCP server to access the Check API, you agree to the [MCP Usage Terms](TERMS_OF_SERVICE.md), which are in addition to your existing agreement with Check.
+
 An [MCP](https://modelcontextprotocol.io/) server that wraps the [Check Payroll API](https://docs.checkhq.com/), providing 263 tools for managing companies, employees, contractors, payrolls, tax configuration, embedded components, and more.
 
 ## Quickstart

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,0 +1,30 @@
+# Check MCP Usage Terms (Beta)
+
+This MCP Usage (Beta) feature is part of, and subject to, your existing agreement
+with Check (the "Agreement"). Capitalized terms not defined here have the meanings
+given in the Agreement.
+
+The Check MCP server is a beta feature that gives you an alternative way to access
+existing Check platform functionality. It does not expand the scope of services
+under the Agreement. By enabling or using MCP, you agree to use it only as part of
+your authorized integration and are responsible for all activity performed using
+your credentials, including actions taken by scripts, automations, or AI agents.
+You should implement appropriate safeguards (such as access controls, monitoring,
+and rate limiting) and may only access data you're authorized to use.
+
+You may not:
+
+- Bypass limits or disrupt the platform
+- Build competing services or datasets
+- Sell or reuse data outside your application
+- Use MCP data to train machine learning models
+- Share data with third-party AI tools or services for training, fine-tuning, or
+  as input context, unless expressly permitted
+
+Check may monitor usage, enforce limits, and suspend access if misuse or risk is
+detected.
+
+MCP may change or be discontinued at any time and is provided "as is" without
+warranties of any kind. Except as set forth in the Agreement, Check is not
+responsible for actions or outcomes resulting from your use of MCP, including
+through automated systems.

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -27,6 +27,12 @@ You are connected to the Check Payroll API — a payroll infrastructure platform
 that lets you manage companies, employees, contractors, payrolls, tax filings, \
 and payments programmatically.
 
+**Important:** Use of this MCP server is subject to Check's MCP Usage Terms \
+(see TERMS_OF_SERVICE.md). The user is responsible for all actions performed \
+using their credentials, including actions taken by AI agents. Always confirm \
+before executing write operations that affect payroll, money movement, or \
+sensitive employee/contractor data.
+
 ## Entity Model
 - **Company** → has Workplaces, Employees, Contractors, Pay Schedules, Bank Accounts
 - **Employee** (W-2) → has Earning Rates, Benefits, Post-Tax Deductions, Tax Params, Forms


### PR DESCRIPTION
## Summary
- Adds TERMS_OF_SERVICE.md with Check MCP beta usage terms covering credential responsibility, prohibited uses (competing services, ML training, data resale), monitoring/suspension rights, and beta disclaimers
- Adds a prominent terms notice to the README, directly below the existing beta warning
- Surfaces the terms in SERVER_INSTRUCTIONS so the LLM is reminded to confirm before write operations affecting payroll, money movement, or sensitive data

## Context
Per discussion with legal (Slack thread in #legal), we need terms governing usage of the MCP server -- both the open source repo and the hosted version. This PR covers the repo side. The hosted server click-through is a separate product/auth flow concern.

## Test plan
- [x] All 370 tests pass
- [ ] Verify TERMS_OF_SERVICE.md renders correctly on GitHub
- [ ] Verify README blockquote link resolves to the terms file

Generated with [Claude Code](https://claude.com/claude-code)