### PR TITLE
Add ?read_only=true URL query parameter support

### DIFF
--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -109,17 +109,25 @@ class CheckMCP(FastMCP):
     def _get_active_filter(self) -> ToolFilter:
         """Return the filter for the current request.
 
-        For HTTP transports, merges request-header overrides with the
-        static (env-based) filter, taking the most restrictive value
-        for each field.  The env filter acts as a policy floor that
-        clients cannot relax.  For stdio, returns the static filter.
+        For HTTP transports, merges request-header and query-parameter
+        overrides with the static (env-based) filter, taking the most
+        restrictive value for each field.  The env filter acts as a
+        policy floor that clients cannot relax.  For stdio, returns
+        the static filter.
         """
         try:
             request = self._mcp_server.request_context.request
-            if request is not None and hasattr(request, "headers"):
-                header_filter = ToolFilter.from_headers(request.headers)
-                if header_filter != ToolFilter():
-                    return self._static_filter.merge(header_filter)
+            if request is not None:
+                result = self._static_filter
+                if hasattr(request, "headers"):
+                    header_filter = ToolFilter.from_headers(request.headers)
+                    if header_filter != ToolFilter():
+                        result = result.merge(header_filter)
+                if hasattr(request, "query_params"):
+                    qp_filter = ToolFilter.from_query_params(request.query_params)
+                    if qp_filter != ToolFilter():
+                        result = result.merge(qp_filter)
+                return result
         except Exception:
             pass
         return self._static_filter

--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -229,3 +229,20 @@ class ToolFilter:
             read_only=_parse_bool(get("x-mcp-readonly")),
             confirm_destructive=_parse_bool(get("x-mcp-confirm-destructive")),
         )
+
+    @classmethod
+    def from_query_params(cls, query_params: dict[str, str] | object) -> ToolFilter:
+        """Build a ToolFilter from URL query parameters.
+
+        Currently only supports the ``read_only`` parameter.
+
+        Args:
+            query_params: A dict-like object (e.g. Starlette QueryParams)
+                          supporting .get().
+        """
+        get = getattr(query_params, "get", None)
+        if get is None:
+            return cls()
+        return cls(
+            read_only=_parse_bool(get("read_only")),
+        )

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -147,6 +147,50 @@ class TestFromHeaders:
         assert tf.read_only is True
 
 
+# --- ToolFilter.from_query_params ---
+
+
+class TestFromQueryParams:
+    def test_read_only_true(self):
+        tf = ToolFilter.from_query_params({"read_only": "true"})
+        assert tf.read_only is True
+
+    def test_read_only_numeric(self):
+        tf = ToolFilter.from_query_params({"read_only": "1"})
+        assert tf.read_only is True
+
+    def test_read_only_false(self):
+        tf = ToolFilter.from_query_params({"read_only": "false"})
+        assert tf.read_only is False
+
+    def test_empty_query_params(self):
+        tf = ToolFilter.from_query_params({})
+        assert tf == ToolFilter()
+
+    def test_no_get_method(self):
+        tf = ToolFilter.from_query_params(42)  # type: ignore[arg-type]
+        assert tf == ToolFilter()
+
+    def test_unrelated_params_ignored(self):
+        tf = ToolFilter.from_query_params({"foo": "bar", "baz": "1"})
+        assert tf == ToolFilter()
+
+    def test_only_read_only_is_parsed(self):
+        """Query params for other filter fields (toolsets, confirm_destructive, etc.) are ignored."""
+        tf = ToolFilter.from_query_params({
+            "read_only": "true",
+            "confirm_destructive": "true",
+            "toolsets": "companies",
+            "tools": "list_companies",
+            "exclude_tools": "delete_company",
+        })
+        assert tf.read_only is True
+        assert tf.confirm_destructive is False
+        assert tf.toolsets is None
+        assert tf.tools is None
+        assert tf.exclude_tools == frozenset()
+
+
 # --- is_tool_allowed precedence ---
 
 
@@ -354,6 +398,21 @@ class TestMerge:
         env = ToolFilter(confirm_destructive=True)
         header = ToolFilter(confirm_destructive=False)
         assert env.merge(header).confirm_destructive is True
+
+    def test_merge_three_way_env_header_query(self):
+        """Env, header, and query-param filters combine correctly."""
+        env = ToolFilter(toolsets=frozenset({"companies", "employees"}))
+        header = ToolFilter(toolsets=frozenset({"companies", "payrolls"}))
+        query = ToolFilter(read_only=True)
+        merged = env.merge(header).merge(query)
+        assert merged.toolsets == frozenset({"companies"})
+        assert merged.read_only is True
+
+    def test_merge_query_param_cannot_relax_env(self):
+        """read_only=False from query params cannot override read_only=True from env."""
+        env = ToolFilter(read_only=True)
+        query = ToolFilter(read_only=False)
+        assert env.merge(query).read_only is True
 
     def test_merge_full_policy_scenario(self):
         """Realistic scenario: env locks down to read-only companies,

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -177,13 +177,15 @@ class TestFromQueryParams:
 
     def test_only_read_only_is_parsed(self):
         """Query params for other filter fields (toolsets, confirm_destructive, etc.) are ignored."""
-        tf = ToolFilter.from_query_params({
-            "read_only": "true",
-            "confirm_destructive": "true",
-            "toolsets": "companies",
-            "tools": "list_companies",
-            "exclude_tools": "delete_company",
-        })
+        tf = ToolFilter.from_query_params(
+            {
+                "read_only": "true",
+                "confirm_destructive": "true",
+                "toolsets": "companies",
+                "tools": "list_companies",
+                "exclude_tools": "delete_company",
+            }
+        )
         assert tf.read_only is True
         assert tf.confirm_destructive is False
         assert tf.toolsets is None


### PR DESCRIPTION
## Summary
- Adds `?read_only=true` as a URL query parameter alternative for enforcing read-only mode, for users who cannot set HTTP headers
- Adds `ToolFilter.from_query_params()` classmethod scoped to `read_only` only (no other filter options exposed via query params)
- Updates `_get_active_filter()` to merge query-param overrides after header overrides, with the env filter still acting as a policy floor that clients cannot relax

## Test plan
- [x] `TestFromQueryParams`: 7 tests covering truthy/falsy values, empty params, non-dict input, unrelated params ignored, only `read_only` parsed
- [x] `TestMerge`: 2 new tests for three-way env+header+query merge and relaxation guard
- [x] Full test suite passes (427 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)