### PR TITLE
Update default pagination limits on list endpoints to use max page sizes

### DIFF
--- a/src/mcp_server_check/tools/bank_accounts.py
+++ b/src/mcp_server_check/tools/bank_accounts.py
@@ -17,7 +17,7 @@ from mcp_server_check.helpers import (
 async def list_bank_accounts(
     ctx: Ctx,
     company: str | None = None,
-    limit: int | None = None,
+    limit: int = 500,
     cursor: str | None = None,
     employee: str | None = None,
     contractor: str | None = None,
@@ -26,7 +26,7 @@ async def list_bank_accounts(
 
     Args:
         company: Filter to bank accounts belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
+        limit: Maximum number of results to return (default 500, max 500).
         cursor: Pagination cursor.
         employee: Filter by employee ID.
         contractor: Filter by contractor ID.
@@ -34,8 +34,7 @@ async def list_bank_accounts(
     params: dict = {}
     if company is not None:
         params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
     if employee is not None:

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -95,6 +95,7 @@ _benefits = Resource(
     id_description="The Check benefit ID.",
     description="employee benefits",
     list_filters=["company", "employee", "include_external"],
+    default_limit=500,
     fields=[
         Field("employee", str, required_for="create", doc="The Check employee ID."),
         Field(
@@ -172,6 +173,7 @@ _post_tax_deductions = Resource(
     id_description="The Check post-tax deduction ID.",
     description="post-tax deductions",
     list_filters=["company", "employee", "include_external"],
+    default_limit=500,
     fields=[
         Field("employee", str, required_for="create", doc="The Check employee ID."),
         Field(
@@ -242,6 +244,7 @@ _company_benefits = Resource(
     id_description="The Check company benefit ID.",
     description="company-level benefits",
     list_filters=["company"],
+    default_limit=500,
     fields=[
         Field(
             "company",
@@ -428,6 +431,7 @@ _net_pay_splits = Resource(
     description="net pay splits",
     list_filters=["company", "employee", "contractor"],
     has_delete=False,
+    default_limit=500,
     fields=[
         Field(
             "splits",

--- a/src/mcp_server_check/tools/contractor_payments.py
+++ b/src/mcp_server_check/tools/contractor_payments.py
@@ -18,7 +18,7 @@ async def list_contractor_payments(
     ctx: Ctx,
     company: str | None = None,
     contractor: str | None = None,
-    limit: int | None = None,
+    limit: int = 500,
     ids: list[str] | None = None,
     cursor: str | None = None,
     payroll: str | None = None,
@@ -28,7 +28,7 @@ async def list_contractor_payments(
     Args:
         company: Filter to contractor payments belonging to this Check company ID (e.g. "com_xxxxx").
         contractor: Filter to payments for this Check contractor ID (e.g. "ctr_xxxxx").
-        limit: Maximum number of results to return (default 10, max 100).
+        limit: Maximum number of results to return (default 500, max 500).
         ids: Filter to specific contractor payment IDs.
         cursor: Pagination cursor from a previous response.
         payroll: Filter by payroll ID.
@@ -38,8 +38,7 @@ async def list_contractor_payments(
         params["company"] = company
     if contractor is not None:
         params["contractor"] = contractor
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if ids:
         params["ids"] = ",".join(ids)
     if cursor:

--- a/src/mcp_server_check/tools/documents.py
+++ b/src/mcp_server_check/tools/documents.py
@@ -17,7 +17,7 @@ from mcp_server_check.helpers import (
 
 async def list_company_tax_documents(
     ctx: Ctx,
-    limit: int | None = None,
+    limit: int = 500,
     cursor: str | None = None,
     company: str | None = None,
     year: int | None = None,
@@ -26,15 +26,14 @@ async def list_company_tax_documents(
     """List company tax documents.
 
     Args:
-        limit: Maximum number of results to return.
+        limit: Maximum number of results to return (default 500, max 500).
         cursor: Pagination cursor.
         company: Filter by company ID.
         year: Filter by tax year.
         quarter: Filter by tax quarter.
     """
     params: dict = {}
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
     if company is not None:
@@ -121,7 +120,7 @@ async def download_company_authorization_document(ctx: Ctx, document_id: str) ->
 
 async def list_employee_tax_documents(
     ctx: Ctx,
-    limit: int | None = None,
+    limit: int = 500,
     cursor: str | None = None,
     employee: str | None = None,
     company: str | None = None,
@@ -130,15 +129,14 @@ async def list_employee_tax_documents(
     """List employee tax documents.
 
     Args:
-        limit: Maximum number of results to return.
+        limit: Maximum number of results to return (default 500, max 500).
         cursor: Pagination cursor.
         employee: Filter by employee ID.
         company: Filter by company ID.
         year: Filter by tax year.
     """
     params: dict = {}
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
     if employee is not None:

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -390,7 +390,7 @@ async def update_employee_tax_elections(ctx: Ctx, employee_id: str, data: dict) 
 async def list_tax_filings(
     ctx: Ctx,
     company: str | None = None,
-    limit: int | None = None,
+    limit: int = 500,
     cursor: str | None = None,
     year: int | None = None,
     period: str | None = None,
@@ -399,7 +399,7 @@ async def list_tax_filings(
 
     Args:
         company: Filter to tax filings belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
+        limit: Maximum number of results to return (default 500, max 500).
         cursor: Pagination cursor.
         year: Filter by tax year.
         period: Filter by filing period.
@@ -407,8 +407,7 @@ async def list_tax_filings(
     params: dict = {}
     if company is not None:
         params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
     if year is not None:

--- a/src/mcp_server_check/tools/webhooks.py
+++ b/src/mcp_server_check/tools/webhooks.py
@@ -17,21 +17,20 @@ from mcp_server_check.helpers import (
 async def list_webhook_configs(
     ctx: Ctx,
     company: str | None = None,
-    limit: int | None = None,
+    limit: int = 500,
     cursor: str | None = None,
 ) -> dict:
     """List webhook configurations, optionally filtered by company.
 
     Args:
         company: Filter to webhook configs belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
+        limit: Maximum number of results to return (default 500, max 500).
         cursor: Pagination cursor.
     """
     params: dict = {}
     if company is not None:
         params["company"] = company
-    if limit is not None:
-        params["limit"] = limit
+    params["limit"] = limit
     if cursor:
         params["cursor"] = cursor
     return await check_api_list(ctx, "/webhook_configs", params=params or None)


### PR DESCRIPTION
Set default limit parameter to the maximum supported page size for each
list endpoint: 500 for most endpoints (webhooks, tax filings, documents,
bank accounts, contractor payments, benefits, post-tax deductions,
company benefits, net pay splits) and 100 for employees. This reduces
the number of API calls needed when fetching large datasets.

https://claude.ai/code/session_015Xw7FpmhBqWWc11qmF2BAD