### PR TITLE
Add MCP tool titles and annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build/
 .pytest_cache/
 .ruff_cache/
 .DS_Store
+.env
+.env.*
+!.env.example

--- a/src/mcp_server_check/annotations.py
+++ b/src/mcp_server_check/annotations.py
@@ -1,0 +1,155 @@
+"""Helpers for deriving MCP tool titles and ToolAnnotations from function names.
+
+Centralises the classification logic so that every Check API tool is registered
+with a consistent, accurate set of MCP hints (``readOnlyHint``,
+``destructiveHint``, ``idempotentHint``, ``openWorldHint``) and a human-readable
+``title``. The Check API is a closed-world domain so ``openWorldHint`` is
+always ``False`` for these tools.
+
+Classification rules consume :mod:`mcp_server_check.tool_filter` as the source
+of truth for write/destructive detection — no parallel taxonomy.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+from fastmcp.tools import FunctionTool, Tool
+from mcp.types import ToolAnnotations
+
+from mcp_server_check.tool_filter import is_destructive_tool, is_write_tool
+
+# Acronyms that should remain uppercase in the human-readable title.
+_ACRONYMS: frozenset[str] = frozenset(
+    {
+        "ssn",
+        "ein",
+        "ach",
+        "irs",
+        "w2",
+        "w4",
+        "url",
+        "id",
+        "pdf",
+        "csv",
+    }
+)
+
+# Word-level overrides that don't fit the simple Title-Case rule.
+_WORD_OVERRIDES: dict[str, str] = {
+    "w2": "W-2",
+    "w4": "W-4",
+}
+
+# Lowercase joining words (skipped only when they appear in the middle of a
+# title — the first word is always capitalised).
+_LOWERCASE_JOINERS: frozenset[str] = frozenset(
+    {"and", "or", "for", "of", "to", "the", "a", "an"}
+)
+
+# Tool-name prefixes that imply an idempotent mutating call (PUT/DELETE).
+# Idempotent means: calling repeatedly with the same arguments has no
+# additional effect beyond the first call.
+_IDEMPOTENT_WRITE_PREFIXES: tuple[str, ...] = (
+    "update_",
+    "bulk_update_",
+    "delete_",
+    "bulk_delete_",
+)
+
+# Sandbox-only mutating tools — flagged with a "(Sandbox)" suffix in the title
+# so users can tell them apart from production-state operations.
+_SANDBOX_PREFIXES: tuple[str, ...] = ("simulate_",)
+
+
+def _humanize_word(word: str, *, is_first: bool = False) -> str:
+    """Convert a single snake_case token into its title-cased form.
+
+    ``is_first`` keeps the very first word capitalised even when it would
+    otherwise be a lowercase joiner (e.g. "of", "and").
+    """
+    lower = word.lower()
+    if lower in _WORD_OVERRIDES:
+        return _WORD_OVERRIDES[lower]
+    if lower in _ACRONYMS:
+        return lower.upper()
+    if not is_first and lower in _LOWERCASE_JOINERS:
+        return lower
+    return word.capitalize()
+
+
+def derive_title(fn_name: str) -> str:
+    """Return a human-readable title for a tool given its function name.
+
+    Examples:
+        list_companies -> "List Companies"
+        get_employee_paystub -> "Get Employee Paystub"
+        reveal_employee_ssn -> "Reveal Employee SSN"
+        simulate_complete_funding -> "Simulate Complete Funding (Sandbox)"
+        sign_and_submit_employee_form -> "Sign and Submit Employee Form"
+    """
+    parts = [p for p in re.split(r"_+", fn_name) if p]
+    title = " ".join(_humanize_word(p, is_first=(i == 0)) for i, p in enumerate(parts))
+    if any(fn_name.startswith(p) for p in _SANDBOX_PREFIXES):
+        title += " (Sandbox)"
+    return title
+
+
+def derive_annotations(fn_name: str) -> ToolAnnotations:
+    """Derive a ToolAnnotations from the tool name.
+
+    Classification:
+      * Read-only: anything not flagged by ``is_write_tool``.
+      * Destructive: anything flagged by ``is_destructive_tool``
+        (delete/cancel/refund/approve/simulate, etc.).
+      * Idempotent: read-only calls, plus update_/delete_ style writes.
+      * Open-world: always ``False`` (Check API is a closed domain).
+    """
+    title = derive_title(fn_name)
+    write = is_write_tool(fn_name)
+    destructive = is_destructive_tool(fn_name)
+
+    if not write:
+        return ToolAnnotations(
+            title=title,
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        )
+
+    idempotent = any(fn_name.startswith(p) for p in _IDEMPOTENT_WRITE_PREFIXES)
+    return ToolAnnotations(
+        title=title,
+        readOnlyHint=False,
+        destructiveHint=destructive,
+        idempotentHint=idempotent,
+        openWorldHint=False,
+    )
+
+
+def build_tool(fn: Callable[..., Any]) -> FunctionTool:
+    """Wrap a plain function in a FunctionTool with derived title and annotations."""
+    title = derive_title(fn.__name__)
+    annotations = derive_annotations(fn.__name__)
+    return Tool.from_function(fn, title=title, annotations=annotations)
+
+
+def add_annotated_tool(mcp: Any, fn: Callable[..., Any]) -> None:
+    """Register ``fn`` on ``mcp`` with a derived title and ToolAnnotations.
+
+    Designed to be a drop-in replacement for ``mcp.add_tool(fn)`` at every
+    registration site. Works against both real :class:`FastMCP` instances
+    (which require a :class:`Tool` object) and the lightweight collectors
+    used during indexing (which accept the raw function).
+    """
+    title = derive_title(fn.__name__)
+    annotations = derive_annotations(fn.__name__)
+    accepts_kwargs = getattr(mcp, "_annotated_tool_supports_kwargs", False)
+    if accepts_kwargs:
+        mcp.add_tool(fn, title=title, annotations=annotations)
+        return
+    tool = Tool.from_function(fn, title=title, annotations=annotations)
+    mcp.add_tool(tool)

--- a/src/mcp_server_check/annotations.py
+++ b/src/mcp_server_check/annotations.py
@@ -41,6 +41,7 @@ _ACRONYMS: frozenset[str] = frozenset(
 _WORD_OVERRIDES: dict[str, str] = {
     "w2": "W-2",
     "w4": "W-4",
+    "ids": "IDs",
 }
 
 # Lowercase joining words (skipped only when they appear in the middle of a

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -165,7 +165,15 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
     index.build()
     server._tool_index = index
 
-    @server.tool()
+    @server.tool(
+        title="Search Tools",
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    )
     def search_tools(
         query: str = "",
         toolset: str | None = None,
@@ -185,7 +193,15 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
         results = index.search(query, tool_filter=tf, toolset=toolset, limit=limit)
         return json.dumps(results, indent=2)
 
-    @server.tool()
+    @server.tool(
+        title="List Toolsets",
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": False,
+        },
+    )
     def list_toolsets() -> str:
         """List all available API toolsets with descriptions.
 
@@ -197,7 +213,14 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
         results = index.search("", tool_filter=tf)
         return json.dumps(results, indent=2)
 
-    @server.tool()
+    @server.tool(
+        title="Run Tool",
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "openWorldHint": False,
+        },
+    )
     async def run_tool(
         ctx: Context,
         tool_name: str,

--- a/src/mcp_server_check/tool_index.py
+++ b/src/mcp_server_check/tool_index.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from fastmcp.tools import FunctionTool as Tool
 
+from mcp_server_check.annotations import build_tool
 from mcp_server_check.tool_filter import ToolFilter, is_write_tool
 from mcp_server_check.tools import collect_all_tools
 
@@ -117,7 +118,7 @@ class ToolIndex:
         for toolset_name, functions in all_tools.items():
             toolset_list: list[ToolEntry] = []
             for fn in functions:
-                tool = Tool.from_function(fn)
+                tool = build_tool(fn)
                 description = _first_line(fn.__doc__)
                 # Include parameter names in search tokens for richer matching
                 param_names = set()

--- a/src/mcp_server_check/tools/__init__.py
+++ b/src/mcp_server_check/tools/__init__.py
@@ -54,12 +54,19 @@ def collect_all_tools() -> dict[str, list[Callable]]:
     """Return {toolset_name: [fn, ...]} for all toolsets.
 
     Calls each module's register() with a collector to capture tool functions.
+    The collector advertises kwargs support so ``add_annotated_tool`` passes the
+    raw function rather than a wrapped Tool object — the index needs the
+    function for introspection and to derive Tool instances itself.
     """
     result: dict[str, list[Callable]] = {}
     for name, module in _TOOLSETS.items():
         functions: list[Callable] = []
 
         class _Collector:
+            # Tells add_annotated_tool to pass the raw function so we can
+            # introspect it during indexing.
+            _annotated_tool_supports_kwargs = True
+
             @staticmethod
             def add_tool(fn: Callable, **kwargs: Any) -> None:
                 functions.append(fn)
@@ -82,10 +89,17 @@ def register_all(mcp: FastMCP, registry: dict[str, str]) -> None:
 
     current_toolset: list[str] = []
 
-    def tracking_add_tool(fn, **kwargs):
-        original_add_tool(fn, **kwargs)
-        tool_name = kwargs.get("name") or fn.__name__
+    def tracking_add_tool(tool, **kwargs):
+        # ``tool`` may be a FunctionTool (the new annotated path) or a raw
+        # callable (legacy / direct callers). Resolve the public tool name
+        # from whichever shape was supplied.
+        result = original_add_tool(tool, **kwargs)
+        if hasattr(tool, "name"):
+            tool_name = tool.name
+        else:
+            tool_name = kwargs.get("name") or tool.__name__
         registry[tool_name] = current_toolset[0]
+        return result
 
     try:
         mcp.add_tool = tracking_add_tool  # type: ignore[assignment]

--- a/src/mcp_server_check/tools/bank_accounts.py
+++ b/src/mcp_server_check/tools/bank_accounts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import (
     Ctx,
     check_api_delete,
@@ -126,9 +127,9 @@ async def delete_bank_account(ctx: Ctx, bank_account_id: str) -> dict:
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_bank_accounts)
-    mcp.add_tool(get_bank_account)
+    add_annotated_tool(mcp, list_bank_accounts)
+    add_annotated_tool(mcp, get_bank_account)
     if not read_only:
-        mcp.add_tool(create_bank_account)
-        mcp.add_tool(update_bank_account)
-        mcp.add_tool(delete_bank_account)
+        add_annotated_tool(mcp, create_bank_account)
+        add_annotated_tool(mcp, update_bank_account)
+        add_annotated_tool(mcp, delete_bank_account)

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import Address
 from mcp_server_check.helpers import (
     Ctx,
@@ -607,23 +608,23 @@ async def request_embedded_setup(ctx: Ctx, company_id: str) -> dict:
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_companies)
-    mcp.add_tool(get_company)
-    mcp.add_tool(get_company_paydays)
-    mcp.add_tool(list_company_tax_deposits)
-    mcp.add_tool(get_company_benefit_aggregations)
-    mcp.add_tool(get_company_report)
-    mcp.add_tool(list_federal_ein_verifications)
-    mcp.add_tool(get_federal_ein_verification)
-    mcp.add_tool(list_signatories)
-    mcp.add_tool(get_enrollment_profile)
+    add_annotated_tool(mcp, list_companies)
+    add_annotated_tool(mcp, get_company)
+    add_annotated_tool(mcp, get_company_paydays)
+    add_annotated_tool(mcp, list_company_tax_deposits)
+    add_annotated_tool(mcp, get_company_benefit_aggregations)
+    add_annotated_tool(mcp, get_company_report)
+    add_annotated_tool(mcp, list_federal_ein_verifications)
+    add_annotated_tool(mcp, get_federal_ein_verification)
+    add_annotated_tool(mcp, list_signatories)
+    add_annotated_tool(mcp, get_enrollment_profile)
     if not read_only:
-        mcp.add_tool(create_company)
-        mcp.add_tool(update_company)
-        mcp.add_tool(onboard_company)
-        mcp.add_tool(create_signatory)
-        mcp.add_tool(create_enrollment_profile)
-        mcp.add_tool(update_enrollment_profile)
-        mcp.add_tool(start_implementation)
-        mcp.add_tool(cancel_implementation)
-        mcp.add_tool(request_embedded_setup)
+        add_annotated_tool(mcp, create_company)
+        add_annotated_tool(mcp, update_company)
+        add_annotated_tool(mcp, onboard_company)
+        add_annotated_tool(mcp, create_signatory)
+        add_annotated_tool(mcp, create_enrollment_profile)
+        add_annotated_tool(mcp, update_enrollment_profile)
+        add_annotated_tool(mcp, start_implementation)
+        add_annotated_tool(mcp, cancel_implementation)
+        add_annotated_tool(mcp, request_embedded_setup)

--- a/src/mcp_server_check/tools/compensation.py
+++ b/src/mcp_server_check/tools/compensation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import Ctx, check_api_get
 from mcp_server_check.tool_factory import Field, Resource, generate_tools
 
@@ -454,49 +455,49 @@ create_net_pay_split = _net_pay_split_tools.create_fn
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Pay Schedules
-    mcp.add_tool(list_pay_schedules)
-    mcp.add_tool(get_pay_schedule)
-    mcp.add_tool(get_pay_schedule_paydays)
+    add_annotated_tool(mcp, list_pay_schedules)
+    add_annotated_tool(mcp, get_pay_schedule)
+    add_annotated_tool(mcp, get_pay_schedule_paydays)
     # Benefits
-    mcp.add_tool(list_benefits)
-    mcp.add_tool(get_benefit)
+    add_annotated_tool(mcp, list_benefits)
+    add_annotated_tool(mcp, get_benefit)
     # Post-Tax Deductions
-    mcp.add_tool(list_post_tax_deductions)
-    mcp.add_tool(get_post_tax_deduction)
+    add_annotated_tool(mcp, list_post_tax_deductions)
+    add_annotated_tool(mcp, get_post_tax_deduction)
     # Company Benefits
-    mcp.add_tool(list_company_benefits)
-    mcp.add_tool(get_company_benefit)
+    add_annotated_tool(mcp, list_company_benefits)
+    add_annotated_tool(mcp, get_company_benefit)
     # Earning Rates
-    mcp.add_tool(list_earning_rates)
-    mcp.add_tool(get_earning_rate)
+    add_annotated_tool(mcp, list_earning_rates)
+    add_annotated_tool(mcp, get_earning_rate)
     # Earning Codes
-    mcp.add_tool(list_earning_codes)
-    mcp.add_tool(get_earning_code)
+    add_annotated_tool(mcp, list_earning_codes)
+    add_annotated_tool(mcp, get_earning_code)
     # Net Pay Splits
-    mcp.add_tool(list_net_pay_splits)
-    mcp.add_tool(get_net_pay_split)
+    add_annotated_tool(mcp, list_net_pay_splits)
+    add_annotated_tool(mcp, get_net_pay_split)
     if not read_only:
         # Pay Schedules
-        mcp.add_tool(create_pay_schedule)
-        mcp.add_tool(update_pay_schedule)
-        mcp.add_tool(delete_pay_schedule)
+        add_annotated_tool(mcp, create_pay_schedule)
+        add_annotated_tool(mcp, update_pay_schedule)
+        add_annotated_tool(mcp, delete_pay_schedule)
         # Benefits
-        mcp.add_tool(create_benefit)
-        mcp.add_tool(update_benefit)
-        mcp.add_tool(delete_benefit)
+        add_annotated_tool(mcp, create_benefit)
+        add_annotated_tool(mcp, update_benefit)
+        add_annotated_tool(mcp, delete_benefit)
         # Post-Tax Deductions
-        mcp.add_tool(create_post_tax_deduction)
-        mcp.add_tool(update_post_tax_deduction)
-        mcp.add_tool(delete_post_tax_deduction)
+        add_annotated_tool(mcp, create_post_tax_deduction)
+        add_annotated_tool(mcp, update_post_tax_deduction)
+        add_annotated_tool(mcp, delete_post_tax_deduction)
         # Company Benefits
-        mcp.add_tool(create_company_benefit)
-        mcp.add_tool(update_company_benefit)
-        mcp.add_tool(delete_company_benefit)
+        add_annotated_tool(mcp, create_company_benefit)
+        add_annotated_tool(mcp, update_company_benefit)
+        add_annotated_tool(mcp, delete_company_benefit)
         # Earning Rates
-        mcp.add_tool(create_earning_rate)
-        mcp.add_tool(update_earning_rate)
+        add_annotated_tool(mcp, create_earning_rate)
+        add_annotated_tool(mcp, update_earning_rate)
         # Earning Codes
-        mcp.add_tool(create_earning_code)
-        mcp.add_tool(update_earning_code)
+        add_annotated_tool(mcp, create_earning_code)
+        add_annotated_tool(mcp, update_earning_code)
         # Net Pay Splits
-        mcp.add_tool(create_net_pay_split)
+        add_annotated_tool(mcp, create_net_pay_split)

--- a/src/mcp_server_check/tools/components.py
+++ b/src/mcp_server_check/tools/components.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import Ctx, check_api_post
 
 COMPANY_COMPONENTS = [
@@ -139,6 +140,6 @@ async def create_component(
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_component_types)
+    add_annotated_tool(mcp, list_component_types)
     if not read_only:
-        mcp.add_tool(create_component)
+        add_annotated_tool(mcp, create_component)

--- a/src/mcp_server_check/tools/contractor_payments.py
+++ b/src/mcp_server_check/tools/contractor_payments.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import (
     Ctx,
     check_api_delete,
@@ -164,10 +165,10 @@ async def get_contractor_payment_paper_check(
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_contractor_payments)
-    mcp.add_tool(get_contractor_payment)
-    mcp.add_tool(get_contractor_payment_paper_check)
+    add_annotated_tool(mcp, list_contractor_payments)
+    add_annotated_tool(mcp, get_contractor_payment)
+    add_annotated_tool(mcp, get_contractor_payment_paper_check)
     if not read_only:
-        mcp.add_tool(create_contractor_payment)
-        mcp.add_tool(update_contractor_payment)
-        mcp.add_tool(delete_contractor_payment)
+        add_annotated_tool(mcp, create_contractor_payment)
+        add_annotated_tool(mcp, update_contractor_payment)
+        add_annotated_tool(mcp, delete_contractor_payment)

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import Address, FormParameter
 from mcp_server_check.helpers import (
     Ctx,
@@ -275,13 +276,13 @@ async def submit_contractor_form(
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_contractors)
-    mcp.add_tool(get_contractor)
-    mcp.add_tool(list_contractor_payments_for_contractor)
-    mcp.add_tool(get_contractor_payment_for_payroll)
-    mcp.add_tool(list_contractor_forms)
+    add_annotated_tool(mcp, list_contractors)
+    add_annotated_tool(mcp, get_contractor)
+    add_annotated_tool(mcp, list_contractor_payments_for_contractor)
+    add_annotated_tool(mcp, get_contractor_payment_for_payroll)
+    add_annotated_tool(mcp, list_contractor_forms)
     if not read_only:
-        mcp.add_tool(create_contractor)
-        mcp.add_tool(update_contractor)
-        mcp.add_tool(onboard_contractor)
-        mcp.add_tool(submit_contractor_form)
+        add_annotated_tool(mcp, create_contractor)
+        add_annotated_tool(mcp, update_contractor)
+        add_annotated_tool(mcp, onboard_contractor)
+        add_annotated_tool(mcp, submit_contractor_form)

--- a/src/mcp_server_check/tools/documents.py
+++ b/src/mcp_server_check/tools/documents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import (
     Ctx,
     build_body,
@@ -315,28 +316,28 @@ async def upload_company_provided_document_file(
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Company Tax Documents
-    mcp.add_tool(list_company_tax_documents)
-    mcp.add_tool(get_company_tax_document)
-    mcp.add_tool(download_company_tax_document)
+    add_annotated_tool(mcp, list_company_tax_documents)
+    add_annotated_tool(mcp, get_company_tax_document)
+    add_annotated_tool(mcp, download_company_tax_document)
     # Company Authorization Documents
-    mcp.add_tool(list_company_authorization_documents)
-    mcp.add_tool(get_company_authorization_document)
-    mcp.add_tool(download_company_authorization_document)
+    add_annotated_tool(mcp, list_company_authorization_documents)
+    add_annotated_tool(mcp, get_company_authorization_document)
+    add_annotated_tool(mcp, download_company_authorization_document)
     # Employee Tax Documents
-    mcp.add_tool(list_employee_tax_documents)
-    mcp.add_tool(get_employee_tax_document)
-    mcp.add_tool(download_employee_tax_document)
+    add_annotated_tool(mcp, list_employee_tax_documents)
+    add_annotated_tool(mcp, get_employee_tax_document)
+    add_annotated_tool(mcp, download_employee_tax_document)
     # Contractor Tax Documents
-    mcp.add_tool(list_contractor_tax_documents)
-    mcp.add_tool(get_contractor_tax_document)
-    mcp.add_tool(download_contractor_tax_document)
+    add_annotated_tool(mcp, list_contractor_tax_documents)
+    add_annotated_tool(mcp, get_contractor_tax_document)
+    add_annotated_tool(mcp, download_contractor_tax_document)
     # Setup Documents
-    mcp.add_tool(list_setup_documents)
-    mcp.add_tool(get_setup_document)
-    mcp.add_tool(download_setup_document)
+    add_annotated_tool(mcp, list_setup_documents)
+    add_annotated_tool(mcp, get_setup_document)
+    add_annotated_tool(mcp, download_setup_document)
     # Company Provided Documents
-    mcp.add_tool(list_company_provided_documents)
-    mcp.add_tool(get_company_provided_document)
+    add_annotated_tool(mcp, list_company_provided_documents)
+    add_annotated_tool(mcp, get_company_provided_document)
     if not read_only:
-        mcp.add_tool(create_company_provided_document)
-        mcp.add_tool(upload_company_provided_document_file)
+        add_annotated_tool(mcp, create_company_provided_document)
+        add_annotated_tool(mcp, upload_company_provided_document_file)

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import Address, FormParameter
 from mcp_server_check.helpers import (
     Ctx,
@@ -390,20 +391,20 @@ async def authorize_employee_partner(
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_employees)
-    mcp.add_tool(get_employee)
-    mcp.add_tool(list_employee_paystubs)
-    mcp.add_tool(get_employee_paystub)
-    mcp.add_tool(list_employee_forms)
-    mcp.add_tool(get_employee_form)
-    mcp.add_tool(get_employee_company_defined_attributes)
-    mcp.add_tool(get_employee_reciprocity_elections)
+    add_annotated_tool(mcp, list_employees)
+    add_annotated_tool(mcp, get_employee)
+    add_annotated_tool(mcp, list_employee_paystubs)
+    add_annotated_tool(mcp, get_employee_paystub)
+    add_annotated_tool(mcp, list_employee_forms)
+    add_annotated_tool(mcp, get_employee_form)
+    add_annotated_tool(mcp, get_employee_company_defined_attributes)
+    add_annotated_tool(mcp, get_employee_reciprocity_elections)
     if not read_only:
-        mcp.add_tool(create_employee)
-        mcp.add_tool(update_employee)
-        mcp.add_tool(onboard_employee)
-        mcp.add_tool(submit_employee_form)
-        mcp.add_tool(sign_and_submit_employee_form)
-        mcp.add_tool(update_employee_company_defined_attributes)
-        mcp.add_tool(update_employee_reciprocity_elections)
-        mcp.add_tool(authorize_employee_partner)
+        add_annotated_tool(mcp, create_employee)
+        add_annotated_tool(mcp, update_employee)
+        add_annotated_tool(mcp, onboard_employee)
+        add_annotated_tool(mcp, submit_employee_form)
+        add_annotated_tool(mcp, sign_and_submit_employee_form)
+        add_annotated_tool(mcp, update_employee_company_defined_attributes)
+        add_annotated_tool(mcp, update_employee_reciprocity_elections)
+        add_annotated_tool(mcp, authorize_employee_partner)

--- a/src/mcp_server_check/tools/external_payrolls.py
+++ b/src/mcp_server_check/tools/external_payrolls.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import (
     Ctx,
     check_api_delete,
@@ -167,12 +168,12 @@ async def preview_external_payroll(ctx: Ctx, external_payroll_id: str) -> dict:
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_external_payrolls)
-    mcp.add_tool(get_external_payroll)
-    mcp.add_tool(preview_external_payroll)
+    add_annotated_tool(mcp, list_external_payrolls)
+    add_annotated_tool(mcp, get_external_payroll)
+    add_annotated_tool(mcp, preview_external_payroll)
     if not read_only:
-        mcp.add_tool(create_external_payroll)
-        mcp.add_tool(update_external_payroll)
-        mcp.add_tool(delete_external_payroll)
-        mcp.add_tool(approve_external_payroll)
-        mcp.add_tool(reopen_external_payroll)
+        add_annotated_tool(mcp, create_external_payroll)
+        add_annotated_tool(mcp, update_external_payroll)
+        add_annotated_tool(mcp, delete_external_payroll)
+        add_annotated_tool(mcp, approve_external_payroll)
+        add_annotated_tool(mcp, reopen_external_payroll)

--- a/src/mcp_server_check/tools/forms.py
+++ b/src/mcp_server_check/tools/forms.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import FormParameter
 from mcp_server_check.helpers import (
     Ctx,
@@ -83,7 +84,7 @@ async def validate_form(
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_forms)
-    mcp.add_tool(get_form)
-    mcp.add_tool(render_form)
-    mcp.add_tool(validate_form)
+    add_annotated_tool(mcp, list_forms)
+    add_annotated_tool(mcp, get_form)
+    add_annotated_tool(mcp, render_form)
+    add_annotated_tool(mcp, validate_form)

--- a/src/mcp_server_check/tools/payments.py
+++ b/src/mcp_server_check/tools/payments.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import (
     Ctx,
     build_params,
@@ -121,10 +122,10 @@ async def cancel_payment(ctx: Ctx, payment_id: str) -> dict:
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_payments)
-    mcp.add_tool(get_payment)
-    mcp.add_tool(list_payment_attempts)
+    add_annotated_tool(mcp, list_payments)
+    add_annotated_tool(mcp, get_payment)
+    add_annotated_tool(mcp, list_payment_attempts)
     if not read_only:
-        mcp.add_tool(retry_payment)
-        mcp.add_tool(refund_payment)
-        mcp.add_tool(cancel_payment)
+        add_annotated_tool(mcp, retry_payment)
+        add_annotated_tool(mcp, refund_payment)
+        add_annotated_tool(mcp, cancel_payment)

--- a/src/mcp_server_check/tools/payroll_items.py
+++ b/src/mcp_server_check/tools/payroll_items.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import (
     Ctx,
     check_api_delete,
@@ -182,12 +183,12 @@ async def get_payroll_item_paper_check(ctx: Ctx, payroll_item_id: str) -> dict:
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_payroll_items)
-    mcp.add_tool(get_payroll_item)
-    mcp.add_tool(get_payroll_item_paper_check)
+    add_annotated_tool(mcp, list_payroll_items)
+    add_annotated_tool(mcp, get_payroll_item)
+    add_annotated_tool(mcp, get_payroll_item_paper_check)
     if not read_only:
-        mcp.add_tool(create_payroll_item)
-        mcp.add_tool(update_payroll_item)
-        mcp.add_tool(bulk_update_payroll_items)
-        mcp.add_tool(delete_payroll_item)
-        mcp.add_tool(bulk_delete_payroll_items)
+        add_annotated_tool(mcp, create_payroll_item)
+        add_annotated_tool(mcp, update_payroll_item)
+        add_annotated_tool(mcp, bulk_update_payroll_items)
+        add_annotated_tool(mcp, delete_payroll_item)
+        add_annotated_tool(mcp, bulk_delete_payroll_items)

--- a/src/mcp_server_check/tools/payrolls.py
+++ b/src/mcp_server_check/tools/payrolls.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import OffCycleOptions
 from mcp_server_check.helpers import (
     Ctx,
@@ -314,19 +315,19 @@ async def simulate_complete_disbursements(ctx: Ctx, payroll_id: str) -> dict:
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_payrolls)
-    mcp.add_tool(get_payroll)
-    mcp.add_tool(preview_payroll)
-    mcp.add_tool(get_payroll_paper_checks)
-    mcp.add_tool(get_payroll_cash_requirement_report)
-    mcp.add_tool(get_payroll_paper_checks_report)
+    add_annotated_tool(mcp, list_payrolls)
+    add_annotated_tool(mcp, get_payroll)
+    add_annotated_tool(mcp, preview_payroll)
+    add_annotated_tool(mcp, get_payroll_paper_checks)
+    add_annotated_tool(mcp, get_payroll_cash_requirement_report)
+    add_annotated_tool(mcp, get_payroll_paper_checks_report)
     if not read_only:
-        mcp.add_tool(create_payroll)
-        mcp.add_tool(update_payroll)
-        mcp.add_tool(delete_payroll)
-        mcp.add_tool(approve_payroll)
-        mcp.add_tool(reopen_payroll)
-        mcp.add_tool(simulate_start_processing)
-        mcp.add_tool(simulate_complete_funding)
-        mcp.add_tool(simulate_fail_funding)
-        mcp.add_tool(simulate_complete_disbursements)
+        add_annotated_tool(mcp, create_payroll)
+        add_annotated_tool(mcp, update_payroll)
+        add_annotated_tool(mcp, delete_payroll)
+        add_annotated_tool(mcp, approve_payroll)
+        add_annotated_tool(mcp, reopen_payroll)
+        add_annotated_tool(mcp, simulate_start_processing)
+        add_annotated_tool(mcp, simulate_complete_funding)
+        add_annotated_tool(mcp, simulate_fail_funding)
+        add_annotated_tool(mcp, simulate_complete_disbursements)

--- a/src/mcp_server_check/tools/platform.py
+++ b/src/mcp_server_check/tools/platform.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import EmailDetails
 from mcp_server_check.helpers import (
     Ctx,
@@ -571,42 +572,42 @@ async def get_applied_for_ids_report(ctx: Ctx) -> dict:
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Notifications
-    mcp.add_tool(list_notifications)
-    mcp.add_tool(get_notification)
+    add_annotated_tool(mcp, list_notifications)
+    add_annotated_tool(mcp, get_notification)
     # Communications
-    mcp.add_tool(list_communications)
-    mcp.add_tool(get_communication)
+    add_annotated_tool(mcp, list_communications)
+    add_annotated_tool(mcp, get_communication)
     # Usage
-    mcp.add_tool(list_usage_summaries)
-    mcp.add_tool(list_usage_records)
+    add_annotated_tool(mcp, list_usage_summaries)
+    add_annotated_tool(mcp, list_usage_records)
     # Integrations
-    mcp.add_tool(list_integration_partners)
-    mcp.add_tool(get_integration_partner)
-    mcp.add_tool(list_integration_permissions)
-    mcp.add_tool(get_integration_permission)
-    mcp.add_tool(list_integration_accesses)
+    add_annotated_tool(mcp, list_integration_partners)
+    add_annotated_tool(mcp, get_integration_partner)
+    add_annotated_tool(mcp, list_integration_permissions)
+    add_annotated_tool(mcp, get_integration_permission)
+    add_annotated_tool(mcp, list_integration_accesses)
     # Accounting Integrations
-    mcp.add_tool(list_accounting_accounts)
-    mcp.add_tool(get_accounting_mappings)
-    mcp.add_tool(list_accounting_sync_attempts)
+    add_annotated_tool(mcp, list_accounting_accounts)
+    add_annotated_tool(mcp, get_accounting_mappings)
+    add_annotated_tool(mcp, list_accounting_sync_attempts)
     # Company Groups
-    mcp.add_tool(list_company_groups)
+    add_annotated_tool(mcp, list_company_groups)
     # Addresses
-    mcp.add_tool(validate_address)
+    add_annotated_tool(mcp, validate_address)
     # Setups
-    mcp.add_tool(list_setups)
-    mcp.add_tool(get_setup)
+    add_annotated_tool(mcp, list_setups)
+    add_annotated_tool(mcp, get_setup)
     # Requirements
-    mcp.add_tool(list_requirements)
-    mcp.add_tool(get_requirement)
+    add_annotated_tool(mcp, list_requirements)
+    add_annotated_tool(mcp, get_requirement)
     # Reports
-    mcp.add_tool(get_applied_for_ids_report)
+    add_annotated_tool(mcp, get_applied_for_ids_report)
     if not read_only:
-        mcp.add_tool(create_communication)
-        mcp.add_tool(authorize_integration_partner)
-        mcp.add_tool(refresh_accounting_accounts)
-        mcp.add_tool(update_accounting_mappings)
-        mcp.add_tool(toggle_accounting_mappings)
-        mcp.add_tool(sync_accounting)
-        mcp.add_tool(create_company_group)
-        mcp.add_tool(update_company_group)
+        add_annotated_tool(mcp, create_communication)
+        add_annotated_tool(mcp, authorize_integration_partner)
+        add_annotated_tool(mcp, refresh_accounting_accounts)
+        add_annotated_tool(mcp, update_accounting_mappings)
+        add_annotated_tool(mcp, toggle_accounting_mappings)
+        add_annotated_tool(mcp, sync_accounting)
+        add_annotated_tool(mcp, create_company_group)
+        add_annotated_tool(mcp, update_company_group)

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import TaxParamUpdate
 from mcp_server_check.helpers import (
     Ctx,
@@ -565,44 +566,44 @@ async def get_tax_package(ctx: Ctx, tax_package_id: str) -> dict:
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Company Tax Params
-    mcp.add_tool(get_company_tax_params)
-    mcp.add_tool(list_company_tax_param_settings)
-    mcp.add_tool(get_company_tax_param_setting)
-    mcp.add_tool(list_company_jurisdictions)
+    add_annotated_tool(mcp, get_company_tax_params)
+    add_annotated_tool(mcp, list_company_tax_param_settings)
+    add_annotated_tool(mcp, get_company_tax_param_setting)
+    add_annotated_tool(mcp, list_company_jurisdictions)
     # Employee Tax Params
-    mcp.add_tool(list_employee_tax_params)
-    mcp.add_tool(get_employee_tax_params)
-    mcp.add_tool(list_employee_tax_param_settings)
-    mcp.add_tool(get_employee_tax_param_setting)
-    mcp.add_tool(list_employee_jurisdictions)
-    mcp.add_tool(bulk_get_employee_tax_param_settings)
+    add_annotated_tool(mcp, list_employee_tax_params)
+    add_annotated_tool(mcp, get_employee_tax_params)
+    add_annotated_tool(mcp, list_employee_tax_param_settings)
+    add_annotated_tool(mcp, get_employee_tax_param_setting)
+    add_annotated_tool(mcp, list_employee_jurisdictions)
+    add_annotated_tool(mcp, bulk_get_employee_tax_param_settings)
     # Company Tax Elections
-    mcp.add_tool(list_company_tax_elections)
+    add_annotated_tool(mcp, list_company_tax_elections)
     # Employee Tax Elections
-    mcp.add_tool(list_employee_tax_elections)
+    add_annotated_tool(mcp, list_employee_tax_elections)
     # Tax Filings
-    mcp.add_tool(list_tax_filings)
-    mcp.add_tool(get_tax_filing)
+    add_annotated_tool(mcp, list_tax_filings)
+    add_annotated_tool(mcp, get_tax_filing)
     # Tax Filing Events
-    mcp.add_tool(get_tax_filing_event)
+    add_annotated_tool(mcp, get_tax_filing_event)
     # Exempt Status
-    mcp.add_tool(get_exempt_status)
+    add_annotated_tool(mcp, get_exempt_status)
     # Exemptible Taxes
-    mcp.add_tool(list_exemptible_taxes)
+    add_annotated_tool(mcp, list_exemptible_taxes)
     # Employee Tax Statements
-    mcp.add_tool(list_employee_tax_statements)
-    mcp.add_tool(get_employee_tax_statement)
+    add_annotated_tool(mcp, list_employee_tax_statements)
+    add_annotated_tool(mcp, get_employee_tax_statement)
     # Tax Packages
-    mcp.add_tool(get_tax_package)
+    add_annotated_tool(mcp, get_tax_package)
     if not read_only:
-        mcp.add_tool(update_company_tax_params)
-        mcp.add_tool(update_employee_tax_params)
-        mcp.add_tool(bulk_update_employee_tax_param_settings)
-        mcp.add_tool(create_company_tax_elections)
-        mcp.add_tool(update_company_tax_elections)
-        mcp.add_tool(update_employee_tax_elections)
-        mcp.add_tool(request_tax_filing_refile)
-        mcp.add_tool(update_exempt_status)
-        mcp.add_tool(update_exemptible_tax)
-        mcp.add_tool(bulk_update_exemptible_taxes)
-        mcp.add_tool(request_tax_package)
+        add_annotated_tool(mcp, update_company_tax_params)
+        add_annotated_tool(mcp, update_employee_tax_params)
+        add_annotated_tool(mcp, bulk_update_employee_tax_param_settings)
+        add_annotated_tool(mcp, create_company_tax_elections)
+        add_annotated_tool(mcp, update_company_tax_elections)
+        add_annotated_tool(mcp, update_employee_tax_elections)
+        add_annotated_tool(mcp, request_tax_filing_refile)
+        add_annotated_tool(mcp, update_exempt_status)
+        add_annotated_tool(mcp, update_exemptible_tax)
+        add_annotated_tool(mcp, bulk_update_exemptible_taxes)
+        add_annotated_tool(mcp, request_tax_package)

--- a/src/mcp_server_check/tools/webhooks.py
+++ b/src/mcp_server_check/tools/webhooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import (
     Ctx,
     build_body,
@@ -105,11 +106,11 @@ async def retry_webhook_events(ctx: Ctx, data: dict) -> dict:
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_webhook_configs)
-    mcp.add_tool(get_webhook_config)
+    add_annotated_tool(mcp, list_webhook_configs)
+    add_annotated_tool(mcp, get_webhook_config)
     if not read_only:
-        mcp.add_tool(create_webhook_config)
-        mcp.add_tool(update_webhook_config)
-        mcp.add_tool(delete_webhook_config)
-        mcp.add_tool(ping_webhook_config)
-        mcp.add_tool(retry_webhook_events)
+        add_annotated_tool(mcp, create_webhook_config)
+        add_annotated_tool(mcp, update_webhook_config)
+        add_annotated_tool(mcp, delete_webhook_config)
+        add_annotated_tool(mcp, ping_webhook_config)
+        add_annotated_tool(mcp, retry_webhook_events)

--- a/src/mcp_server_check/tools/workflows.py
+++ b/src/mcp_server_check/tools/workflows.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.helpers import Ctx, check_api_get, check_api_list
 
 
@@ -319,10 +320,10 @@ async def get_onboarding_status(
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(get_company_overview)
-    mcp.add_tool(get_employee_snapshot)
-    mcp.add_tool(diagnose_payment)
-    mcp.add_tool(get_payroll_details)
-    mcp.add_tool(get_contractor_snapshot)
-    mcp.add_tool(get_company_tax_overview)
-    mcp.add_tool(get_onboarding_status)
+    add_annotated_tool(mcp, get_company_overview)
+    add_annotated_tool(mcp, get_employee_snapshot)
+    add_annotated_tool(mcp, diagnose_payment)
+    add_annotated_tool(mcp, get_payroll_details)
+    add_annotated_tool(mcp, get_contractor_snapshot)
+    add_annotated_tool(mcp, get_company_tax_overview)
+    add_annotated_tool(mcp, get_onboarding_status)

--- a/src/mcp_server_check/tools/workplaces.py
+++ b/src/mcp_server_check/tools/workplaces.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastmcp import FastMCP
 
+from mcp_server_check.annotations import add_annotated_tool
 from mcp_server_check.types import Address
 from mcp_server_check.helpers import (
     Ctx,
@@ -109,8 +110,8 @@ async def update_workplace(
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
-    mcp.add_tool(list_workplaces)
-    mcp.add_tool(get_workplace)
+    add_annotated_tool(mcp, list_workplaces)
+    add_annotated_tool(mcp, get_workplace)
     if not read_only:
-        mcp.add_tool(create_workplace)
-        mcp.add_tool(update_workplace)
+        add_annotated_tool(mcp, create_workplace)
+        add_annotated_tool(mcp, update_workplace)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -33,6 +33,7 @@ class TestDeriveTitle:
             ("render_form", "Render Form"),
             ("ping_webhook_config", "Ping Webhook Config"),
             ("download_employee_tax_document", "Download Employee Tax Document"),
+            ("get_applied_for_ids_report", "Get Applied for IDs Report"),
         ],
     )
     def test_titles(self, name: str, expected: str) -> None:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,202 @@
+"""Tests for tool title and annotation derivation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from mcp_server_check.annotations import (
+    add_annotated_tool,
+    build_tool,
+    derive_annotations,
+    derive_title,
+)
+from mcp_server_check.server import CheckMCP
+from mcp_server_check.tools import register_all
+
+
+class TestDeriveTitle:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("list_companies", "List Companies"),
+            ("get_company", "Get Company"),
+            ("get_employee_paystub", "Get Employee Paystub"),
+            ("create_employee", "Create Employee"),
+            ("update_company", "Update Company"),
+            ("delete_payroll", "Delete Payroll"),
+            ("simulate_complete_funding", "Simulate Complete Funding (Sandbox)"),
+            ("simulate_fail_funding", "Simulate Fail Funding (Sandbox)"),
+            ("sign_and_submit_employee_form", "Sign and Submit Employee Form"),
+            ("bulk_delete_payroll_items", "Bulk Delete Payroll Items"),
+            ("validate_address", "Validate Address"),
+            ("render_form", "Render Form"),
+            ("ping_webhook_config", "Ping Webhook Config"),
+            ("download_employee_tax_document", "Download Employee Tax Document"),
+        ],
+    )
+    def test_titles(self, name: str, expected: str) -> None:
+        assert derive_title(name) == expected
+
+
+class TestDeriveAnnotations:
+    def test_read_only_list_tool(self) -> None:
+        a = derive_annotations("list_companies")
+        assert a.title == "List Companies"
+        assert a.readOnlyHint is True
+        assert a.destructiveHint is False
+        assert a.idempotentHint is True
+        assert a.openWorldHint is False
+
+    def test_read_only_get_tool(self) -> None:
+        a = derive_annotations("get_employee")
+        assert a.readOnlyHint is True
+        assert a.destructiveHint is False
+
+    def test_destructive_delete_tool(self) -> None:
+        a = derive_annotations("delete_payroll")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is True
+        # delete is idempotent (calling twice has no extra effect after the
+        # first call)
+        assert a.idempotentHint is True
+
+    def test_destructive_approve_tool(self) -> None:
+        a = derive_annotations("approve_payroll")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is True
+        assert a.idempotentHint is False
+
+    def test_destructive_simulate_tool(self) -> None:
+        a = derive_annotations("simulate_complete_funding")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is True
+        assert a.openWorldHint is False
+
+    def test_non_destructive_mutating_create(self) -> None:
+        a = derive_annotations("create_employee")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is False
+        assert a.idempotentHint is False
+
+    def test_non_destructive_mutating_update(self) -> None:
+        a = derive_annotations("update_company")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is False
+        assert a.idempotentHint is True
+
+    def test_non_destructive_bulk_update(self) -> None:
+        a = derive_annotations("bulk_update_payroll_items")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is False
+        assert a.idempotentHint is True
+
+    def test_destructive_bulk_delete(self) -> None:
+        a = derive_annotations("bulk_delete_payroll_items")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is True
+        assert a.idempotentHint is True
+
+    def test_open_world_always_false(self) -> None:
+        for name in (
+            "list_companies",
+            "create_employee",
+            "delete_payroll",
+            "simulate_complete_funding",
+            "ping_webhook_config",
+        ):
+            assert derive_annotations(name).openWorldHint is False, name
+
+
+class TestBuildTool:
+    def test_build_tool_sets_title_and_annotations(self) -> None:
+        async def list_companies() -> dict:  # pragma: no cover - dummy fn
+            """Dummy tool."""
+            return {}
+
+        tool = build_tool(list_companies)
+        assert tool.name == "list_companies"
+        assert tool.title == "List Companies"
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
+
+
+class TestAddAnnotatedTool:
+    def test_register_through_collector(self) -> None:
+        captured: list = []
+
+        class Collector:
+            _annotated_tool_supports_kwargs = True
+
+            @staticmethod
+            def add_tool(fn, **kwargs):
+                captured.append((fn, kwargs))
+
+        async def get_company() -> dict:  # pragma: no cover - dummy fn
+            return {}
+
+        add_annotated_tool(Collector(), get_company)
+        assert len(captured) == 1
+        fn, kwargs = captured[0]
+        assert fn is get_company
+        assert kwargs["title"] == "Get Company"
+        assert kwargs["annotations"].readOnlyHint is True
+
+
+class TestRegisteredServerTools:
+    """End-to-end checks that the live server exposes correct annotations."""
+
+    @pytest.fixture
+    def server(self) -> CheckMCP:
+        s = CheckMCP("Test")
+        register_all(s, registry=s._registry)
+        return s
+
+    def _tools_by_name(self, server: CheckMCP) -> dict:
+        return {t.name: t for t in asyncio.run(server.list_tools())}
+
+    def test_list_companies_is_read_only(self, server: CheckMCP) -> None:
+        tools = self._tools_by_name(server)
+        t = tools["list_companies"]
+        assert t.title == "List Companies"
+        assert t.annotations is not None
+        assert t.annotations.readOnlyHint is True
+        assert t.annotations.destructiveHint is False
+        assert t.annotations.openWorldHint is False
+
+    def test_delete_payroll_is_destructive(self, server: CheckMCP) -> None:
+        tools = self._tools_by_name(server)
+        t = tools["delete_payroll"]
+        assert t.title == "Delete Payroll"
+        assert t.annotations is not None
+        assert t.annotations.readOnlyHint is False
+        assert t.annotations.destructiveHint is True
+
+    def test_create_employee_is_non_destructive_mutating(
+        self, server: CheckMCP
+    ) -> None:
+        tools = self._tools_by_name(server)
+        t = tools["create_employee"]
+        assert t.title == "Create Employee"
+        assert t.annotations is not None
+        assert t.annotations.readOnlyHint is False
+        assert t.annotations.destructiveHint is False
+
+    def test_simulate_tool_marked_sandbox_and_destructive(
+        self, server: CheckMCP
+    ) -> None:
+        tools = self._tools_by_name(server)
+        t = tools["simulate_complete_funding"]
+        assert t.title == "Simulate Complete Funding (Sandbox)"
+        assert t.annotations is not None
+        assert t.annotations.destructiveHint is True
+
+    def test_all_tools_have_title_and_annotations(self, server: CheckMCP) -> None:
+        tools = self._tools_by_name(server)
+        # Every Check API tool should have a derived title and annotations
+        # with openWorldHint=False (closed-world API).
+        missing = [name for name, t in tools.items() if not t.title]
+        assert not missing, f"tools missing titles: {missing[:5]}"
+        for name, t in tools.items():
+            assert t.annotations is not None, f"{name} missing annotations"
+            assert t.annotations.openWorldHint is False, name


### PR DESCRIPTION
## Why

We're applying to list this server in the [Anthropic MCP Directory](https://www.notion.so/checkhq/Claude-Office-MCP-Application-3574274a2e7580689332c78eb1b237d9). The submission form has a hard requirement under "Tool Titles & Annotations":

> All servers must specify accurate tool titles & annotations (readOnlyHint, etc.)
> - I've specified user-friendly titles for all tools in my server
> - I've specified accurate tool annotations for all tools in my server

Today we don't — `mcp.add_tool(fn)` is called without `title=` or `annotations=`, so titles fall back to snake_case function names and clients have no signal about which tools are read-only vs. destructive. That's a blocker for the directory listing and also degrades client UX (e.g. Claude.ai can't surface confirmation prompts for destructive calls based on the standard MCP hint).

## What

- Adds user-friendly `title` strings and `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint=False`) to every tool the server exposes.
- New centralised classifier in `src/mcp_server_check/annotations.py` (`derive_title`, `derive_annotations`, `add_annotated_tool`) — sources read-only / destructive classification from `tool_filter.is_write_tool` / `is_destructive_tool` so there is a single source of truth.
- All 18 `tools/*.py` modules switched from `mcp.add_tool(fn)` to `add_annotated_tool(mcp, fn)`. The 3 dynamic-mode meta-tools (`search_tools`, `list_toolsets`, `run_tool`) carry annotations too.

## Coverage

- 227 Check API tools + 3 meta-tools, all with titles and annotations
- 132 read-only, 21 destructive, the rest non-destructive mutating
- Acronyms preserved in titles: SSN, EIN, W-2, ACH, etc.
- `simulate_*` tools get a "(Sandbox)" suffix and `destructiveHint=True`

## Test plan

- [x] `uv run pytest` — 458 passed (31 new in `tests/test_annotations.py`)
- [x] `uv run ruff format` / `uv run ruff check` — clean
- [ ] Inspect a representative tool listing in MCP Inspector / Claude Desktop to confirm titles render

🤖 Generated with [Claude Code](https://claude.com/claude-code)