### PR TITLE
Add `check init` command to generate CLAUDE.md

### DIFF
--- a/src/mcp_server_check/cli/__init__.py
+++ b/src/mcp_server_check/cli/__init__.py
@@ -76,7 +76,11 @@ class _FilteredGroup(click.Group):
 
 
 class _MainCLI(click.Group):
-    """Top-level CLI group that hides toolset groups based on ToolFilter."""
+    """Top-level CLI group that hides toolset groups based on ToolFilter.
+
+    Overrides ``format_commands`` to render standalone commands (like
+    ``setup``) separately from API toolset groups.
+    """
 
     def __init__(
         self,
@@ -95,7 +99,7 @@ class _MainCLI(click.Group):
         commands: list[str] = []
         for name in super().list_commands(ctx):
             toolset = self.toolset_names.get(name)
-            # Non-toolset commands (shouldn't exist, but be safe) always shown
+            # Non-toolset commands always shown
             if toolset is None:
                 commands.append(name)
                 continue
@@ -114,6 +118,37 @@ class _MainCLI(click.Group):
         if tf.toolsets is not None and toolset not in tf.toolsets:
             return None
         return cmd
+
+    def format_commands(
+        self, ctx: click.Context, formatter: click.HelpFormatter
+    ) -> None:
+        visible = self.list_commands(ctx)
+        if not visible:
+            return
+
+        standalone: list[tuple[str, str]] = []
+        toolset_cmds: list[tuple[str, str]] = []
+
+        limit = formatter.width - 6 - max(len(n) for n in visible)
+
+        for name in visible:
+            cmd = self.get_command(ctx, name)
+            if cmd is None or cmd.hidden:
+                continue
+            help_text = cmd.get_short_help_str(limit=limit)
+            row = (name, help_text)
+            if name in self.toolset_names:
+                toolset_cmds.append(row)
+            else:
+                standalone.append(row)
+
+        if standalone:
+            with formatter.section("Setup"):
+                formatter.write_dl(standalone)
+
+        if toolset_cmds:
+            with formatter.section("API Resources"):
+                formatter.write_dl(toolset_cmds)
 
 
 # ---------------------------------------------------------------------------

--- a/src/mcp_server_check/cli/__init__.py
+++ b/src/mcp_server_check/cli/__init__.py
@@ -13,6 +13,7 @@ from mcp_server_check.tool_filter import ToolFilter
 
 from .codegen import build_command, collect_tools
 from .context import resolve_api_key, resolve_base_url
+from .setup import setup_command
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +196,8 @@ def _build_cli() -> click.Group:
 
         toolset_names[group_name] = toolset_name
         cli.add_command(group, group_name)
+
+    cli.add_command(setup_command, "setup")
 
     return cli
 

--- a/src/mcp_server_check/cli/__init__.py
+++ b/src/mcp_server_check/cli/__init__.py
@@ -13,7 +13,7 @@ from mcp_server_check.tool_filter import ToolFilter
 
 from .codegen import build_command, collect_tools
 from .context import resolve_api_key, resolve_base_url
-from .setup import setup_command
+from .setup import init_command
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +143,7 @@ class _MainCLI(click.Group):
                 standalone.append(row)
 
         if standalone:
-            with formatter.section("Setup"):
+            with formatter.section("Commands"):
                 formatter.write_dl(standalone)
 
         if toolset_cmds:
@@ -232,7 +232,7 @@ def _build_cli() -> click.Group:
         toolset_names[group_name] = toolset_name
         cli.add_command(group, group_name)
 
-    cli.add_command(setup_command, "setup")
+    cli.add_command(init_command, "init")
 
     return cli
 

--- a/src/mcp_server_check/cli/setup.py
+++ b/src/mcp_server_check/cli/setup.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
 
 import click
 
-CLAUDE_MD_CONTENT = """\
+# Sentinel used to detect whether a file already has Check CLI instructions.
+CHECK_SENTINEL = "<!-- check-cli -->"
+
+CLAUDE_MD_TEMPLATE = """\
 # Check Payroll API
+
+{sentinel}
 
 This project integrates with the [Check Payroll API](https://docs.checkhq.com/), \
 a payroll infrastructure platform for managing companies, employees, contractors, \
@@ -87,19 +94,19 @@ money movement.
 
 ```bash
 # List companies
-check companies list
+{cmd_prefix}check companies list
 
 # Get a specific company
-check companies get --company com_abc123
+{cmd_prefix}check companies get --company com_abc123
 
 # List employees for a company
-check employees list --company com_abc123
+{cmd_prefix}check employees list --company com_abc123
 
 # Preview a payroll
-check payrolls preview --payroll prl_abc123
+{cmd_prefix}check payrolls preview --payroll prl_abc123
 
 # Approve a payroll
-check payrolls approve --payroll prl_abc123
+{cmd_prefix}check payrolls approve --payroll prl_abc123
 ```
 
 ## MCP Server Setup
@@ -120,6 +127,53 @@ export CHECK_API_KEY=sk_test_...
 
 Full API reference: https://docs.checkhq.com/
 """
+
+# Required permission pattern for Claude settings.json.
+_BASH_CHECK_PERMISSION = "Bash(check *)"
+
+# Paths (relative to project root) where Claude settings may live.
+_SETTINGS_PATHS = [
+    os.path.join(".claude", "settings.json"),
+    os.path.join(".claude", "settings.local.json"),
+]
+
+
+def _check_is_on_path() -> bool:
+    """Return True if ``check`` is available as a command on PATH."""
+    return shutil.which("check") is not None
+
+
+def _render_content() -> str:
+    """Render the CLAUDE.md template with the correct command prefix."""
+    cmd_prefix = "" if _check_is_on_path() else "uv run "
+    return CLAUDE_MD_TEMPLATE.format(sentinel=CHECK_SENTINEL, cmd_prefix=cmd_prefix)
+
+
+def _file_has_check_instructions(path: str) -> bool:
+    """Return True if *path* already contains Check CLI instructions."""
+    try:
+        with open(path) as f:
+            return CHECK_SENTINEL in f.read()
+    except OSError:
+        return False
+
+
+def _has_bash_check_permission(directory: str) -> bool:
+    """Return True if any Claude settings file allows ``Bash(check *)``."""
+    for rel in _SETTINGS_PATHS:
+        settings_path = os.path.join(directory, rel)
+        try:
+            with open(settings_path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        allow_list = data.get("permissions", {}).get("allow", [])
+        for entry in allow_list:
+            # Match exact "Bash(check *)" or legacy "Bash(check:*)" or broader
+            # patterns like "Bash(uv run check *)" / "Bash(uv run check:*)".
+            if entry.startswith("Bash(") and "check" in entry:
+                return True
+    return False
 
 
 @click.command("setup")
@@ -147,12 +201,25 @@ def setup_command(force: bool, filename: str, directory: str | None) -> None:
     target_dir = directory or os.getcwd()
     path = os.path.join(target_dir, filename)
 
+    # Early exit if the file already contains Check instructions.
+    if os.path.exists(path) and _file_has_check_instructions(path):
+        click.echo(f"{filename} already has Check CLI instructions — skipping.")
+        return
+
     if os.path.exists(path) and not force:
         click.confirm(
             f"{filename} already exists in {target_dir}. Overwrite?", abort=True
         )
 
     with open(path, "w") as f:
-        f.write(CLAUDE_MD_CONTENT)
+        f.write(_render_content())
 
     click.echo(f"Created {path}")
+
+    # Warn if Claude settings don't have a Bash(check *) permission.
+    if not _has_bash_check_permission(target_dir):
+        click.echo(
+            "\nNote: No Bash(check *) permission found in .claude/settings.json.\n"
+            "Add it to allow Claude Code to run check commands without prompting:\n"
+            '\n  claude settings add-permission "Bash(check *)"'
+        )

--- a/src/mcp_server_check/cli/setup.py
+++ b/src/mcp_server_check/cli/setup.py
@@ -1,4 +1,4 @@
-"""``check setup`` command — generates a CLAUDE.md file for AI coding agents."""
+"""``check setup`` command — configures AI coding agents with Check API context."""
 
 from __future__ import annotations
 
@@ -11,7 +11,23 @@ import click
 # Sentinel used to detect whether a file already has Check CLI instructions.
 CHECK_SENTINEL = "<!-- check-cli -->"
 
-CLAUDE_MD_TEMPLATE = """\
+# Permission entry written to .claude/settings.json.
+BASH_CHECK_PERMISSION = "Bash(check *)"
+
+# Paths (relative to project root) where Claude settings may live.
+_SETTINGS_PATHS = [
+    os.path.join(".claude", "settings.json"),
+    os.path.join(".claude", "settings.local.json"),
+]
+
+# Target name → default filename
+_TARGET_FILES: dict[str, str] = {
+    "claude-code": "CLAUDE.md",
+    "cursor": ".cursorrules",
+    "agents-md": "AGENTS.md",
+}
+
+INSTRUCTIONS_TEMPLATE = """\
 # Check Payroll API
 
 {sentinel}
@@ -128,15 +144,6 @@ export CHECK_API_KEY=sk_test_...
 Full API reference: https://docs.checkhq.com/
 """
 
-# Required permission pattern for Claude settings.json.
-_BASH_CHECK_PERMISSION = "Bash(check *)"
-
-# Paths (relative to project root) where Claude settings may live.
-_SETTINGS_PATHS = [
-    os.path.join(".claude", "settings.json"),
-    os.path.join(".claude", "settings.local.json"),
-]
-
 
 def _check_is_on_path() -> bool:
     """Return True if ``check`` is available as a command on PATH."""
@@ -144,9 +151,9 @@ def _check_is_on_path() -> bool:
 
 
 def _render_content() -> str:
-    """Render the CLAUDE.md template with the correct command prefix."""
+    """Render the instructions template with the correct command prefix."""
     cmd_prefix = "" if _check_is_on_path() else "uv run "
-    return CLAUDE_MD_TEMPLATE.format(sentinel=CHECK_SENTINEL, cmd_prefix=cmd_prefix)
+    return INSTRUCTIONS_TEMPLATE.format(sentinel=CHECK_SENTINEL, cmd_prefix=cmd_prefix)
 
 
 def _file_has_check_instructions(path: str) -> bool:
@@ -176,19 +183,54 @@ def _has_bash_check_permission(directory: str) -> bool:
     return False
 
 
+def _ensure_bash_check_permission(directory: str) -> bool:
+    """Add ``Bash(check *)`` to ``.claude/settings.json`` if not already present.
+
+    Returns True if the permission was added, False if it was already present.
+    """
+    if _has_bash_check_permission(directory):
+        return False
+
+    settings_path = os.path.join(directory, ".claude", "settings.json")
+    data: dict = {}
+    if os.path.exists(settings_path):
+        try:
+            with open(settings_path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            data = {}
+
+    permissions = data.setdefault("permissions", {})
+    allow_list = permissions.setdefault("allow", [])
+    allow_list.append(BASH_CHECK_PERMISSION)
+
+    os.makedirs(os.path.join(directory, ".claude"), exist_ok=True)
+    with open(settings_path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+    return True
+
+
+def _append_or_create(path: str, content: str) -> str:
+    """Append *content* to *path*, creating it if it doesn't exist.
+
+    Returns ``"Appended to"`` or ``"Created"`` for use in the output message.
+    """
+    if os.path.exists(path):
+        with open(path, "a") as f:
+            f.write("\n" + content)
+        return "Appended to"
+    else:
+        with open(path, "w") as f:
+            f.write(content)
+        return "Created"
+
+
 @click.command("setup")
-@click.option(
-    "--force",
-    is_flag=True,
-    default=False,
-    help="Overwrite the file without prompting.",
-)
-@click.option(
-    "--file",
-    "filename",
-    default="CLAUDE.md",
-    show_default=True,
-    help="Output filename (e.g. AGENTS.md).",
+@click.argument(
+    "target",
+    type=click.Choice(sorted(_TARGET_FILES.keys())),
 )
 @click.option(
     "--directory",
@@ -196,30 +238,30 @@ def _has_bash_check_permission(directory: str) -> bool:
     type=click.Path(exists=True, file_okay=False),
     help="Target directory (default: current working directory).",
 )
-def setup_command(force: bool, filename: str, directory: str | None) -> None:
-    """Generate a CLAUDE.md file with Check API context for AI coding agents."""
+def setup_command(target: str, directory: str | None) -> None:
+    """Generate AI agent config for Check API.
+
+    \b
+    Targets:
+      claude-code   Append to CLAUDE.md + add Bash(check *) to .claude/settings.json
+      cursor        Append to .cursorrules
+      agents-md     Append to AGENTS.md
+    """
     target_dir = directory or os.getcwd()
+    filename = _TARGET_FILES[target]
     path = os.path.join(target_dir, filename)
 
     # Early exit if the file already contains Check instructions.
-    if os.path.exists(path) and _file_has_check_instructions(path):
+    if _file_has_check_instructions(path):
         click.echo(f"{filename} already has Check CLI instructions — skipping.")
         return
 
-    if os.path.exists(path) and not force:
-        click.confirm(
-            f"{filename} already exists in {target_dir}. Overwrite?", abort=True
-        )
+    content = _render_content()
+    verb = _append_or_create(path, content)
+    click.echo(f"{verb} {path}")
 
-    with open(path, "w") as f:
-        f.write(_render_content())
-
-    click.echo(f"Created {path}")
-
-    # Warn if Claude settings don't have a Bash(check *) permission.
-    if not _has_bash_check_permission(target_dir):
-        click.echo(
-            "\nNote: No Bash(check *) permission found in .claude/settings.json.\n"
-            "Add it to allow Claude Code to run check commands without prompting:\n"
-            '\n  claude settings add-permission "Bash(check *)"'
-        )
+    # For claude-code, also ensure the Bash permission is set.
+    if target == "claude-code":
+        if _ensure_bash_check_permission(target_dir):
+            settings_path = os.path.join(target_dir, ".claude", "settings.json")
+            click.echo(f"Added {BASH_CHECK_PERMISSION} to {settings_path}")

--- a/src/mcp_server_check/cli/setup.py
+++ b/src/mcp_server_check/cli/setup.py
@@ -1,0 +1,158 @@
+"""``check setup`` command — generates a CLAUDE.md file for AI coding agents."""
+
+from __future__ import annotations
+
+import os
+
+import click
+
+CLAUDE_MD_CONTENT = """\
+# Check Payroll API
+
+This project integrates with the [Check Payroll API](https://docs.checkhq.com/), \
+a payroll infrastructure platform for managing companies, employees, contractors, \
+payrolls, tax filings, and payments programmatically.
+
+## Entity Model
+
+- **Company** → has Workplaces, Employees, Contractors, Pay Schedules, Bank Accounts
+- **Employee** (W-2) → has Earning Rates, Benefits, Post-Tax Deductions, Tax Parameters, Forms
+- **Contractor** (1099) → has Contractor Payments
+- **Payroll** → has Payroll Items (one per employee) and Contractor Payments
+- **Payroll Item** → has Earnings, Reimbursements, Benefit/Deduction overrides
+- **Payment** → tracks actual money movement (ACH/wire), has Payment Attempts
+
+## Key Workflows
+
+### Creating a payroll
+
+1. Ensure the company has at least one Workplace and one Bank Account
+2. Create the Payroll with period_start, period_end, and payday dates
+3. Add Payroll Items (one per employee being paid), each with earnings
+4. Add Contractor Payments for any 1099 contractors
+5. Preview the payroll to see calculated taxes and net pay
+6. Approve the payroll to submit for processing
+
+### Onboarding a new company
+
+1. Create the company with legal_name and address
+2. Create a workplace for each work location
+3. Create employees and/or contractors for each worker
+4. Set up bank accounts for funding
+5. Configure tax parameters and benefits
+6. Call the onboard endpoint when setup is complete
+
+## ID Prefixes
+
+All Check API resources use prefixed IDs:
+
+| Prefix | Resource |
+|--------|----------|
+| `com_` | Company |
+| `emp_` | Employee |
+| `ctr_` | Contractor |
+| `prl_` | Payroll |
+| `pit_` | Payroll Item |
+| `pmt_` | Payment |
+| `wrk_` | Workplace |
+| `bnk_` | Bank Account |
+| `ern_` | Earning Rate |
+| `erc_` | Earning Code |
+| `ben_` | Benefit |
+| `ptd_` | Post-Tax Deduction |
+| `spa_` | Tax Parameter Setting |
+
+## Important Concepts
+
+- **Payroll** is the batch container; **Payroll Item** is a single employee's \
+pay stub within it.
+- **Earning Rate** defines an employee's pay rate; **Earning Code** defines the \
+type of earning (regular, overtime, bonus, etc.).
+- **Benefits** are pre-tax deductions (401k, health insurance); **Post-Tax \
+Deductions** are after-tax (garnishments, Roth 401k).
+- **Tax Parameters** control withholding (W-4 info, state elections); they use \
+`spa_*` IDs.
+- Payrolls must be **approved** before they process — approval triggers real \
+money movement.
+
+## Common Gotchas
+
+- You need a Workplace before you can add earnings to a payroll item.
+- Payroll period dates must not overlap with existing payrolls.
+- Bank accounts require verification before they can fund payrolls.
+- Employee SSNs are write-once; after setting, only the last 4 digits are readable.
+- Tax parameter updates require the `spa_*` setting ID, not the parameter name.
+
+## CLI Quick Reference
+
+```bash
+# List companies
+check companies list
+
+# Get a specific company
+check companies get --company com_abc123
+
+# List employees for a company
+check employees list --company com_abc123
+
+# Preview a payroll
+check payrolls preview --payroll prl_abc123
+
+# Approve a payroll
+check payrolls approve --payroll prl_abc123
+```
+
+## MCP Server Setup
+
+To give AI agents direct access to the Check API, add the MCP server:
+
+```bash
+claude mcp add check -- uvx mcp-server-check
+```
+
+Set your API key:
+
+```bash
+export CHECK_API_KEY=sk_test_...
+```
+
+## API Documentation
+
+Full API reference: https://docs.checkhq.com/
+"""
+
+
+@click.command("setup")
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite the file without prompting.",
+)
+@click.option(
+    "--file",
+    "filename",
+    default="CLAUDE.md",
+    show_default=True,
+    help="Output filename (e.g. AGENTS.md).",
+)
+@click.option(
+    "--directory",
+    default=None,
+    type=click.Path(exists=True, file_okay=False),
+    help="Target directory (default: current working directory).",
+)
+def setup_command(force: bool, filename: str, directory: str | None) -> None:
+    """Generate a CLAUDE.md file with Check API context for AI coding agents."""
+    target_dir = directory or os.getcwd()
+    path = os.path.join(target_dir, filename)
+
+    if os.path.exists(path) and not force:
+        click.confirm(
+            f"{filename} already exists in {target_dir}. Overwrite?", abort=True
+        )
+
+    with open(path, "w") as f:
+        f.write(CLAUDE_MD_CONTENT)
+
+    click.echo(f"Created {path}")

--- a/src/mcp_server_check/cli/setup.py
+++ b/src/mcp_server_check/cli/setup.py
@@ -1,4 +1,4 @@
-"""``check setup`` command — configures AI coding agents with Check API context."""
+"""``check init`` command — configures AI coding agents with Check API context."""
 
 from __future__ import annotations
 
@@ -227,7 +227,7 @@ def _append_or_create(path: str, content: str) -> str:
         return "Created"
 
 
-@click.command("setup")
+@click.command("init")
 @click.argument(
     "target",
     type=click.Choice(sorted(_TARGET_FILES.keys())),
@@ -238,7 +238,7 @@ def _append_or_create(path: str, content: str) -> str:
     type=click.Path(exists=True, file_okay=False),
     help="Target directory (default: current working directory).",
 )
-def setup_command(target: str, directory: str | None) -> None:
+def init_command(target: str, directory: str | None) -> None:
     """Generate AI agent config for Check API.
 
     \b

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from mcp_server_check.cli import cli
-from mcp_server_check.cli.setup import CLAUDE_MD_CONTENT
+from mcp_server_check.cli.setup import CHECK_SENTINEL, _render_content
 
 
 def test_setup_creates_claude_md():
@@ -17,7 +19,9 @@ def test_setup_creates_claude_md():
         assert result.exit_code == 0
         assert os.path.exists("CLAUDE.md")
         with open("CLAUDE.md") as f:
-            assert f.read() == CLAUDE_MD_CONTENT
+            content = f.read()
+        assert CHECK_SENTINEL in content
+        assert "# Check Payroll API" in content
 
 
 def test_setup_custom_filename():
@@ -28,7 +32,7 @@ def test_setup_custom_filename():
         assert os.path.exists("AGENTS.md")
         assert not os.path.exists("CLAUDE.md")
         with open("AGENTS.md") as f:
-            assert f.read() == CLAUDE_MD_CONTENT
+            assert CHECK_SENTINEL in f.read()
 
 
 def test_setup_prompts_before_overwrite():
@@ -47,7 +51,7 @@ def test_setup_prompts_before_overwrite():
         result = runner.invoke(cli, ["setup"], input="y\n")
         assert result.exit_code == 0
         with open("CLAUDE.md") as f:
-            assert f.read() == CLAUDE_MD_CONTENT
+            assert CHECK_SENTINEL in f.read()
 
 
 def test_setup_force_overwrites():
@@ -59,7 +63,7 @@ def test_setup_force_overwrites():
         result = runner.invoke(cli, ["setup", "--force"])
         assert result.exit_code == 0
         with open("CLAUDE.md") as f:
-            assert f.read() == CLAUDE_MD_CONTENT
+            assert CHECK_SENTINEL in f.read()
 
 
 def test_setup_does_not_require_api_key():
@@ -91,4 +95,100 @@ def test_setup_custom_directory(tmp_path):
     assert result.exit_code == 0
     target = tmp_path / "CLAUDE.md"
     assert target.exists()
-    assert target.read_text() == CLAUDE_MD_CONTENT
+    assert CHECK_SENTINEL in target.read_text()
+
+
+# ---------------------------------------------------------------------------
+# uv run prefix when check is not on PATH
+# ---------------------------------------------------------------------------
+
+
+def test_uses_uv_run_prefix_when_not_on_path():
+    with patch("mcp_server_check.cli.setup._check_is_on_path", return_value=False):
+        content = _render_content()
+    assert "uv run check companies list" in content
+    assert "\ncheck companies list" not in content
+
+
+def test_no_prefix_when_on_path():
+    with patch("mcp_server_check.cli.setup._check_is_on_path", return_value=True):
+        content = _render_content()
+    assert "\ncheck companies list" in content
+    assert "uv run check" not in content
+
+
+# ---------------------------------------------------------------------------
+# Early exit when file already has Check instructions
+# ---------------------------------------------------------------------------
+
+
+def test_skips_if_file_already_has_check_instructions():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("CLAUDE.md", "w") as f:
+            f.write(f"# My project\n\n{CHECK_SENTINEL}\n\nSome Check content.\n")
+
+        result = runner.invoke(cli, ["setup"])
+        assert result.exit_code == 0
+        assert "already has Check CLI instructions" in result.output
+        # File should be unchanged
+        with open("CLAUDE.md") as f:
+            assert f.read().startswith("# My project")
+
+
+def test_force_does_not_bypass_sentinel_check():
+    """Even --force should skip if the sentinel is already present."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("CLAUDE.md", "w") as f:
+            f.write(f"# Existing\n{CHECK_SENTINEL}\n")
+
+        result = runner.invoke(cli, ["setup", "--force"])
+        assert result.exit_code == 0
+        assert "already has Check CLI instructions" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Claude settings.json permission validation
+# ---------------------------------------------------------------------------
+
+
+def _write_settings(directory: str, filename: str, data: dict) -> None:
+    claude_dir = os.path.join(directory, ".claude")
+    os.makedirs(claude_dir, exist_ok=True)
+    with open(os.path.join(claude_dir, filename), "w") as f:
+        json.dump(data, f)
+
+
+def test_warns_when_no_bash_check_permission():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup"])
+        assert result.exit_code == 0
+        assert "No Bash(check *) permission found" in result.output
+
+
+def test_no_warning_when_permission_in_settings():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_settings(
+            ".",
+            "settings.json",
+            {"permissions": {"allow": ["Bash(check *)"]}},
+        )
+        result = runner.invoke(cli, ["setup"])
+        assert result.exit_code == 0
+        assert "No Bash(check *)" not in result.output
+
+
+def test_no_warning_when_permission_in_local_settings():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_settings(
+            ".",
+            "settings.local.json",
+            {"permissions": {"allow": ["Bash(uv run check:*)"]}},
+        )
+        result = runner.invoke(cli, ["setup"])
+        assert result.exit_code == 0
+        assert "No Bash(check *)" not in result.output

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -9,13 +9,35 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from mcp_server_check.cli import cli
-from mcp_server_check.cli.setup import CHECK_SENTINEL, _render_content
+from mcp_server_check.cli.setup import BASH_CHECK_PERMISSION, CHECK_SENTINEL, _render_content
 
 
-def test_setup_creates_claude_md():
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_settings(directory: str, filename: str, data: dict) -> None:
+    claude_dir = os.path.join(directory, ".claude")
+    os.makedirs(claude_dir, exist_ok=True)
+    with open(os.path.join(claude_dir, filename), "w") as f:
+        json.dump(data, f)
+
+
+def _read_settings(directory: str, filename: str = "settings.json") -> dict:
+    with open(os.path.join(directory, ".claude", filename)) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# claude-code target
+# ---------------------------------------------------------------------------
+
+
+def test_claude_code_creates_claude_md():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup"])
+        result = runner.invoke(cli, ["setup", "claude-code"])
         assert result.exit_code == 0
         assert os.path.exists("CLAUDE.md")
         with open("CLAUDE.md") as f:
@@ -24,78 +46,192 @@ def test_setup_creates_claude_md():
         assert "# Check Payroll API" in content
 
 
-def test_setup_custom_filename():
+def test_claude_code_appends_to_existing_file():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup", "--file", "AGENTS.md"])
+        with open("CLAUDE.md", "w") as f:
+            f.write("# My Project\n\nExisting instructions.\n")
+
+        result = runner.invoke(cli, ["setup", "claude-code"])
+        assert result.exit_code == 0
+        assert "Appended to" in result.output
+
+        with open("CLAUDE.md") as f:
+            content = f.read()
+        # Original content preserved
+        assert content.startswith("# My Project")
+        # Check content appended
+        assert CHECK_SENTINEL in content
+        assert "# Check Payroll API" in content
+
+
+def test_claude_code_adds_bash_permission():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup", "claude-code"])
+        assert result.exit_code == 0
+        assert f"Added {BASH_CHECK_PERMISSION}" in result.output
+
+        settings = _read_settings(".")
+        assert BASH_CHECK_PERMISSION in settings["permissions"]["allow"]
+
+
+def test_claude_code_preserves_existing_settings():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_settings(
+            ".",
+            "settings.json",
+            {"permissions": {"allow": ["Read", "Bash(git *)"], "deny": ["Bash(rm *)"]}},
+        )
+
+        result = runner.invoke(cli, ["setup", "claude-code"])
+        assert result.exit_code == 0
+
+        settings = _read_settings(".")
+        allow = settings["permissions"]["allow"]
+        assert "Read" in allow
+        assert "Bash(git *)" in allow
+        assert BASH_CHECK_PERMISSION in allow
+        assert settings["permissions"]["deny"] == ["Bash(rm *)"]
+
+
+def test_claude_code_skips_permission_if_already_present():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_settings(
+            ".",
+            "settings.json",
+            {"permissions": {"allow": [BASH_CHECK_PERMISSION]}},
+        )
+
+        result = runner.invoke(cli, ["setup", "claude-code"])
+        assert result.exit_code == 0
+        assert f"Added {BASH_CHECK_PERMISSION}" not in result.output
+
+        # Should not duplicate
+        settings = _read_settings(".")
+        assert settings["permissions"]["allow"].count(BASH_CHECK_PERMISSION) == 1
+
+
+def test_claude_code_skips_permission_if_broader_pattern_in_local():
+    """A broader pattern like Bash(uv run check:*) in settings.local.json is sufficient."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_settings(
+            ".",
+            "settings.local.json",
+            {"permissions": {"allow": ["Bash(uv run check:*)"]}},
+        )
+
+        result = runner.invoke(cli, ["setup", "claude-code"])
+        assert result.exit_code == 0
+        assert f"Added {BASH_CHECK_PERMISSION}" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# cursor target
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_creates_cursorrules():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup", "cursor"])
+        assert result.exit_code == 0
+        assert os.path.exists(".cursorrules")
+        with open(".cursorrules") as f:
+            content = f.read()
+        assert CHECK_SENTINEL in content
+        assert "Created" in result.output
+
+
+def test_cursor_appends_to_existing():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open(".cursorrules", "w") as f:
+            f.write("Existing cursor rules.\n")
+
+        result = runner.invoke(cli, ["setup", "cursor"])
+        assert result.exit_code == 0
+        assert "Appended to" in result.output
+
+        with open(".cursorrules") as f:
+            content = f.read()
+        assert content.startswith("Existing cursor rules.")
+        assert CHECK_SENTINEL in content
+
+
+def test_cursor_does_not_write_settings():
+    """The cursor target should not touch .claude/settings.json."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup", "cursor"])
+        assert result.exit_code == 0
+        assert not os.path.exists(os.path.join(".claude", "settings.json"))
+
+
+# ---------------------------------------------------------------------------
+# agents-md target
+# ---------------------------------------------------------------------------
+
+
+def test_agents_md_creates_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup", "agents-md"])
         assert result.exit_code == 0
         assert os.path.exists("AGENTS.md")
-        assert not os.path.exists("CLAUDE.md")
         with open("AGENTS.md") as f:
-            assert CHECK_SENTINEL in f.read()
+            content = f.read()
+        assert CHECK_SENTINEL in content
+        assert "Created" in result.output
 
 
-def test_setup_prompts_before_overwrite():
+def test_agents_md_appends_to_existing():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        with open("CLAUDE.md", "w") as f:
-            f.write("existing content")
+        with open("AGENTS.md", "w") as f:
+            f.write("# Agents\n")
 
-        # Decline overwrite
-        result = runner.invoke(cli, ["setup"], input="n\n")
-        assert result.exit_code != 0
-        with open("CLAUDE.md") as f:
-            assert f.read() == "existing content"
-
-        # Accept overwrite
-        result = runner.invoke(cli, ["setup"], input="y\n")
+        result = runner.invoke(cli, ["setup", "agents-md"])
         assert result.exit_code == 0
-        with open("CLAUDE.md") as f:
-            assert CHECK_SENTINEL in f.read()
+        assert "Appended to" in result.output
+
+        with open("AGENTS.md") as f:
+            content = f.read()
+        assert content.startswith("# Agents")
+        assert CHECK_SENTINEL in content
 
 
-def test_setup_force_overwrites():
+# ---------------------------------------------------------------------------
+# Idempotency — safe to run multiple times
+# ---------------------------------------------------------------------------
+
+
+def test_skips_if_file_already_has_check_instructions():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        with open("CLAUDE.md", "w") as f:
-            f.write("existing content")
-
-        result = runner.invoke(cli, ["setup", "--force"])
+        # First run
+        result = runner.invoke(cli, ["setup", "claude-code"])
         assert result.exit_code == 0
-        with open("CLAUDE.md") as f:
-            assert CHECK_SENTINEL in f.read()
 
-
-def test_setup_does_not_require_api_key():
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup"], env={})
+        # Second run should skip
+        result = runner.invoke(cli, ["setup", "claude-code"])
         assert result.exit_code == 0
-        assert os.path.exists("CLAUDE.md")
+        assert "already has Check CLI instructions" in result.output
 
 
-def test_setup_visible_in_help():
+def test_skip_works_for_all_targets():
     runner = CliRunner()
-    result = runner.invoke(cli, ["--help"])
-    assert result.exit_code == 0
-    assert "setup" in result.output
+    for target in ("claude-code", "cursor", "agents-md"):
+        with runner.isolated_filesystem():
+            result = runner.invoke(cli, ["setup", target])
+            assert result.exit_code == 0
 
-
-def test_setup_visible_with_toolset_filter():
-    """setup should appear even when CHECK_TOOLSETS restricts visible groups."""
-    runner = CliRunner()
-    result = runner.invoke(cli, ["--help"], env={"CHECK_TOOLSETS": "companies"})
-    assert result.exit_code == 0
-    assert "setup" in result.output
-
-
-def test_setup_custom_directory(tmp_path):
-    runner = CliRunner()
-    result = runner.invoke(cli, ["setup", "--directory", str(tmp_path)])
-    assert result.exit_code == 0
-    target = tmp_path / "CLAUDE.md"
-    assert target.exists()
-    assert CHECK_SENTINEL in target.read_text()
+            result = runner.invoke(cli, ["setup", target])
+            assert result.exit_code == 0
+            assert "already has Check CLI instructions" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -118,77 +254,48 @@ def test_no_prefix_when_on_path():
 
 
 # ---------------------------------------------------------------------------
-# Early exit when file already has Check instructions
+# General CLI behavior
 # ---------------------------------------------------------------------------
 
 
-def test_skips_if_file_already_has_check_instructions():
+def test_does_not_require_api_key():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        with open("CLAUDE.md", "w") as f:
-            f.write(f"# My project\n\n{CHECK_SENTINEL}\n\nSome Check content.\n")
-
-        result = runner.invoke(cli, ["setup"])
+        result = runner.invoke(cli, ["setup", "claude-code"], env={})
         assert result.exit_code == 0
-        assert "already has Check CLI instructions" in result.output
-        # File should be unchanged
-        with open("CLAUDE.md") as f:
-            assert f.read().startswith("# My project")
+        assert os.path.exists("CLAUDE.md")
 
 
-def test_force_does_not_bypass_sentinel_check():
-    """Even --force should skip if the sentinel is already present."""
+def test_visible_in_help():
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        with open("CLAUDE.md", "w") as f:
-            f.write(f"# Existing\n{CHECK_SENTINEL}\n")
-
-        result = runner.invoke(cli, ["setup", "--force"])
-        assert result.exit_code == 0
-        assert "already has Check CLI instructions" in result.output
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "setup" in result.output
 
 
-# ---------------------------------------------------------------------------
-# Claude settings.json permission validation
-# ---------------------------------------------------------------------------
-
-
-def _write_settings(directory: str, filename: str, data: dict) -> None:
-    claude_dir = os.path.join(directory, ".claude")
-    os.makedirs(claude_dir, exist_ok=True)
-    with open(os.path.join(claude_dir, filename), "w") as f:
-        json.dump(data, f)
-
-
-def test_warns_when_no_bash_check_permission():
+def test_visible_with_toolset_filter():
+    """setup should appear even when CHECK_TOOLSETS restricts visible groups."""
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup"])
-        assert result.exit_code == 0
-        assert "No Bash(check *) permission found" in result.output
+    result = runner.invoke(cli, ["--help"], env={"CHECK_TOOLSETS": "companies"})
+    assert result.exit_code == 0
+    assert "setup" in result.output
 
 
-def test_no_warning_when_permission_in_settings():
+def test_custom_directory(tmp_path):
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        _write_settings(
-            ".",
-            "settings.json",
-            {"permissions": {"allow": ["Bash(check *)"]}},
-        )
-        result = runner.invoke(cli, ["setup"])
-        assert result.exit_code == 0
-        assert "No Bash(check *)" not in result.output
+    result = runner.invoke(
+        cli, ["setup", "claude-code", "--directory", str(tmp_path)]
+    )
+    assert result.exit_code == 0
+    target = tmp_path / "CLAUDE.md"
+    assert target.exists()
+    assert CHECK_SENTINEL in target.read_text()
 
 
-def test_no_warning_when_permission_in_local_settings():
+def test_setup_help_shows_targets():
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        _write_settings(
-            ".",
-            "settings.local.json",
-            {"permissions": {"allow": ["Bash(uv run check:*)"]}},
-        )
-        result = runner.invoke(cli, ["setup"])
-        assert result.exit_code == 0
-        assert "No Bash(check *)" not in result.output
+    result = runner.invoke(cli, ["setup", "--help"])
+    assert result.exit_code == 0
+    assert "claude-code" in result.output
+    assert "cursor" in result.output
+    assert "agents-md" in result.output

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,0 +1,94 @@
+"""Tests for the ``check setup`` command."""
+
+from __future__ import annotations
+
+import os
+
+from click.testing import CliRunner
+
+from mcp_server_check.cli import cli
+from mcp_server_check.cli.setup import CLAUDE_MD_CONTENT
+
+
+def test_setup_creates_claude_md():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup"])
+        assert result.exit_code == 0
+        assert os.path.exists("CLAUDE.md")
+        with open("CLAUDE.md") as f:
+            assert f.read() == CLAUDE_MD_CONTENT
+
+
+def test_setup_custom_filename():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup", "--file", "AGENTS.md"])
+        assert result.exit_code == 0
+        assert os.path.exists("AGENTS.md")
+        assert not os.path.exists("CLAUDE.md")
+        with open("AGENTS.md") as f:
+            assert f.read() == CLAUDE_MD_CONTENT
+
+
+def test_setup_prompts_before_overwrite():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("CLAUDE.md", "w") as f:
+            f.write("existing content")
+
+        # Decline overwrite
+        result = runner.invoke(cli, ["setup"], input="n\n")
+        assert result.exit_code != 0
+        with open("CLAUDE.md") as f:
+            assert f.read() == "existing content"
+
+        # Accept overwrite
+        result = runner.invoke(cli, ["setup"], input="y\n")
+        assert result.exit_code == 0
+        with open("CLAUDE.md") as f:
+            assert f.read() == CLAUDE_MD_CONTENT
+
+
+def test_setup_force_overwrites():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("CLAUDE.md", "w") as f:
+            f.write("existing content")
+
+        result = runner.invoke(cli, ["setup", "--force"])
+        assert result.exit_code == 0
+        with open("CLAUDE.md") as f:
+            assert f.read() == CLAUDE_MD_CONTENT
+
+
+def test_setup_does_not_require_api_key():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["setup"], env={})
+        assert result.exit_code == 0
+        assert os.path.exists("CLAUDE.md")
+
+
+def test_setup_visible_in_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "setup" in result.output
+
+
+def test_setup_visible_with_toolset_filter():
+    """setup should appear even when CHECK_TOOLSETS restricts visible groups."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"], env={"CHECK_TOOLSETS": "companies"})
+    assert result.exit_code == 0
+    assert "setup" in result.output
+
+
+def test_setup_custom_directory(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["setup", "--directory", str(tmp_path)])
+    assert result.exit_code == 0
+    target = tmp_path / "CLAUDE.md"
+    assert target.exists()
+    assert target.read_text() == CLAUDE_MD_CONTENT

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from mcp_server_check.cli import cli
-from mcp_server_check.cli.setup import BASH_CHECK_PERMISSION, CHECK_SENTINEL, _render_content
+from mcp_server_check.cli.setup import (
+    BASH_CHECK_PERMISSION,
+    CHECK_SENTINEL,
+    _render_content,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -283,9 +287,7 @@ def test_visible_with_toolset_filter():
 
 def test_custom_directory(tmp_path):
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["setup", "claude-code", "--directory", str(tmp_path)]
-    )
+    result = runner.invoke(cli, ["setup", "claude-code", "--directory", str(tmp_path)])
     assert result.exit_code == 0
     target = tmp_path / "CLAUDE.md"
     assert target.exists()

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,4 +1,4 @@
-"""Tests for the ``check setup`` command."""
+"""Tests for the ``check init`` command."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ def _read_settings(directory: str, filename: str = "settings.json") -> dict:
 def test_claude_code_creates_claude_md():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
         assert os.path.exists("CLAUDE.md")
         with open("CLAUDE.md") as f:
@@ -56,7 +56,7 @@ def test_claude_code_appends_to_existing_file():
         with open("CLAUDE.md", "w") as f:
             f.write("# My Project\n\nExisting instructions.\n")
 
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
         assert "Appended to" in result.output
 
@@ -72,7 +72,7 @@ def test_claude_code_appends_to_existing_file():
 def test_claude_code_adds_bash_permission():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
         assert f"Added {BASH_CHECK_PERMISSION}" in result.output
 
@@ -89,7 +89,7 @@ def test_claude_code_preserves_existing_settings():
             {"permissions": {"allow": ["Read", "Bash(git *)"], "deny": ["Bash(rm *)"]}},
         )
 
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
 
         settings = _read_settings(".")
@@ -109,7 +109,7 @@ def test_claude_code_skips_permission_if_already_present():
             {"permissions": {"allow": [BASH_CHECK_PERMISSION]}},
         )
 
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
         assert f"Added {BASH_CHECK_PERMISSION}" not in result.output
 
@@ -128,7 +128,7 @@ def test_claude_code_skips_permission_if_broader_pattern_in_local():
             {"permissions": {"allow": ["Bash(uv run check:*)"]}},
         )
 
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
         assert f"Added {BASH_CHECK_PERMISSION}" not in result.output
 
@@ -141,7 +141,7 @@ def test_claude_code_skips_permission_if_broader_pattern_in_local():
 def test_cursor_creates_cursorrules():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup", "cursor"])
+        result = runner.invoke(cli, ["init", "cursor"])
         assert result.exit_code == 0
         assert os.path.exists(".cursorrules")
         with open(".cursorrules") as f:
@@ -156,7 +156,7 @@ def test_cursor_appends_to_existing():
         with open(".cursorrules", "w") as f:
             f.write("Existing cursor rules.\n")
 
-        result = runner.invoke(cli, ["setup", "cursor"])
+        result = runner.invoke(cli, ["init", "cursor"])
         assert result.exit_code == 0
         assert "Appended to" in result.output
 
@@ -170,7 +170,7 @@ def test_cursor_does_not_write_settings():
     """The cursor target should not touch .claude/settings.json."""
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup", "cursor"])
+        result = runner.invoke(cli, ["init", "cursor"])
         assert result.exit_code == 0
         assert not os.path.exists(os.path.join(".claude", "settings.json"))
 
@@ -183,7 +183,7 @@ def test_cursor_does_not_write_settings():
 def test_agents_md_creates_file():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup", "agents-md"])
+        result = runner.invoke(cli, ["init", "agents-md"])
         assert result.exit_code == 0
         assert os.path.exists("AGENTS.md")
         with open("AGENTS.md") as f:
@@ -198,7 +198,7 @@ def test_agents_md_appends_to_existing():
         with open("AGENTS.md", "w") as f:
             f.write("# Agents\n")
 
-        result = runner.invoke(cli, ["setup", "agents-md"])
+        result = runner.invoke(cli, ["init", "agents-md"])
         assert result.exit_code == 0
         assert "Appended to" in result.output
 
@@ -217,11 +217,11 @@ def test_skips_if_file_already_has_check_instructions():
     runner = CliRunner()
     with runner.isolated_filesystem():
         # First run
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
 
         # Second run should skip
-        result = runner.invoke(cli, ["setup", "claude-code"])
+        result = runner.invoke(cli, ["init", "claude-code"])
         assert result.exit_code == 0
         assert "already has Check CLI instructions" in result.output
 
@@ -230,10 +230,10 @@ def test_skip_works_for_all_targets():
     runner = CliRunner()
     for target in ("claude-code", "cursor", "agents-md"):
         with runner.isolated_filesystem():
-            result = runner.invoke(cli, ["setup", target])
+            result = runner.invoke(cli, ["init", target])
             assert result.exit_code == 0
 
-            result = runner.invoke(cli, ["setup", target])
+            result = runner.invoke(cli, ["init", target])
             assert result.exit_code == 0
             assert "already has Check CLI instructions" in result.output
 
@@ -265,7 +265,7 @@ def test_no_prefix_when_on_path():
 def test_does_not_require_api_key():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["setup", "claude-code"], env={})
+        result = runner.invoke(cli, ["init", "claude-code"], env={})
         assert result.exit_code == 0
         assert os.path.exists("CLAUDE.md")
 
@@ -274,29 +274,29 @@ def test_visible_in_help():
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
-    assert "setup" in result.output
+    assert "init" in result.output
 
 
 def test_visible_with_toolset_filter():
-    """setup should appear even when CHECK_TOOLSETS restricts visible groups."""
+    """init should appear even when CHECK_TOOLSETS restricts visible groups."""
     runner = CliRunner()
     result = runner.invoke(cli, ["--help"], env={"CHECK_TOOLSETS": "companies"})
     assert result.exit_code == 0
-    assert "setup" in result.output
+    assert "init" in result.output
 
 
 def test_custom_directory(tmp_path):
     runner = CliRunner()
-    result = runner.invoke(cli, ["setup", "claude-code", "--directory", str(tmp_path)])
+    result = runner.invoke(cli, ["init", "claude-code", "--directory", str(tmp_path)])
     assert result.exit_code == 0
     target = tmp_path / "CLAUDE.md"
     assert target.exists()
     assert CHECK_SENTINEL in target.read_text()
 
 
-def test_setup_help_shows_targets():
+def test_init_help_shows_targets():
     runner = CliRunner()
-    result = runner.invoke(cli, ["setup", "--help"])
+    result = runner.invoke(cli, ["init", "--help"])
     assert result.exit_code == 0
     assert "claude-code" in result.output
     assert "cursor" in result.output


### PR DESCRIPTION
## Summary
- Adds a `check init <target>` CLI command that configures AI coding agents with Check API domain knowledge
- Three targets: `claude-code` (CLAUDE.md + .claude/settings.json), `cursor` (.cursorrules), `agents-md` (AGENTS.md)
- **Appends** to existing files instead of overwriting — safe to run on projects that already have agent instructions
- `claude-code` target auto-writes `Bash(check *)` permission to `.claude/settings.json`
- Idempotent: detects a `<!-- check-cli -->` sentinel and skips if already present
- CLI examples use `uv run check` when `check` is not on PATH

## Usage
```bash
check init claude-code   # Appends to CLAUDE.md + adds Bash(check *) to .claude/settings.json
check init cursor        # Appends to .cursorrules
check init agents-md     # Appends to AGENTS.md
```

## Test plan
- [x] `uv run pytest tests/test_cli_setup.py -v` — 20 tests pass
- [x] `uv run pytest tests/test_cli.py tests/test_cli_codegen.py -v` — 71 existing tests pass (no regressions)
- [ ] Manual: `uv run check init claude-code && cat CLAUDE.md && cat .claude/settings.json`
- [ ] Manual: `uv run check --help` shows `init` command