### PR TITLE
Add Address TypedDict to prevent LLMs from guessing field names

### DIFF
--- a/src/mcp_server_check/cli/codegen.py
+++ b/src/mcp_server_check/cli/codegen.py
@@ -201,11 +201,13 @@ def _build_params(func: Callable) -> list[click.Parameter]:
         if not is_required:
             opt_kwargs["default"] = None
 
-        # Dict or list[dict] → JSON param
-        if base_type is dict or (
+        # Dict / TypedDict or list[dict] → JSON param
+        _is_dict = isinstance(base_type, type) and issubclass(base_type, dict)
+        if _is_dict or (
             typing.get_origin(base_type) is list
             and typing.get_args(base_type)
-            and typing.get_args(base_type)[0] is dict
+            and isinstance(typing.get_args(base_type)[0], type)
+            and issubclass(typing.get_args(base_type)[0], dict)
         ):
             params.append(
                 click.Option([f"--{cli_name}"], type=JSONParam(), **opt_kwargs)

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Sequence
-
-from typing_extensions import TypedDict
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -21,30 +19,6 @@ class CheckContext:
 
 
 Ctx = Context
-
-
-class Address(TypedDict, total=False):
-    """A US mailing address. All keys are optional at the type level; the API
-    will enforce which ones are required for each endpoint."""
-
-    line1: str
-    """Street address or PO Box."""
-
-    line2: str
-    """Apartment, suite, unit, or building."""
-
-    city: str
-    """City, district, suburb, town, or village."""
-
-    state: str
-    """2-letter state code (e.g. "CA")."""
-
-    postal_code: str
-    """5-digit ZIP / postal code (e.g. "94105"). Do NOT use 'zip'."""
-
-    country: str
-    """2-letter country code. Defaults to "US" if omitted."""
-
 
 # Default max results for list endpoints to avoid blowing context windows.
 DEFAULT_LIST_LIMIT = 10

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Sequence, TypedDict
+from typing import Sequence
+
+from typing_extensions import TypedDict
 from urllib.parse import parse_qs, urlparse
 
 import httpx

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Sequence
+from typing import Sequence, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -19,6 +19,30 @@ class CheckContext:
 
 
 Ctx = Context
+
+
+class Address(TypedDict, total=False):
+    """A US mailing address. All keys are optional at the type level; the API
+    will enforce which ones are required for each endpoint."""
+
+    line1: str
+    """Street address or PO Box."""
+
+    line2: str
+    """Apartment, suite, unit, or building."""
+
+    city: str
+    """City, district, suburb, town, or village."""
+
+    state: str
+    """2-letter state code (e.g. "CA")."""
+
+    postal_code: str
+    """5-digit ZIP / postal code (e.g. "94105"). Do NOT use 'zip'."""
+
+    country: str
+    """2-letter country code. Defaults to "US" if omitted."""
+
 
 # Default max results for list endpoints to avoid blowing context windows.
 DEFAULT_LIST_LIMIT = 10

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.types import Address
 from mcp_server_check.helpers import (
-    Address,
     Ctx,
     check_api_get,
     check_api_list,

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
+    Address,
     Ctx,
     check_api_get,
     check_api_list,
@@ -60,7 +61,7 @@ async def create_company(
     website: str | None = None,
     email: str | None = None,
     phone: str | None = None,
-    address: dict | None = None,
+    address: Address | None = None,
     pay_frequency: str | None = None,
     start_date: str | None = None,
     metadata: str | None = None,
@@ -78,7 +79,7 @@ async def create_company(
         website: Company website URL.
         email: Email of the payroll department or administrator.
         phone: Company phone number.
-        address: Address dict with keys: line1, line2, city, state, postal_code, country.
+        address: Address with keys: line1, line2, city, state, postal_code, country.
         pay_frequency: Default pay frequency — "weekly", "biweekly", "semimonthly",
             "monthly", "quarterly", or "annually".
         start_date: Date matching first payday using Check (YYYY-MM-DD).
@@ -121,7 +122,7 @@ async def update_company(
     website: str | None = None,
     email: str | None = None,
     phone: str | None = None,
-    address: dict | None = None,
+    address: Address | None = None,
     principal_place_of_business: str | None = None,
     pay_frequency: str | None = None,
     processing_period: str | None = None,
@@ -142,7 +143,7 @@ async def update_company(
         website: Company website URL.
         email: Email of the payroll department or administrator.
         phone: Company phone number.
-        address: Address dict with keys: line1, line2, city, state, postal_code, country.
+        address: Address with keys: line1, line2, city, state, postal_code, country.
         principal_place_of_business: Workplace ID whose address prints on paystubs.
         pay_frequency: Default pay frequency — "weekly", "biweekly", "semimonthly",
             "monthly", "quarterly", or "annually".

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.types import Address
 from mcp_server_check.helpers import (
-    Address,
     Ctx,
     check_api_get,
     check_api_list,

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
+    Address,
     Ctx,
     check_api_get,
     check_api_list,
@@ -67,7 +68,7 @@ async def create_contractor(
     ein: str | None = None,
     default_net_pay_split: str | None = None,
     payment_method_preference: str | None = None,
-    address: dict | None = None,
+    address: Address | None = None,
     metadata: str | None = None,
 ) -> dict:
     """Create a new contractor.
@@ -89,7 +90,7 @@ async def create_contractor(
         ein: Contractor's Employer Identification Number (for businesses).
         default_net_pay_split: ID of contractor's default net pay split.
         payment_method_preference: "direct_deposit" or "manual".
-        address: Address dict with keys: line1, line2, city, state, postal_code, country.
+        address: Address with keys: line1, line2, city, state, postal_code, country.
         metadata: Additional JSON metadata string.
     """
     body: dict = {"company": company}
@@ -148,7 +149,7 @@ async def update_contractor(
     ein: str | None = None,
     default_net_pay_split: str | None = None,
     payment_method_preference: str | None = None,
-    address: dict | None = None,
+    address: Address | None = None,
     metadata: str | None = None,
 ) -> dict:
     """Update an existing contractor.
@@ -170,7 +171,7 @@ async def update_contractor(
         ein: Contractor's Employer Identification Number (for businesses).
         default_net_pay_split: ID of contractor's default net pay split.
         payment_method_preference: "direct_deposit" or "manual".
-        address: Address dict with keys: line1, line2, city, state, postal_code, country.
+        address: Address with keys: line1, line2, city, state, postal_code, country.
         metadata: Additional JSON metadata string.
     """
     body: dict = {}

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.types import Address
 from mcp_server_check.helpers import (
-    Address,
     Ctx,
     check_api_get,
     check_api_list,

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
+    Address,
     Ctx,
     check_api_get,
     check_api_list,
@@ -66,7 +67,7 @@ async def create_employee(
     dob: str | None = None,
     start_date: str | None = None,
     termination_date: str | None = None,
-    residence: dict | None = None,
+    residence: Address | None = None,
     workplaces: list[str] | None = None,
     primary_workplace: str | None = None,
     ssn: str | None = None,
@@ -85,7 +86,7 @@ async def create_employee(
         dob: Date of birth (YYYY-MM-DD).
         start_date: Most recent start date of employment (YYYY-MM-DD).
         termination_date: Most recent termination date (YYYY-MM-DD).
-        residence: Residence address dict with keys: line1, line2, city, state,
+        residence: Residence address with keys: line1, line2, city, state,
             postal_code, country.
         workplaces: List of workplace IDs where the employee works.
         primary_workplace: Workplace ID of the employee's primary workplace.
@@ -132,7 +133,7 @@ async def update_employee(
     dob: str | None = None,
     start_date: str | None = None,
     termination_date: str | None = None,
-    residence: dict | None = None,
+    residence: Address | None = None,
     workplaces: list[str] | None = None,
     primary_workplace: str | None = None,
     ssn: str | None = None,
@@ -151,7 +152,7 @@ async def update_employee(
         dob: Date of birth (YYYY-MM-DD).
         start_date: Most recent start date of employment (YYYY-MM-DD).
         termination_date: Most recent termination date (YYYY-MM-DD).
-        residence: Residence address dict with keys: line1, line2, city, state,
+        residence: Residence address with keys: line1, line2, city, state,
             postal_code, country.
         workplaces: List of workplace IDs where the employee works.
         primary_workplace: Workplace ID of the employee's primary workplace.

--- a/src/mcp_server_check/tools/workplaces.py
+++ b/src/mcp_server_check/tools/workplaces.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.types import Address
 from mcp_server_check.helpers import (
-    Address,
     Ctx,
     check_api_get,
     check_api_list,

--- a/src/mcp_server_check/tools/workplaces.py
+++ b/src/mcp_server_check/tools/workplaces.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastmcp import FastMCP
 
 from mcp_server_check.helpers import (
+    Address,
     Ctx,
     check_api_get,
     check_api_list,
@@ -47,7 +48,7 @@ async def get_workplace(ctx: Ctx, workplace_id: str) -> dict:
 async def create_workplace(
     ctx: Ctx,
     company: str,
-    address: dict,
+    address: Address,
     name: str | None = None,
     active: bool | None = None,
     metadata: str | None = None,
@@ -56,7 +57,7 @@ async def create_workplace(
 
     Args:
         company: The Check company ID.
-        address: Workplace address dict with keys: line1 (required), line2, city
+        address: Workplace address with keys: line1 (required), line2, city
             (required), state (required), postal_code (required), country.
         name: Human-readable name for the workplace.
         active: Whether the workplace can be associated with employees. Default: true.
@@ -77,7 +78,7 @@ async def update_workplace(
     workplace_id: str,
     company: str | None = None,
     name: str | None = None,
-    address: dict | None = None,
+    address: Address | None = None,
     active: bool | None = None,
     metadata: str | None = None,
 ) -> dict:
@@ -87,7 +88,7 @@ async def update_workplace(
         workplace_id: The Check workplace ID.
         company: The Check company ID.
         name: Human-readable name for the workplace.
-        address: Address dict with keys: line1, line2, city, state, postal_code, country.
+        address: Address with keys: line1, line2, city, state, postal_code, country.
         active: Whether the workplace can be associated with employees.
         metadata: Additional JSON metadata string.
     """

--- a/src/mcp_server_check/types.py
+++ b/src/mcp_server_check/types.py
@@ -1,0 +1,28 @@
+"""Shared types for the Check MCP server."""
+
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+
+class Address(TypedDict, total=False):
+    """A US mailing address. All keys are optional at the type level; the API
+    will enforce which ones are required for each endpoint."""
+
+    line1: str
+    """Street address or PO Box."""
+
+    line2: str
+    """Apartment, suite, unit, or building."""
+
+    city: str
+    """City, district, suburb, town, or village."""
+
+    state: str
+    """2-letter state code (e.g. "CA")."""
+
+    postal_code: str
+    """5-digit ZIP / postal code (e.g. "94105"). Do NOT use 'zip'."""
+
+    country: str
+    """2-letter country code. Defaults to "US" if omitted."""


### PR DESCRIPTION
## Summary
- Adds a shared `Address` TypedDict to `helpers.py` with explicit field names (`line1`, `line2`, `city`, `state`, `postal_code`, `country`) and descriptions
- Replaces all loose `dict` typing on address/residence parameters across employees, contractors, workplaces, and companies
- Updates CLI codegen to recognize TypedDict subclasses as JSON parameters

## Context
During the spring break hackathon, Tristan and Erin found that the LLM was guessing `zip` instead of `postal_code` for address fields because they were typed as plain `dict`. The TypedDict generates a proper JSON schema with named properties, so the LLM sees the exact field names. See [Slack thread](https://checkpayroll.slack.com/archives/C0ANRB4JPNK/p1774632728675639).

## Test plan
- [x] All 397 existing tests pass
- [ ] Verify the generated MCP tool schema includes `postal_code` (not `zip`) in the address properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)