### PR TITLE
Add missing query parameters to list_payments

### DIFF
--- a/src/mcp_server_check/tools/payments.py
+++ b/src/mcp_server_check/tools/payments.py
@@ -15,19 +15,55 @@ from mcp_server_check.helpers import (
 async def list_payments(
     ctx: Ctx,
     company: str | None = None,
+    payroll: str | None = None,
+    payroll_item: str | None = None,
+    contractor_payment: str | None = None,
+    direction: str | None = None,
+    amount_min: str | None = None,
+    amount_max: str | None = None,
+    type: str | None = None,
+    completion_date_after: str | None = None,
+    completion_date_before: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
 ) -> dict:
-    """List payments, optionally filtered by company.
+    """List payments with optional filters.
 
     Args:
         company: Filter to payments belonging to this Check company ID (e.g. "com_xxxxx").
+        payroll: Filter by payroll ID (e.g. "prl_xxxxx").
+        payroll_item: Filter by payroll item ID (e.g. "pit_xxxxx").
+        contractor_payment: Filter by contractor payment ID (e.g. "ctp_xxxxx").
+        direction: Filter by payment direction: "credit" or "debit".
+        amount_min: Minimum payment amount (payments where amount >= this value).
+        amount_max: Maximum payment amount (payments where amount <= this value).
+        type: Filter by payment type: "company_cash_requirement", "employee_net_pay", "net_pay_refund", "collection", or "refund".
+        completion_date_after: Filter to payments with completion date on or after this date (YYYY-MM-DD).
+        completion_date_before: Filter to payments with completion date on or before this date (YYYY-MM-DD).
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
     """
     params: dict = {}
     if company is not None:
         params["company"] = company
+    if payroll is not None:
+        params["payroll"] = payroll
+    if payroll_item is not None:
+        params["payroll_item"] = payroll_item
+    if contractor_payment is not None:
+        params["contractor_payment"] = contractor_payment
+    if direction is not None:
+        params["direction"] = direction
+    if amount_min is not None:
+        params["amount_min"] = amount_min
+    if amount_max is not None:
+        params["amount_max"] = amount_max
+    if type is not None:
+        params["type"] = type
+    if completion_date_after is not None:
+        params["completion_date_after"] = completion_date_after
+    if completion_date_before is not None:
+        params["completion_date_before"] = completion_date_before
     if limit is not None:
         params["limit"] = limit
     if cursor:

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -27,6 +27,35 @@ async def test_list_payments(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_payments_with_filters(mock_api, ctx):
+    mock_api.get("/payments").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "pmt_002"}]},
+        )
+    )
+    result = await list_payments(
+        ctx,
+        company="com_123",
+        payroll="prl_456",
+        type="company_cash_requirement",
+        direction="debit",
+        amount_min="100.00",
+        completion_date_after="2025-01-01",
+    )
+    assert result["results"] == [{"id": "pmt_002"}]
+    req = mock_api.get("/payments").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["payroll"] == "prl_456"
+    assert req.url.params["type"] == "company_cash_requirement"
+    assert req.url.params["direction"] == "debit"
+    assert req.url.params["amount_min"] == "100.00"
+    assert req.url.params["completion_date_after"] == "2025-01-01"
+    assert "amount_max" not in req.url.params
+    assert "completion_date_before" not in req.url.params
+
+
+@pytest.mark.anyio
 async def test_get_payment(mock_api, ctx):
     mock_api.get("/payments/pmt_001").mock(
         return_value=httpx.Response(200, json={"id": "pmt_001"})


### PR DESCRIPTION
## Summary
- Adds 9 missing query parameters to `list_payments` from the OpenAPI spec: `payroll`, `payroll_item`, `contractor_payment`, `direction`, `amount_min`, `amount_max`, `type`, `completion_date_after`, `completion_date_before`
- Partners were forced to paginate through thousands of results because only `company`, `limit`, and `cursor` were supported ([Slack thread](https://checkpayroll.slack.com/archives/C01H6N3GM4M/p1774546779269069))

## Test plan
- [x] `uv run pytest tests/test_payments.py -v` — all 6 tests pass (including new filter forwarding test)
- [x] `uv run pytest tests/ -v` — full suite (367 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)