### PR TITLE
Add implementation_status filter and status fields to list_companies

### DIFF
--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -36,7 +36,14 @@ DEFAULT_LIST_LIMIT = 10
 # When a list response contains many records, only these fields are returned
 # unless the caller explicitly requests full details.
 _SUMMARY_FIELDS: dict[str, Sequence[str]] = {
-    "com_": ("id", "legal_name", "trade_name", "pay_frequency", "onboard", "implementation"),
+    "com_": (
+        "id",
+        "legal_name",
+        "trade_name",
+        "pay_frequency",
+        "onboard",
+        "implementation",
+    ),
     "emp_": ("id", "first_name", "last_name", "email", "status", "start_date"),
     "ctr_": ("id", "first_name", "last_name", "business_name", "type", "status"),
     "prl_": (

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -36,7 +36,7 @@ DEFAULT_LIST_LIMIT = 10
 # When a list response contains many records, only these fields are returned
 # unless the caller explicitly requests full details.
 _SUMMARY_FIELDS: dict[str, Sequence[str]] = {
-    "com_": ("id", "legal_name", "trade_name", "status", "pay_frequency"),
+    "com_": ("id", "legal_name", "trade_name", "pay_frequency", "onboard", "implementation"),
     "emp_": ("id", "first_name", "last_name", "email", "status", "start_date"),
     "ctr_": ("id", "first_name", "last_name", "business_name", "type", "status"),
     "prl_": (

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -23,6 +23,7 @@ async def list_companies(
     active: bool | None = None,
     ids: list[str] | None = None,
     cursor: str | None = None,
+    implementation_status: str | None = None,
 ) -> dict:
     """List companies in your Check account.
 
@@ -31,11 +32,19 @@ async def list_companies(
         active: Filter by active status.
         ids: Filter to specific company IDs.
         cursor: Pagination cursor from a previous response.
+        implementation_status: Filter by implementation status — "needs_attention",
+            "in_review", or "completed".
     """
     return await check_api_list(
         ctx,
         "/companies",
-        params=build_params(limit=limit, active=active, ids=ids, cursor=cursor),
+        params=build_params(
+            limit=limit,
+            active=active,
+            ids=ids,
+            cursor=cursor,
+            implementation_status=implementation_status,
+        ),
     )
 
 

--- a/tests/test_companies.py
+++ b/tests/test_companies.py
@@ -9,6 +9,7 @@ from mcp_server_check.tools.companies import (
     create_company,
     get_company_paydays,
     get_company_report,
+    list_companies,
     list_signatories,
     onboard_company,
     start_implementation,
@@ -16,6 +17,34 @@ from mcp_server_check.tools.companies import (
 )
 
 BASE_URL = "https://sandbox.checkhq.com"
+
+
+@pytest.mark.anyio
+async def test_list_companies_with_implementation_status(mock_api, ctx):
+    route = mock_api.get("/companies").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": "com_001",
+                        "legal_name": "Test Co",
+                        "trade_name": "Test",
+                        "pay_frequency": "biweekly",
+                        "onboard": {"status": "blocking"},
+                        "implementation": {"status": "needs_attention"},
+                    }
+                ],
+            },
+        )
+    )
+    result = await list_companies(ctx, implementation_status="needs_attention")
+    assert result["result_count"] == 1
+    assert result["results"][0]["onboard"] == {"status": "blocking"}
+    assert result["results"][0]["implementation"] == {"status": "needs_attention"}
+    assert "implementation_status=needs_attention" in str(route.calls[0].request.url)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Adds `implementation_status` filter parameter to `list_companies` MCP tool (the Check API already supports this, the MCP tool just wasn't exposing it)
- Adds `onboard` and `implementation` to the company summary fields so `list_companies` returns status info inline instead of stripping it

## Context
A partner (Tekion) reported that querying "which companies are in needs_attention status" took 5+ minutes. Root cause: Claude had to call `get_company` 313 times individually because `list_companies` (1) didn't expose status filters and (2) stripped onboard/implementation from the summary response.

With this change:
- `list_companies(implementation_status="needs_attention")` returns pre-filtered results in one paginated pass
- `list_companies()` now includes `onboard` and `implementation` in each result, enabling client-side filtering for `onboard.status`

## Test plan
- [x] New test for `implementation_status` query param passthrough
- [x] All 418 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)