### PR TITLE
Add missing query parameters to all list endpoints

### DIFF
--- a/src/mcp_server_check/tool_factory.py
+++ b/src/mcp_server_check/tool_factory.py
@@ -283,7 +283,8 @@ def _create_list_function(res: Resource, filter_fields: list[str]):
     for fname in filter_fields:
         # Find the field doc from resource fields
         field_def = next((f for f in res.fields if f.name == fname), None)
-        annotations[fname] = str | None
+        field_type = field_def.type if field_def else str
+        annotations[fname] = field_type | None
         defaults[fname] = None
         if field_def and field_def.doc:
             filter_docs[fname] = field_def.doc
@@ -329,12 +330,14 @@ def _create_list_function(res: Resource, filter_fields: list[str]):
         )
     ]
     for pname in filter_fields:
+        field_def = next((f for f in res.fields if f.name == pname), None)
+        field_type = field_def.type if field_def else str
         params_list.append(
             inspect.Parameter(
                 pname,
                 inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 default=None,
-                annotation=str | None,
+                annotation=field_type | None,
             )
         )
     if limit_default is not None:

--- a/src/mcp_server_check/tools/bank_accounts.py
+++ b/src/mcp_server_check/tools/bank_accounts.py
@@ -19,6 +19,8 @@ async def list_bank_accounts(
     company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    employee: str | None = None,
+    contractor: str | None = None,
 ) -> dict:
     """List bank accounts, optionally filtered by company.
 
@@ -26,6 +28,8 @@ async def list_bank_accounts(
         company: Filter to bank accounts belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        employee: Filter by employee ID.
+        contractor: Filter by contractor ID.
     """
     params: dict = {}
     if company is not None:
@@ -34,6 +38,10 @@ async def list_bank_accounts(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if employee is not None:
+        params["employee"] = employee
+    if contractor is not None:
+        params["contractor"] = contractor
     return await check_api_list(ctx, "/bank_accounts", params=params or None)
 
 

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -94,7 +94,7 @@ _benefits = Resource(
     id_param="benefit_id",
     id_description="The Check benefit ID.",
     description="employee benefits",
-    list_filters=["company", "employee"],
+    list_filters=["company", "employee", "include_external"],
     fields=[
         Field("employee", str, required_for="create", doc="The Check employee ID."),
         Field(
@@ -103,6 +103,11 @@ _benefits = Resource(
             required_for="create",
             doc="The Check company benefit ID.",
             create_only=True,
+        ),
+        Field(
+            "include_external",
+            bool,
+            doc="Include external benefits. Defaults to false.",
         ),
         Field("benefit", str, doc="Type of supported benefit."),
         Field(
@@ -166,7 +171,7 @@ _post_tax_deductions = Resource(
     id_param="deduction_id",
     id_description="The Check post-tax deduction ID.",
     description="post-tax deductions",
-    list_filters=["company", "employee"],
+    list_filters=["company", "employee", "include_external"],
     fields=[
         Field("employee", str, required_for="create", doc="The Check employee ID."),
         Field(
@@ -209,6 +214,11 @@ _post_tax_deductions = Resource(
             "managed",
             bool,
             doc="Whether the deduction should be remitted by Check (child support only).",
+        ),
+        Field(
+            "include_external",
+            bool,
+            doc="Include external deductions. Defaults to false.",
         ),
     ],
 )
@@ -306,7 +316,7 @@ _earning_rates = Resource(
     id_param="earning_rate_id",
     id_description="The Check earning rate ID.",
     description="earning rates",
-    list_filters=["company", "employee"],
+    list_filters=["company", "employee", "active"],
     has_delete=False,
     default_limit=500,
     fields=[
@@ -416,7 +426,7 @@ _net_pay_splits = Resource(
     id_param="net_pay_split_id",
     id_description="The Check net pay split ID.",
     description="net pay splits",
-    list_filters=["company", "employee"],
+    list_filters=["company", "employee", "contractor"],
     has_delete=False,
     fields=[
         Field(

--- a/src/mcp_server_check/tools/contractor_payments.py
+++ b/src/mcp_server_check/tools/contractor_payments.py
@@ -21,6 +21,7 @@ async def list_contractor_payments(
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
+    payroll: str | None = None,
 ) -> dict:
     """List contractor payments, optionally filtered by company or contractor.
 
@@ -30,6 +31,7 @@ async def list_contractor_payments(
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific contractor payment IDs.
         cursor: Pagination cursor from a previous response.
+        payroll: Filter by payroll ID.
     """
     params: dict = {}
     if company is not None:
@@ -42,6 +44,8 @@ async def list_contractor_payments(
         params["ids"] = ",".join(ids)
     if cursor:
         params["cursor"] = cursor
+    if payroll is not None:
+        params["payroll"] = payroll
     return await check_api_list(ctx, "/contractor_payments", params=params or None)
 
 

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -225,6 +225,8 @@ async def list_contractor_payments_for_contractor(
     contractor_id: str,
     limit: int | None = None,
     cursor: str | None = None,
+    payroll: str | None = None,
+    status: str | None = None,
 ) -> dict:
     """List payments for a specific contractor.
 
@@ -232,12 +234,18 @@ async def list_contractor_payments_for_contractor(
         contractor_id: The Check contractor ID.
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        payroll: Filter by payroll ID.
+        status: Filter by status — "pending", "processing", "failed", or "paid".
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if payroll is not None:
+        params["payroll"] = payroll
+    if status is not None:
+        params["status"] = status
     return await check_api_list(
         ctx, f"/contractors/{contractor_id}/payments", params=params or None
     )

--- a/src/mcp_server_check/tools/documents.py
+++ b/src/mcp_server_check/tools/documents.py
@@ -16,19 +16,33 @@ from mcp_server_check.helpers import (
 
 
 async def list_company_tax_documents(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    company: str | None = None,
+    year: int | None = None,
+    quarter: str | None = None,
 ) -> dict:
     """List company tax documents.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
+        year: Filter by tax year.
+        quarter: Filter by tax quarter.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
+    if year is not None:
+        params["year"] = year
+    if quarter is not None:
+        params["quarter"] = quarter
     return await check_api_list(ctx, "/company_tax_documents", params=params or None)
 
 
@@ -54,19 +68,29 @@ async def download_company_tax_document(ctx: Ctx, document_id: str) -> dict:
 
 
 async def list_company_authorization_documents(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    company: str | None = None,
+    year: int | None = None,
 ) -> dict:
     """List company authorization documents.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
+        year: Filter by year.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
+    if year is not None:
+        params["year"] = year
     return await check_api_list(
         ctx, "/company_authorization_documents", params=params or None
     )
@@ -96,19 +120,33 @@ async def download_company_authorization_document(ctx: Ctx, document_id: str) ->
 
 
 async def list_employee_tax_documents(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    employee: str | None = None,
+    company: str | None = None,
+    year: int | None = None,
 ) -> dict:
     """List employee tax documents.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        employee: Filter by employee ID.
+        company: Filter by company ID.
+        year: Filter by tax year.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if employee is not None:
+        params["employee"] = employee
+    if company is not None:
+        params["company"] = company
+    if year is not None:
+        params["year"] = year
     return await check_api_list(ctx, "/employee_tax_documents", params=params or None)
 
 
@@ -134,19 +172,33 @@ async def download_employee_tax_document(ctx: Ctx, document_id: str) -> dict:
 
 
 async def list_contractor_tax_documents(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    contractor: str | None = None,
+    company: str | None = None,
+    year: int | None = None,
 ) -> dict:
     """List contractor tax documents.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        contractor: Filter by contractor ID.
+        company: Filter by company ID.
+        year: Filter by tax year.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if contractor is not None:
+        params["contractor"] = contractor
+    if company is not None:
+        params["company"] = company
+    if year is not None:
+        params["year"] = year
     return await check_api_list(ctx, "/contractor_tax_documents", params=params or None)
 
 
@@ -172,19 +224,25 @@ async def download_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
 
 
 async def list_setup_documents(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    company: str | None = None,
 ) -> dict:
     """List setup documents.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
     return await check_api_list(ctx, "/setup_documents", params=params or None)
 
 
@@ -210,19 +268,25 @@ async def download_setup_document(ctx: Ctx, document_id: str) -> dict:
 
 
 async def list_company_provided_documents(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    company: str | None = None,
 ) -> dict:
     """List company-provided documents.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
     return await check_api_list(
         ctx, "/company_provided_documents", params=params or None
     )

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -19,6 +19,8 @@ async def list_employees(
     limit: int = 100,
     ids: list[str] | None = None,
     cursor: str | None = None,
+    workplace: str | None = None,
+    active: bool | None = None,
 ) -> dict:
     """List employees, optionally filtered by company.
 
@@ -27,6 +29,8 @@ async def list_employees(
         limit: Maximum number of results to return (max 100, default 100).
         ids: Filter to specific employee IDs.
         cursor: Pagination cursor from a previous response.
+        workplace: Filter by workplace ID(s).
+        active: Filter by active status.
     """
     params: dict = {}
     if company is not None:
@@ -36,6 +40,10 @@ async def list_employees(
         params["ids"] = ",".join(ids)
     if cursor:
         params["cursor"] = cursor
+    if workplace is not None:
+        params["workplace"] = workplace
+    if active is not None:
+        params["active"] = str(active).lower()
     return await check_api_list(ctx, "/employees", params=params or None)
 
 
@@ -201,6 +209,11 @@ async def list_employee_paystubs(
     employee_id: str,
     limit: int | None = None,
     cursor: str | None = None,
+    payroll: str | None = None,
+    status: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    type: str | None = None,
 ) -> dict:
     """List paystubs for an employee.
 
@@ -208,12 +221,27 @@ async def list_employee_paystubs(
         employee_id: The Check employee ID.
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        payroll: Filter by payroll ID.
+        status: Filter by status — "pending", "processing", "failed", or "paid".
+        start: Filter to paystubs from payrolls with payday on or after this date (YYYY-MM-DD).
+        end: Filter to paystubs from payrolls with payday on or before this date (YYYY-MM-DD).
+        type: Filter by payroll type — "regular", "balancing", or "amendment".
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if payroll is not None:
+        params["payroll"] = payroll
+    if status is not None:
+        params["status"] = status
+    if start is not None:
+        params["start"] = start
+    if end is not None:
+        params["end"] = end
+    if type is not None:
+        params["type"] = type
     return await check_api_list(
         ctx, f"/employees/{employee_id}/paystubs", params=params or None
     )

--- a/src/mcp_server_check/tools/external_payrolls.py
+++ b/src/mcp_server_check/tools/external_payrolls.py
@@ -20,6 +20,7 @@ async def list_external_payrolls(
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
+    pay_schedule: str | None = None,
 ) -> dict:
     """List external payrolls, optionally filtered by company.
 
@@ -28,6 +29,7 @@ async def list_external_payrolls(
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific external payroll IDs.
         cursor: Pagination cursor from a previous response.
+        pay_schedule: Filter by pay schedule ID.
     """
     params: dict = {}
     if company is not None:
@@ -38,6 +40,8 @@ async def list_external_payrolls(
         params["ids"] = ",".join(ids)
     if cursor:
         params["cursor"] = cursor
+    if pay_schedule is not None:
+        params["pay_schedule"] = pay_schedule
     return await check_api_list(ctx, "/external_payrolls", params=params or None)
 
 

--- a/src/mcp_server_check/tools/forms.py
+++ b/src/mcp_server_check/tools/forms.py
@@ -17,6 +17,9 @@ async def list_forms(
     company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    state: str | None = None,
+    lang: str | None = None,
+    type: str | None = None,
 ) -> dict:
     """List forms, optionally filtered by company.
 
@@ -24,6 +27,9 @@ async def list_forms(
         company: Filter to forms belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        state: Filter by two-letter state abbreviation.
+        lang: Filter by ISO 639-1 language code.
+        type: Filter by form type (e.g. "contractor_setup").
     """
     params: dict = {}
     if company is not None:
@@ -32,6 +38,12 @@ async def list_forms(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if state is not None:
+        params["state"] = state
+    if lang is not None:
+        params["lang"] = lang
+    if type is not None:
+        params["type"] = type
     return await check_api_list(ctx, "/forms", params=params or None)
 
 

--- a/src/mcp_server_check/tools/payrolls.py
+++ b/src/mcp_server_check/tools/payrolls.py
@@ -20,6 +20,15 @@ async def list_payrolls(
     limit: int | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
+    type: str | None = None,
+    status: str | None = None,
+    managed: bool | None = None,
+    approved: bool | None = None,
+    pay_schedule: str | None = None,
+    payday_after: str | None = None,
+    payday_before: str | None = None,
+    include_items: bool | None = None,
+    include_contractor_payments: bool | None = None,
 ) -> dict:
     """List payrolls, optionally filtered by company.
 
@@ -28,6 +37,15 @@ async def list_payrolls(
         limit: Maximum number of results to return (default 10, max 100).
         ids: Filter to specific payroll IDs.
         cursor: Pagination cursor from a previous response.
+        type: Filter by payroll type — "regular", "off_cycle", "amendment", or "balancing".
+        status: Filter by payroll status — "draft", "pending", "processing", "paid", "partially_paid", or "failed".
+        managed: Filter by managed status.
+        approved: Filter by approval status.
+        pay_schedule: Filter by pay schedule ID.
+        payday_after: Filter to payrolls with payday on or after this date (YYYY-MM-DD).
+        payday_before: Filter to payrolls with payday on or before this date (YYYY-MM-DD).
+        include_items: Return payroll items inline.
+        include_contractor_payments: Return contractor payments inline.
     """
     params: dict = {}
     if company is not None:
@@ -38,6 +56,24 @@ async def list_payrolls(
         params["ids"] = ",".join(ids)
     if cursor:
         params["cursor"] = cursor
+    if type is not None:
+        params["type"] = type
+    if status is not None:
+        params["status"] = status
+    if managed is not None:
+        params["managed"] = str(managed).lower()
+    if approved is not None:
+        params["approved"] = str(approved).lower()
+    if pay_schedule is not None:
+        params["pay_schedule"] = pay_schedule
+    if payday_after is not None:
+        params["payday_after"] = payday_after
+    if payday_before is not None:
+        params["payday_before"] = payday_before
+    if include_items is not None:
+        params["include_items"] = str(include_items).lower()
+    if include_contractor_payments is not None:
+        params["include_contractor_payments"] = str(include_contractor_payments).lower()
     return await check_api_list(ctx, "/payrolls", params=params or None)
 
 

--- a/src/mcp_server_check/tools/platform.py
+++ b/src/mcp_server_check/tools/platform.py
@@ -21,6 +21,11 @@ async def list_notifications(
     company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    topic: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    recipient_type: str | None = None,
+    recipient: str | None = None,
 ) -> dict:
     """List notifications, optionally filtered by company.
 
@@ -28,6 +33,11 @@ async def list_notifications(
         company: Filter to notifications belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        topic: Filter by notification topic.
+        start_date: Filter to notifications on or after this date (YYYY-MM-DD).
+        end_date: Filter to notifications on or before this date (YYYY-MM-DD).
+        recipient_type: Filter by recipient type.
+        recipient: Filter by recipient ID.
     """
     params: dict = {}
     if company is not None:
@@ -36,6 +46,16 @@ async def list_notifications(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if topic is not None:
+        params["topic"] = topic
+    if start_date is not None:
+        params["start_date"] = start_date
+    if end_date is not None:
+        params["end_date"] = end_date
+    if recipient_type is not None:
+        params["recipient_type"] = recipient_type
+    if recipient is not None:
+        params["recipient"] = recipient
     return await check_api_list(ctx, "/notifications", params=params or None)
 
 
@@ -56,6 +76,11 @@ async def list_communications(
     company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    type: str | None = None,
+    recipient: str | None = None,
+    recipient_type: str | None = None,
 ) -> dict:
     """List communications, optionally filtered by company.
 
@@ -63,6 +88,11 @@ async def list_communications(
         company: Filter to communications belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        start_date: Filter to communications on or after this date (YYYY-MM-DD).
+        end_date: Filter to communications on or before this date (YYYY-MM-DD).
+        type: Filter by communication type.
+        recipient: Filter by recipient ID.
+        recipient_type: Filter by recipient type.
     """
     params: dict = {}
     if company is not None:
@@ -71,6 +101,16 @@ async def list_communications(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if start_date is not None:
+        params["start_date"] = start_date
+    if end_date is not None:
+        params["end_date"] = end_date
+    if type is not None:
+        params["type"] = type
+    if recipient is not None:
+        params["recipient"] = recipient
+    if recipient_type is not None:
+        params["recipient_type"] = recipient_type
     return await check_api_list(ctx, "/communications", params=params or None)
 
 
@@ -110,36 +150,76 @@ async def create_communication(
 
 
 async def list_usage_summaries(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    company: str | None = None,
+    category: str | None = None,
+    period_start: str | None = None,
+    period_end: str | None = None,
 ) -> dict:
     """List usage summaries.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
+        category: Filter by usage category.
+        period_start: Filter to summaries with period starting on or after this date (YYYY-MM-DD).
+        period_end: Filter to summaries with period ending on or before this date (YYYY-MM-DD).
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
+    if category is not None:
+        params["category"] = category
+    if period_start is not None:
+        params["period_start"] = period_start
+    if period_end is not None:
+        params["period_end"] = period_end
     return await check_api_list(ctx, "/usage_summaries", params=params or None)
 
 
 async def list_usage_records(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    company: str | None = None,
+    category: str | None = None,
+    resource_type: str | None = None,
+    period_start: str | None = None,
+    period_end: str | None = None,
 ) -> dict:
     """List usage records.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
+        category: Filter by usage category.
+        resource_type: Filter by resource type.
+        period_start: Filter to records with period starting on or after this date (YYYY-MM-DD).
+        period_end: Filter to records with period ending on or before this date (YYYY-MM-DD).
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
+    if category is not None:
+        params["category"] = category
+    if resource_type is not None:
+        params["resource_type"] = resource_type
+    if period_start is not None:
+        params["period_start"] = period_start
+    if period_end is not None:
+        params["period_end"] = period_end
     return await check_api_list(ctx, "/usage_records", params=params or None)
 
 
@@ -187,19 +267,25 @@ async def authorize_integration_partner(
 
 
 async def list_integration_permissions(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    integration_partner: str | None = None,
 ) -> dict:
     """List integration permissions.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        integration_partner: Filter by integration partner ID.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if integration_partner is not None:
+        params["integration_partner"] = integration_partner
     return await check_api_list(ctx, "/integration_permissions", params=params or None)
 
 
@@ -213,19 +299,25 @@ async def get_integration_permission(ctx: Ctx, permission_id: str) -> dict:
 
 
 async def list_integration_accesses(
-    ctx: Ctx, limit: int | None = None, cursor: str | None = None
+    ctx: Ctx,
+    limit: int | None = None,
+    cursor: str | None = None,
+    company: str | None = None,
 ) -> dict:
     """List integration accesses.
 
     Args:
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
     return await check_api_list(ctx, "/integration_accesses", params=params or None)
 
 
@@ -470,6 +562,9 @@ async def list_requirements(
     company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    category: str | None = None,
+    requirement: str | None = None,
+    status: str | None = None,
 ) -> dict:
     """List requirements, optionally filtered by company.
 
@@ -477,6 +572,9 @@ async def list_requirements(
         company: Filter to requirements belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        category: Filter by requirement category.
+        requirement: Filter by requirement type.
+        status: Filter by requirement status.
     """
     params: dict = {}
     if company is not None:
@@ -485,6 +583,12 @@ async def list_requirements(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if category is not None:
+        params["category"] = category
+    if requirement is not None:
+        params["requirement"] = requirement
+    if status is not None:
+        params["status"] = status
     return await check_api_list(ctx, "/requirements", params=params or None)
 
 

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -53,6 +53,9 @@ async def list_company_tax_param_settings(
     company_id: str,
     limit: int | None = None,
     cursor: str | None = None,
+    as_of: str | None = None,
+    jurisdiction: str | None = None,
+    submitter: str | None = None,
 ) -> dict:
     """List tax parameter settings for a company.
 
@@ -60,12 +63,21 @@ async def list_company_tax_param_settings(
         company_id: The Check company ID.
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        as_of: Filter as of a specific date (YYYY-MM-DD).
+        jurisdiction: Filter by tax jurisdiction.
+        submitter: Filter by submitter.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if as_of is not None:
+        params["as_of"] = as_of
+    if jurisdiction is not None:
+        params["jurisdiction"] = jurisdiction
+    if submitter is not None:
+        params["submitter"] = submitter
     return await check_api_list(
         ctx, f"/company_tax_params/{company_id}/settings", params=params or None
     )
@@ -116,6 +128,10 @@ async def list_employee_tax_params(
     employee: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    company: str | None = None,
+    as_of: str | None = None,
+    jurisdiction: str | None = None,
+    submitter: str | None = None,
 ) -> dict:
     """List employee tax parameters, optionally filtered by employee.
 
@@ -123,6 +139,10 @@ async def list_employee_tax_params(
         employee: Filter to tax parameters for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
+        as_of: Filter as of a specific date (YYYY-MM-DD).
+        jurisdiction: Filter by tax jurisdiction.
+        submitter: Filter by submitter.
     """
     params: dict = {}
     if employee is not None:
@@ -131,6 +151,14 @@ async def list_employee_tax_params(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
+    if as_of is not None:
+        params["as_of"] = as_of
+    if jurisdiction is not None:
+        params["jurisdiction"] = jurisdiction
+    if submitter is not None:
+        params["submitter"] = submitter
     return await check_api_list(ctx, "/employee_tax_params", params=params or None)
 
 
@@ -171,6 +199,9 @@ async def list_employee_tax_param_settings(
     employee_id: str,
     limit: int | None = None,
     cursor: str | None = None,
+    as_of: str | None = None,
+    jurisdiction: str | None = None,
+    submitter: str | None = None,
 ) -> dict:
     """List tax parameter settings for an employee.
 
@@ -178,12 +209,21 @@ async def list_employee_tax_param_settings(
         employee_id: The Check employee ID.
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        as_of: Filter as of a specific date (YYYY-MM-DD).
+        jurisdiction: Filter by tax jurisdiction.
+        submitter: Filter by submitter.
     """
     params: dict = {}
     if limit is not None:
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if as_of is not None:
+        params["as_of"] = as_of
+    if jurisdiction is not None:
+        params["jurisdiction"] = jurisdiction
+    if submitter is not None:
+        params["submitter"] = submitter
     return await check_api_list(
         ctx, f"/employee_tax_params/{employee_id}/settings", params=params or None
     )
@@ -352,6 +392,8 @@ async def list_tax_filings(
     company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    year: int | None = None,
+    period: str | None = None,
 ) -> dict:
     """List tax filings, optionally filtered by company.
 
@@ -359,6 +401,8 @@ async def list_tax_filings(
         company: Filter to tax filings belonging to this Check company ID (e.g. "com_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        year: Filter by tax year.
+        period: Filter by filing period.
     """
     params: dict = {}
     if company is not None:
@@ -367,6 +411,10 @@ async def list_tax_filings(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if year is not None:
+        params["year"] = year
+    if period is not None:
+        params["period"] = period
     return await check_api_list(ctx, "/tax_filings", params=params or None)
 
 
@@ -483,6 +531,8 @@ async def list_employee_tax_statements(
     employee: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
+    company: str | None = None,
+    year: int | None = None,
 ) -> dict:
     """List employee tax statements, optionally filtered by employee.
 
@@ -490,6 +540,8 @@ async def list_employee_tax_statements(
         employee: Filter to tax statements for this Check employee ID (e.g. "emp_xxxxx").
         limit: Maximum number of results to return.
         cursor: Pagination cursor.
+        company: Filter by company ID.
+        year: Filter by tax year.
     """
     params: dict = {}
     if employee is not None:
@@ -498,6 +550,10 @@ async def list_employee_tax_statements(
         params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
+    if company is not None:
+        params["company"] = company
+    if year is not None:
+        params["year"] = year
     return await check_api_list(ctx, "/employee_tax_statements", params=params or None)
 
 

--- a/tests/test_bank_accounts.py
+++ b/tests/test_bank_accounts.py
@@ -25,6 +25,24 @@ async def test_list_bank_accounts(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_bank_accounts_with_filters(mock_api, ctx):
+    mock_api.get("/bank_accounts").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "bnk_001"}]},
+        )
+    )
+    result = await list_bank_accounts(
+        ctx, company="com_123", employee="emp_456", contractor="ctr_789"
+    )
+    assert result["results"] == [{"id": "bnk_001"}]
+    req = mock_api.get("/bank_accounts").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["employee"] == "emp_456"
+    assert req.url.params["contractor"] == "ctr_789"
+
+
+@pytest.mark.anyio
 async def test_create_bank_account(mock_api, ctx):
     mock_api.post("/bank_accounts").mock(
         return_value=httpx.Response(201, json={"id": "bnk_new"})

--- a/tests/test_compensation.py
+++ b/tests/test_compensation.py
@@ -9,9 +9,13 @@ from mcp_server_check.tools.compensation import (
     create_benefit,
     create_pay_schedule,
     delete_pay_schedule,
+    list_benefits,
     list_company_benefits,
     list_earning_codes,
+    list_earning_rates,
+    list_net_pay_splits,
     list_pay_schedules,
+    list_post_tax_deductions,
 )
 
 
@@ -68,6 +72,74 @@ async def test_list_company_benefits(mock_api, ctx):
     )
     result = await list_company_benefits(ctx)
     assert result["results"] == [{"id": "cb_001"}]
+
+
+@pytest.mark.anyio
+async def test_list_benefits_with_filters(mock_api, ctx):
+    mock_api.get("/benefits").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ben_001"}]},
+        )
+    )
+    result = await list_benefits(
+        ctx, company="com_123", employee="emp_456", include_external=True
+    )
+    assert result["results"] == [{"id": "ben_001"}]
+    req = mock_api.get("/benefits").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["employee"] == "emp_456"
+    assert req.url.params["include_external"] == "true"
+
+
+@pytest.mark.anyio
+async def test_list_post_tax_deductions_with_filters(mock_api, ctx):
+    mock_api.get("/post_tax_deductions").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ptd_001"}]},
+        )
+    )
+    result = await list_post_tax_deductions(
+        ctx, company="com_123", include_external=True
+    )
+    assert result["results"] == [{"id": "ptd_001"}]
+    req = mock_api.get("/post_tax_deductions").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["include_external"] == "true"
+
+
+@pytest.mark.anyio
+async def test_list_earning_rates_with_filters(mock_api, ctx):
+    mock_api.get("/earning_rates").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "er_001"}]},
+        )
+    )
+    result = await list_earning_rates(
+        ctx, company="com_123", employee="emp_456", active=True
+    )
+    assert result["results"] == [{"id": "er_001"}]
+    req = mock_api.get("/earning_rates").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["employee"] == "emp_456"
+    assert req.url.params["active"] == "true"
+
+
+@pytest.mark.anyio
+async def test_list_net_pay_splits_with_filters(mock_api, ctx):
+    mock_api.get("/net_pay_splits").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "nps_001"}]},
+        )
+    )
+    result = await list_net_pay_splits(ctx, company="com_123", contractor="ctr_456")
+    assert result["results"] == [{"id": "nps_001"}]
+    req = mock_api.get("/net_pay_splits").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["contractor"] == "ctr_456"
 
 
 @pytest.mark.anyio

--- a/tests/test_contractor_payments.py
+++ b/tests/test_contractor_payments.py
@@ -26,6 +26,24 @@ async def test_list_contractor_payments(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_contractor_payments_with_filters(mock_api, ctx):
+    mock_api.get("/contractor_payments").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "cp_001"}]},
+        )
+    )
+    result = await list_contractor_payments(
+        ctx, company="com_123", contractor="ctr_456", payroll="prl_789"
+    )
+    assert result["results"] == [{"id": "cp_001"}]
+    req = mock_api.get("/contractor_payments").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["contractor"] == "ctr_456"
+    assert req.url.params["payroll"] == "prl_789"
+
+
+@pytest.mark.anyio
 async def test_get_contractor_payment(mock_api, ctx):
     mock_api.get("/contractor_payments/cp_001").mock(
         return_value=httpx.Response(200, json={"id": "cp_001"})

--- a/tests/test_contractors.py
+++ b/tests/test_contractors.py
@@ -69,6 +69,23 @@ async def test_list_contractor_payments_for_contractor(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_contractor_payments_for_contractor_with_filters(mock_api, ctx):
+    mock_api.get("/contractors/ctr_001/payments").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "cp_001"}]},
+        )
+    )
+    result = await list_contractor_payments_for_contractor(
+        ctx, contractor_id="ctr_001", payroll="prl_123", status="paid"
+    )
+    assert result["results"] == [{"id": "cp_001"}]
+    req = mock_api.get("/contractors/ctr_001/payments").calls.last.request
+    assert req.url.params["payroll"] == "prl_123"
+    assert req.url.params["status"] == "paid"
+
+
+@pytest.mark.anyio
 async def test_list_contractor_forms(mock_api, ctx):
     mock_api.get("/contractors/ctr_001/forms").mock(
         return_value=httpx.Response(

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -8,7 +8,10 @@ import pytest
 from mcp_server_check.tools.documents import (
     create_company_provided_document,
     get_company_tax_document,
+    list_company_authorization_documents,
+    list_company_provided_documents,
     list_company_tax_documents,
+    list_contractor_tax_documents,
     list_employee_tax_documents,
     list_setup_documents,
 )
@@ -57,6 +60,105 @@ async def test_list_setup_documents(mock_api, ctx):
     )
     result = await list_setup_documents(ctx)
     assert result["results"] == [{"id": "sd_001"}]
+
+
+@pytest.mark.anyio
+async def test_list_company_tax_documents_with_filters(mock_api, ctx):
+    mock_api.get("/company_tax_documents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ctd_001"}]},
+        )
+    )
+    result = await list_company_tax_documents(
+        ctx, company="com_123", year=2025, quarter="Q1"
+    )
+    assert result["results"] == [{"id": "ctd_001"}]
+    req = mock_api.get("/company_tax_documents").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["year"] == "2025"
+    assert req.url.params["quarter"] == "Q1"
+
+
+@pytest.mark.anyio
+async def test_list_company_authorization_documents_with_filters(mock_api, ctx):
+    mock_api.get("/company_authorization_documents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "cad_001"}]},
+        )
+    )
+    result = await list_company_authorization_documents(
+        ctx, company="com_123", year=2025
+    )
+    assert result["results"] == [{"id": "cad_001"}]
+    req = mock_api.get("/company_authorization_documents").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["year"] == "2025"
+
+
+@pytest.mark.anyio
+async def test_list_employee_tax_documents_with_filters(mock_api, ctx):
+    mock_api.get("/employee_tax_documents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "etd_001"}]},
+        )
+    )
+    result = await list_employee_tax_documents(
+        ctx, employee="emp_123", company="com_456", year=2025
+    )
+    assert result["results"] == [{"id": "etd_001"}]
+    req = mock_api.get("/employee_tax_documents").calls.last.request
+    assert req.url.params["employee"] == "emp_123"
+    assert req.url.params["company"] == "com_456"
+    assert req.url.params["year"] == "2025"
+
+
+@pytest.mark.anyio
+async def test_list_contractor_tax_documents_with_filters(mock_api, ctx):
+    mock_api.get("/contractor_tax_documents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ctd_001"}]},
+        )
+    )
+    result = await list_contractor_tax_documents(
+        ctx, contractor="ctr_123", company="com_456", year=2025
+    )
+    assert result["results"] == [{"id": "ctd_001"}]
+    req = mock_api.get("/contractor_tax_documents").calls.last.request
+    assert req.url.params["contractor"] == "ctr_123"
+    assert req.url.params["company"] == "com_456"
+    assert req.url.params["year"] == "2025"
+
+
+@pytest.mark.anyio
+async def test_list_setup_documents_with_filters(mock_api, ctx):
+    mock_api.get("/setup_documents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "sd_001"}]},
+        )
+    )
+    result = await list_setup_documents(ctx, company="com_123")
+    assert result["results"] == [{"id": "sd_001"}]
+    req = mock_api.get("/setup_documents").calls.last.request
+    assert req.url.params["company"] == "com_123"
+
+
+@pytest.mark.anyio
+async def test_list_company_provided_documents_with_filters(mock_api, ctx):
+    mock_api.get("/company_provided_documents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "cpd_001"}]},
+        )
+    )
+    result = await list_company_provided_documents(ctx, company="com_123")
+    assert result["results"] == [{"id": "cpd_001"}]
+    req = mock_api.get("/company_provided_documents").calls.last.request
+    assert req.url.params["company"] == "com_123"
 
 
 @pytest.mark.anyio

--- a/tests/test_employees.py
+++ b/tests/test_employees.py
@@ -10,12 +10,57 @@ from mcp_server_check.tools.employees import (
     get_employee_paystub,
     list_employee_forms,
     list_employee_paystubs,
+    list_employees,
     onboard_employee,
     submit_employee_form,
     update_employee,
 )
 
 BASE_URL = "https://sandbox.checkhq.com"
+
+
+@pytest.mark.anyio
+async def test_list_employees_with_filters(mock_api, ctx):
+    mock_api.get("/employees").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "emp_001"}]},
+        )
+    )
+    result = await list_employees(
+        ctx, company="com_123", workplace="wrk_456", active=True
+    )
+    assert result["results"] == [{"id": "emp_001"}]
+    req = mock_api.get("/employees").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["workplace"] == "wrk_456"
+    assert req.url.params["active"] == "true"
+
+
+@pytest.mark.anyio
+async def test_list_employee_paystubs_with_filters(mock_api, ctx):
+    mock_api.get("/employees/emp_001/paystubs").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ps_001"}]},
+        )
+    )
+    result = await list_employee_paystubs(
+        ctx,
+        employee_id="emp_001",
+        payroll="prl_123",
+        status="paid",
+        start="2026-01-01",
+        end="2026-06-30",
+        type="regular",
+    )
+    assert result["results"] == [{"id": "ps_001"}]
+    req = mock_api.get("/employees/emp_001/paystubs").calls.last.request
+    assert req.url.params["payroll"] == "prl_123"
+    assert req.url.params["status"] == "paid"
+    assert req.url.params["start"] == "2026-01-01"
+    assert req.url.params["end"] == "2026-06-30"
+    assert req.url.params["type"] == "regular"
 
 
 @pytest.mark.anyio

--- a/tests/test_external_payrolls.py
+++ b/tests/test_external_payrolls.py
@@ -26,6 +26,23 @@ async def test_list_external_payrolls(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_external_payrolls_with_filters(mock_api, ctx):
+    mock_api.get("/external_payrolls").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ep_001"}]},
+        )
+    )
+    result = await list_external_payrolls(
+        ctx, company="com_123", pay_schedule="psc_456"
+    )
+    assert result["results"] == [{"id": "ep_001"}]
+    req = mock_api.get("/external_payrolls").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["pay_schedule"] == "psc_456"
+
+
+@pytest.mark.anyio
 async def test_create_external_payroll(mock_api, ctx):
     mock_api.post("/external_payrolls").mock(
         return_value=httpx.Response(201, json={"id": "ep_new"})

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,27 @@
+"""Tests for form tools."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from mcp_server_check.tools.forms import list_forms
+
+
+@pytest.mark.anyio
+async def test_list_forms_with_filters(mock_api, ctx):
+    mock_api.get("/forms").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "frm_001"}]},
+        )
+    )
+    result = await list_forms(
+        ctx, company="com_123", state="CA", lang="en", type="contractor_setup"
+    )
+    assert result["results"] == [{"id": "frm_001"}]
+    req = mock_api.get("/forms").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["state"] == "CA"
+    assert req.url.params["lang"] == "en"
+    assert req.url.params["type"] == "contractor_setup"

--- a/tests/test_payrolls.py
+++ b/tests/test_payrolls.py
@@ -9,6 +9,7 @@ from mcp_server_check.tools.payrolls import (
     approve_payroll,
     create_payroll,
     delete_payroll,
+    list_payrolls,
     preview_payroll,
     reopen_payroll,
     simulate_start_processing,
@@ -16,6 +17,41 @@ from mcp_server_check.tools.payrolls import (
 )
 
 BASE_URL = "https://sandbox.checkhq.com"
+
+
+@pytest.mark.anyio
+async def test_list_payrolls_with_filters(mock_api, ctx):
+    mock_api.get("/payrolls").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "prl_001"}]},
+        )
+    )
+    result = await list_payrolls(
+        ctx,
+        company="com_123",
+        type="regular",
+        status="paid",
+        managed=True,
+        approved=False,
+        pay_schedule="psc_456",
+        payday_after="2026-01-01",
+        payday_before="2026-12-31",
+        include_items=True,
+        include_contractor_payments=False,
+    )
+    assert result["results"] == [{"id": "prl_001"}]
+    req = mock_api.get("/payrolls").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["type"] == "regular"
+    assert req.url.params["status"] == "paid"
+    assert req.url.params["managed"] == "true"
+    assert req.url.params["approved"] == "false"
+    assert req.url.params["pay_schedule"] == "psc_456"
+    assert req.url.params["payday_after"] == "2026-01-01"
+    assert req.url.params["payday_before"] == "2026-12-31"
+    assert req.url.params["include_items"] == "true"
+    assert req.url.params["include_contractor_payments"] == "false"
 
 
 @pytest.mark.anyio

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -8,7 +8,12 @@ import pytest
 from mcp_server_check.tools.platform import (
     create_communication,
     get_applied_for_ids_report,
+    list_communications,
+    list_integration_accesses,
+    list_integration_permissions,
     list_notifications,
+    list_requirements,
+    list_usage_records,
     list_usage_summaries,
     validate_address,
 )
@@ -24,6 +29,57 @@ async def test_list_notifications(mock_api, ctx):
     )
     result = await list_notifications(ctx)
     assert result["results"] == [{"id": "ntf_001"}]
+
+
+@pytest.mark.anyio
+async def test_list_notifications_with_filters(mock_api, ctx):
+    mock_api.get("/notifications").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ntf_001"}]},
+        )
+    )
+    result = await list_notifications(
+        ctx,
+        company="com_123",
+        topic="payroll.completed",
+        start_date="2026-01-01",
+        end_date="2026-06-30",
+        recipient_type="employee",
+        recipient="emp_456",
+    )
+    assert result["results"] == [{"id": "ntf_001"}]
+    req = mock_api.get("/notifications").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["topic"] == "payroll.completed"
+    assert req.url.params["start_date"] == "2026-01-01"
+    assert req.url.params["end_date"] == "2026-06-30"
+    assert req.url.params["recipient_type"] == "employee"
+    assert req.url.params["recipient"] == "emp_456"
+
+
+@pytest.mark.anyio
+async def test_list_communications_with_filters(mock_api, ctx):
+    mock_api.get("/communications").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "comm_001"}]},
+        )
+    )
+    result = await list_communications(
+        ctx,
+        company="com_123",
+        start_date="2026-01-01",
+        type="email",
+        recipient="emp_456",
+    )
+    assert result["results"] == [{"id": "comm_001"}]
+    req = mock_api.get("/communications").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["start_date"] == "2026-01-01"
+    assert req.url.params["type"] == "email"
+    assert req.url.params["recipient"] == "emp_456"
+    assert "end_date" not in req.url.params
 
 
 @pytest.mark.anyio
@@ -45,6 +101,90 @@ async def test_list_usage_summaries(mock_api, ctx):
     )
     result = await list_usage_summaries(ctx)
     assert result["results"] == [{"id": "us_001"}]
+
+
+@pytest.mark.anyio
+async def test_list_usage_summaries_with_filters(mock_api, ctx):
+    mock_api.get("/usage_summaries").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "us_001"}]},
+        )
+    )
+    result = await list_usage_summaries(
+        ctx, company="com_123", category="payroll", period_start="2026-01-01"
+    )
+    assert result["results"] == [{"id": "us_001"}]
+    req = mock_api.get("/usage_summaries").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["category"] == "payroll"
+    assert req.url.params["period_start"] == "2026-01-01"
+    assert "period_end" not in req.url.params
+
+
+@pytest.mark.anyio
+async def test_list_usage_records_with_filters(mock_api, ctx):
+    mock_api.get("/usage_records").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ur_001"}]},
+        )
+    )
+    result = await list_usage_records(
+        ctx, company="com_123", resource_type="employee", period_start="2026-01-01"
+    )
+    assert result["results"] == [{"id": "ur_001"}]
+    req = mock_api.get("/usage_records").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["resource_type"] == "employee"
+    assert req.url.params["period_start"] == "2026-01-01"
+
+
+@pytest.mark.anyio
+async def test_list_integration_permissions_with_filters(mock_api, ctx):
+    mock_api.get("/integration_permissions").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ip_001"}]},
+        )
+    )
+    result = await list_integration_permissions(ctx, integration_partner="ipt_123")
+    assert result["results"] == [{"id": "ip_001"}]
+    req = mock_api.get("/integration_permissions").calls.last.request
+    assert req.url.params["integration_partner"] == "ipt_123"
+
+
+@pytest.mark.anyio
+async def test_list_integration_accesses_with_filters(mock_api, ctx):
+    mock_api.get("/integration_accesses").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ia_001"}]},
+        )
+    )
+    result = await list_integration_accesses(ctx, company="com_123")
+    assert result["results"] == [{"id": "ia_001"}]
+    req = mock_api.get("/integration_accesses").calls.last.request
+    assert req.url.params["company"] == "com_123"
+
+
+@pytest.mark.anyio
+async def test_list_requirements_with_filters(mock_api, ctx):
+    mock_api.get("/requirements").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "req_001"}]},
+        )
+    )
+    result = await list_requirements(
+        ctx, company="com_123", category="tax", status="pending"
+    )
+    assert result["results"] == [{"id": "req_001"}]
+    req = mock_api.get("/requirements").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["category"] == "tax"
+    assert req.url.params["status"] == "pending"
+    assert "requirement" not in req.url.params
 
 
 @pytest.mark.anyio

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -9,7 +9,10 @@ from mcp_server_check.tools.tax import (
     get_company_tax_params,
     get_tax_filing,
     list_company_tax_elections,
+    list_company_tax_param_settings,
+    list_employee_tax_param_settings,
     list_employee_tax_params,
+    list_employee_tax_statements,
     list_tax_filings,
     update_company_tax_params,
 )
@@ -69,6 +72,93 @@ async def test_list_tax_filings(mock_api, ctx):
     )
     result = await list_tax_filings(ctx)
     assert result["results"] == [{"id": "tf_001"}]
+
+
+@pytest.mark.anyio
+async def test_list_employee_tax_params_with_filters(mock_api, ctx):
+    mock_api.get("/employee_tax_params").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "etp_001"}]},
+        )
+    )
+    result = await list_employee_tax_params(
+        ctx, employee="emp_123", company="com_456", jurisdiction="CA"
+    )
+    assert result["results"] == [{"id": "etp_001"}]
+    req = mock_api.get("/employee_tax_params").calls.last.request
+    assert req.url.params["employee"] == "emp_123"
+    assert req.url.params["company"] == "com_456"
+    assert req.url.params["jurisdiction"] == "CA"
+    assert "as_of" not in req.url.params
+
+
+@pytest.mark.anyio
+async def test_list_company_tax_param_settings_with_filters(mock_api, ctx):
+    mock_api.get("/company_tax_params/com_001/settings").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "sps_001"}]},
+        )
+    )
+    result = await list_company_tax_param_settings(
+        ctx, company_id="com_001", as_of="2026-01-01", jurisdiction="CA"
+    )
+    assert result["results"] == [{"id": "sps_001"}]
+    req = mock_api.get("/company_tax_params/com_001/settings").calls.last.request
+    assert req.url.params["as_of"] == "2026-01-01"
+    assert req.url.params["jurisdiction"] == "CA"
+
+
+@pytest.mark.anyio
+async def test_list_employee_tax_param_settings_with_filters(mock_api, ctx):
+    mock_api.get("/employee_tax_params/emp_001/settings").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "sps_001"}]},
+        )
+    )
+    result = await list_employee_tax_param_settings(
+        ctx, employee_id="emp_001", jurisdiction="NY", submitter="employer"
+    )
+    assert result["results"] == [{"id": "sps_001"}]
+    req = mock_api.get("/employee_tax_params/emp_001/settings").calls.last.request
+    assert req.url.params["jurisdiction"] == "NY"
+    assert req.url.params["submitter"] == "employer"
+
+
+@pytest.mark.anyio
+async def test_list_tax_filings_with_filters(mock_api, ctx):
+    mock_api.get("/tax_filings").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "tf_001"}]},
+        )
+    )
+    result = await list_tax_filings(ctx, company="com_123", year=2025, period="Q1")
+    assert result["results"] == [{"id": "tf_001"}]
+    req = mock_api.get("/tax_filings").calls.last.request
+    assert req.url.params["company"] == "com_123"
+    assert req.url.params["year"] == "2025"
+    assert req.url.params["period"] == "Q1"
+
+
+@pytest.mark.anyio
+async def test_list_employee_tax_statements_with_filters(mock_api, ctx):
+    mock_api.get("/employee_tax_statements").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "ets_001"}]},
+        )
+    )
+    result = await list_employee_tax_statements(
+        ctx, employee="emp_123", company="com_456", year=2025
+    )
+    assert result["results"] == [{"id": "ets_001"}]
+    req = mock_api.get("/employee_tax_statements").calls.last.request
+    assert req.url.params["employee"] == "emp_123"
+    assert req.url.params["company"] == "com_456"
+    assert req.url.params["year"] == "2025"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Adds missing server-side filtering query parameters to **27 list functions** across **11 tool files**, based on an audit against the OpenAPI spec
- Fixes `tool_factory.py` to use correct field types (e.g. `bool | None`) for filter params in generated list function signatures
- Previously most list endpoints only supported `company`, `limit`, and `cursor`, forcing MCP users to paginate through large result sets instead of filtering at the API level

### Files changed
| File | Functions | New params |
|---|---|---|
| `payrolls.py` | `list_payrolls` | type, status, managed, approved, pay_schedule, payday_after, payday_before, include_items, include_contractor_payments |
| `employees.py` | `list_employees`, `list_employee_paystubs` | workplace, active, payroll, status, start, end, type |
| `contractors.py` | `list_contractor_payments_for_contractor` | payroll, status |
| `contractor_payments.py` | `list_contractor_payments` | payroll |
| `bank_accounts.py` | `list_bank_accounts` | employee, contractor |
| `forms.py` | `list_forms` | state, lang, type |
| `external_payrolls.py` | `list_external_payrolls` | pay_schedule |
| `platform.py` | 7 list functions | topic, start_date, end_date, recipient_type, recipient, type, company, category, period_start, period_end, resource_type, integration_partner, requirement, status |
| `documents.py` | 6 list functions | company, year, quarter, employee, contractor |
| `tax.py` | 5 list functions | company, as_of, jurisdiction, submitter, year, period |
| `compensation.py` | 4 declarative resources | include_external (x2), active, contractor |
| `tool_factory.py` | `_create_list_function` | Use field-specific types for filter param annotations |

## Test plan
- [x] 30 new `*_with_filters` tests verify params are forwarded to request URLs and omitted params are absent
- [x] All 397 tests pass (`uv run pytest tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)