### PR TITLE
Migrate MCP tax filing tools to new /filings API

### DIFF
--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -61,7 +61,8 @@ _WRITE_KEYWORDS = (
     "toggle_",
     "sync_",
     "upload_",
-    "request_tax_",
+    "add_",
+    "remove_",
 )
 
 # Tools that trigger irreversible real-world effects (money movement, deletion).

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -367,63 +367,85 @@ async def update_employee_tax_elections(ctx: Ctx, employee_id: str, data: dict) 
     )
 
 
-# --- Tax Filings ---
+# --- Filings ---
 
 
-async def list_tax_filings(
+async def list_filings(
     ctx: Ctx,
     company: str | None = None,
     limit: int | None = None,
     cursor: str | None = None,
     year: int | None = None,
     period: str | None = None,
+    status: str | None = None,
 ) -> dict:
-    """List tax filings, optionally filtered by company.
+    """List filings, optionally filtered by company.
+
+    Returns filing history and expected upcoming filings. Each filing includes
+    its current status, status_history, blocked_reasons, and amendment
+    relationships.
 
     Args:
-        company: Filter to tax filings belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
+        company: Filter to filings belonging to this Check company ID (e.g. "com_xxxxx").
+        limit: Maximum number of results to return (1-500, default 25).
         cursor: Pagination cursor.
         year: Filter by tax year.
-        period: Filter by filing period.
+        period: Filter by filing period (e.g. "annual", "q1", "q2", "q3", "q4", "january", etc.).
+        status: Filter by filing status ("pending", "blocked", "submitted", "filed", or "inapplicable").
     """
     return await check_api_list(
         ctx,
-        "/tax_filings",
+        "/filings",
         params=build_params(
-            company=company, limit=limit, cursor=cursor, year=year, period=period
+            company=company,
+            limit=limit,
+            cursor=cursor,
+            year=year,
+            period=period,
+            status=status,
         ),
     )
 
 
-async def get_tax_filing(ctx: Ctx, tax_filing_id: str) -> dict:
-    """Get details for a specific tax filing.
+async def get_filing(ctx: Ctx, filing_id: str) -> dict:
+    """Get details for a specific filing.
+
+    Returns the full filing object including status, status_history,
+    blocked_reasons, document, and amendment relationships (amends/amended_by).
 
     Args:
-        tax_filing_id: The Check tax filing ID.
+        filing_id: The Check filing ID (prefixed with "com_fil_").
     """
-    return await check_api_get(ctx, f"/tax_filings/{tax_filing_id}")
+    return await check_api_get(ctx, f"/filings/{filing_id}")
 
 
-async def request_tax_filing_refile(ctx: Ctx, tax_filing_id: str) -> dict:
-    """Request a refile for a tax filing.
+async def add_filing_blockers(ctx: Ctx, filing_id: str, data: dict) -> dict:
+    """Add blockers to a filing.
+
+    In production, you can add the "held_by_customer" blocker to any filing
+    with a pending status. This communicates that the employer is not ready
+    for this filing to be filed with the agency.
 
     Args:
-        tax_filing_id: The Check tax filing ID.
+        filing_id: The Check filing ID (prefixed with "com_fil_").
+        data: Request body with blocked_reasons to add (e.g. {"blocked_reasons": ["held_by_customer"]}).
     """
-    return await check_api_post(ctx, f"/tax_filings/{tax_filing_id}/request_refile")
+    return await check_api_post(ctx, f"/filings/{filing_id}/add_blockers", data=data)
 
 
-# --- Tax Filing Events ---
+async def remove_filing_blockers(ctx: Ctx, filing_id: str, data: dict) -> dict:
+    """Remove blockers from a filing.
 
-
-async def get_tax_filing_event(ctx: Ctx, event_id: str) -> dict:
-    """Get a specific tax filing event.
+    Removes eligible blockers from a filing. In production, you can remove
+    the "held_by_customer" blocker.
 
     Args:
-        event_id: The tax filing event ID.
+        filing_id: The Check filing ID (prefixed with "com_fil_").
+        data: Request body with blocked_reasons to remove (e.g. {"blocked_reasons": ["held_by_customer"]}).
     """
-    return await check_api_get(ctx, f"/tax_filing_events/{event_id}")
+    return await check_api_post(
+        ctx, f"/filings/{filing_id}/remove_blockers", data=data
+    )
 
 
 # --- Exempt Status ---
@@ -581,11 +603,9 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     add_annotated_tool(mcp, list_company_tax_elections)
     # Employee Tax Elections
     add_annotated_tool(mcp, list_employee_tax_elections)
-    # Tax Filings
-    add_annotated_tool(mcp, list_tax_filings)
-    add_annotated_tool(mcp, get_tax_filing)
-    # Tax Filing Events
-    add_annotated_tool(mcp, get_tax_filing_event)
+    # Filings
+    add_annotated_tool(mcp, list_filings)
+    add_annotated_tool(mcp, get_filing)
     # Exempt Status
     add_annotated_tool(mcp, get_exempt_status)
     # Exemptible Taxes
@@ -602,7 +622,8 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
         add_annotated_tool(mcp, create_company_tax_elections)
         add_annotated_tool(mcp, update_company_tax_elections)
         add_annotated_tool(mcp, update_employee_tax_elections)
-        add_annotated_tool(mcp, request_tax_filing_refile)
+        add_annotated_tool(mcp, add_filing_blockers)
+        add_annotated_tool(mcp, remove_filing_blockers)
         add_annotated_tool(mcp, update_exempt_status)
         add_annotated_tool(mcp, update_exemptible_tax)
         add_annotated_tool(mcp, bulk_update_exemptible_taxes)

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -443,9 +443,7 @@ async def remove_filing_blockers(ctx: Ctx, filing_id: str, data: dict) -> dict:
         filing_id: The Check filing ID (prefixed with "com_fil_").
         data: Request body with blocked_reasons to remove (e.g. {"blocked_reasons": ["held_by_customer"]}).
     """
-    return await check_api_post(
-        ctx, f"/filings/{filing_id}/remove_blockers", data=data
-    )
+    return await check_api_post(ctx, f"/filings/{filing_id}/remove_blockers", data=data)
 
 
 # --- Exempt Status ---

--- a/src/mcp_server_check/tools/workflows.py
+++ b/src/mcp_server_check/tools/workflows.py
@@ -247,9 +247,9 @@ async def get_company_tax_overview(
             f"/companies/{company_id}/tax_elections",
         )
     if include_filings:
-        calls["tax_filings"] = check_api_list(
+        calls["filings"] = check_api_list(
             ctx,
-            "/tax_filings",
+            "/filings",
             params={"company": company_id, "limit": filing_limit},
         )
 

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -7,13 +7,13 @@ import pytest
 
 from mcp_server_check.tools.tax import (
     get_company_tax_params,
-    get_tax_filing,
+    get_filing,
     list_company_tax_elections,
     list_company_tax_param_settings,
     list_employee_tax_param_settings,
     list_employee_tax_params,
     list_employee_tax_statements,
-    list_tax_filings,
+    list_filings,
     update_company_tax_params,
 )
 
@@ -63,15 +63,19 @@ async def test_list_company_tax_elections(mock_api, ctx):
 
 
 @pytest.mark.anyio
-async def test_list_tax_filings(mock_api, ctx):
-    mock_api.get("/tax_filings").mock(
+async def test_list_filings(mock_api, ctx):
+    mock_api.get("/filings").mock(
         return_value=httpx.Response(
             200,
-            json={"next": None, "previous": None, "results": [{"id": "tf_001"}]},
+            json={
+                "next": None,
+                "previous": None,
+                "results": [{"id": "com_fil_001"}],
+            },
         )
     )
-    result = await list_tax_filings(ctx)
-    assert result["results"] == [{"id": "tf_001"}]
+    result = await list_filings(ctx)
+    assert result["results"] == [{"id": "com_fil_001"}]
 
 
 @pytest.mark.anyio
@@ -128,19 +132,26 @@ async def test_list_employee_tax_param_settings_with_filters(mock_api, ctx):
 
 
 @pytest.mark.anyio
-async def test_list_tax_filings_with_filters(mock_api, ctx):
-    mock_api.get("/tax_filings").mock(
+async def test_list_filings_with_filters(mock_api, ctx):
+    mock_api.get("/filings").mock(
         return_value=httpx.Response(
             200,
-            json={"next": None, "previous": None, "results": [{"id": "tf_001"}]},
+            json={
+                "next": None,
+                "previous": None,
+                "results": [{"id": "com_fil_001"}],
+            },
         )
     )
-    result = await list_tax_filings(ctx, company="com_123", year=2025, period="Q1")
-    assert result["results"] == [{"id": "tf_001"}]
-    req = mock_api.get("/tax_filings").calls.last.request
+    result = await list_filings(
+        ctx, company="com_123", year=2025, period="q1", status="blocked"
+    )
+    assert result["results"] == [{"id": "com_fil_001"}]
+    req = mock_api.get("/filings").calls.last.request
     assert req.url.params["company"] == "com_123"
     assert req.url.params["year"] == "2025"
-    assert req.url.params["period"] == "Q1"
+    assert req.url.params["period"] == "q1"
+    assert req.url.params["status"] == "blocked"
 
 
 @pytest.mark.anyio
@@ -162,9 +173,9 @@ async def test_list_employee_tax_statements_with_filters(mock_api, ctx):
 
 
 @pytest.mark.anyio
-async def test_get_tax_filing(mock_api, ctx):
-    mock_api.get("/tax_filings/tf_001").mock(
-        return_value=httpx.Response(200, json={"id": "tf_001"})
+async def test_get_filing(mock_api, ctx):
+    mock_api.get("/filings/com_fil_001").mock(
+        return_value=httpx.Response(200, json={"id": "com_fil_001"})
     )
-    result = await get_tax_filing(ctx, tax_filing_id="tf_001")
-    assert result["id"] == "tf_001"
+    result = await get_filing(ctx, filing_id="com_fil_001")
+    assert result["id"] == "com_fil_001"

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -43,7 +43,8 @@ class TestIsWriteTool:
             "toggle_accounting_mappings",
             "sync_accounting",
             "upload_company_provided_document_file",
-            "request_tax_filing_refile",
+            "add_filing_blockers",
+            "remove_filing_blockers",
         ],
     )
     def test_write_tools_detected(self, name):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -221,7 +221,7 @@ async def test_get_company_tax_overview(mock_api, ctx):
     mock_api.get("/companies/com_001/tax_elections").mock(
         return_value=httpx.Response(200, json=_list_response([{"id": "ele_001"}]))
     )
-    mock_api.get("/tax_filings").mock(
+    mock_api.get("/filings").mock(
         return_value=httpx.Response(
             200, json=_list_response([{"id": "fil_001", "status": "filed"}])
         )
@@ -231,7 +231,7 @@ async def test_get_company_tax_overview(mock_api, ctx):
 
     assert result["tax_params"]["id"] == "com_001"
     assert result["tax_elections"]["results"][0]["id"] == "ele_001"
-    assert result["tax_filings"]["results"][0]["id"] == "fil_001"
+    assert result["filings"]["results"][0]["id"] == "fil_001"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Replaces legacy `/tax_filings` and `/tax_filing_events` endpoints with the new `/filings` API per the [migration guide](https://docs.checkhq.com/docs/migrating-from-the-legacy-tax-filings-api)
- Adds `add_filing_blockers` and `remove_filing_blockers` tools for the new blocker management endpoints
- Adds `status` filter parameter to `list_filings`
- Updates `get_company_tax_overview` workflow to use `/filings`

## Test plan
- [x] All 460 existing tests pass
- [ ] Verify `list_filings` returns results from `/filings` endpoint in sandbox
- [ ] Verify `get_filing` retrieves a single filing by `com_fil_*` ID
- [ ] Verify `add_filing_blockers` / `remove_filing_blockers` work in sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)