### PR TITLE
Add company, employee, and contractor search tools

### DIFF
--- a/src/mcp_server_check/tool_index.py
+++ b/src/mcp_server_check/tool_index.py
@@ -27,7 +27,7 @@ _SYNONYM_GROUPS: list[set[str]] = [
     {"create", "add", "new", "setup", "set"},
     {"delete", "remove", "destroy"},
     {"update", "edit", "modify", "change", "patch"},
-    {"list", "index", "all", "browse"},
+    {"list", "index", "all", "browse", "search", "find"},
     {"get", "show", "view", "read", "fetch", "retrieve", "detail", "details"},
     {"payment", "disbursement", "deposit", "transfer"},
     {"tax", "withholding", "filing", "w2", "w4"},

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -49,6 +49,29 @@ async def list_companies(
     )
 
 
+async def search_companies(
+    ctx: Ctx,
+    term: str,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict:
+    """Search companies by name.
+
+    Searches across legal name, trade name, and company ID using
+    case-insensitive matching.
+
+    Args:
+        term: Search term to match against company legal name, trade name, or ID.
+        limit: Maximum number of results to return.
+        cursor: Pagination cursor from a previous response.
+    """
+    return await check_api_list(
+        ctx,
+        "/companies/search",
+        params=build_params(term=term, limit=limit, cursor=cursor),
+    )
+
+
 async def get_company(ctx: Ctx, company_id: str) -> dict:
     """Get details for a specific company.
 
@@ -609,6 +632,7 @@ async def request_embedded_setup(ctx: Ctx, company_id: str) -> dict:
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     add_annotated_tool(mcp, list_companies)
+    add_annotated_tool(mcp, search_companies)
     add_annotated_tool(mcp, get_company)
     add_annotated_tool(mcp, get_company_paydays)
     add_annotated_tool(mcp, list_company_tax_deposits)

--- a/src/mcp_server_check/tools/contractors.py
+++ b/src/mcp_server_check/tools/contractors.py
@@ -39,6 +39,30 @@ async def list_contractors(
     )
 
 
+async def search_contractors(
+    ctx: Ctx,
+    term: str,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict:
+    """Search contractors by name.
+
+    Splits the search term by spaces and matches each word against first name,
+    middle name, last name, business name, or contractor ID using
+    case-insensitive matching. All terms must match (AND logic).
+
+    Args:
+        term: Search term to match against contractor name fields or ID.
+        limit: Maximum number of results to return.
+        cursor: Pagination cursor from a previous response.
+    """
+    return await check_api_list(
+        ctx,
+        "/contractors/search",
+        params=build_params(term=term, limit=limit, cursor=cursor),
+    )
+
+
 async def get_contractor(ctx: Ctx, contractor_id: str) -> dict:
     """Get details for a specific contractor.
 
@@ -277,6 +301,7 @@ async def submit_contractor_form(
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     add_annotated_tool(mcp, list_contractors)
+    add_annotated_tool(mcp, search_contractors)
     add_annotated_tool(mcp, get_contractor)
     add_annotated_tool(mcp, list_contractor_payments_for_contractor)
     add_annotated_tool(mcp, get_contractor_payment_for_payroll)

--- a/src/mcp_server_check/tools/employees.py
+++ b/src/mcp_server_check/tools/employees.py
@@ -50,6 +50,30 @@ async def list_employees(
     )
 
 
+async def search_employees(
+    ctx: Ctx,
+    term: str,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict:
+    """Search employees by name.
+
+    Splits the search term by spaces and matches each word against first name,
+    middle name, last name, or employee ID using case-insensitive matching.
+    All terms must match (AND logic).
+
+    Args:
+        term: Search term to match against employee name fields or ID.
+        limit: Maximum number of results to return.
+        cursor: Pagination cursor from a previous response.
+    """
+    return await check_api_list(
+        ctx,
+        "/employees/search",
+        params=build_params(term=term, limit=limit, cursor=cursor),
+    )
+
+
 async def get_employee(ctx: Ctx, employee_id: str) -> dict:
     """Get details for a specific employee.
 
@@ -392,6 +416,7 @@ async def authorize_employee_partner(
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     add_annotated_tool(mcp, list_employees)
+    add_annotated_tool(mcp, search_employees)
     add_annotated_tool(mcp, get_employee)
     add_annotated_tool(mcp, list_employee_paystubs)
     add_annotated_tool(mcp, get_employee_paystub)


### PR DESCRIPTION
## Summary
- Add `search_companies`, `search_employees`, and `search_contractors` MCP tools that use the Check API `/search` endpoints to find entities by name with case-insensitive matching
- Register all three as read-only tools alongside existing list tools
- Add "search" and "find" to the synonym group in `tool_index.py` so these tools are discoverable via the `search_tools` meta-tool

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 460 existing tests pass
- [ ] Manual smoke test: start the MCP server and use `search_tools` to search for "search companies" — should surface the new `search_companies` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)