### PR TITLE
Fix usage endpoint paths causing 302 redirects

### DIFF
--- a/src/mcp_server_check/tools/platform.py
+++ b/src/mcp_server_check/tools/platform.py
@@ -165,7 +165,7 @@ async def list_usage_summaries(
     """
     return await check_api_list(
         ctx,
-        "/usage_summaries",
+        "/usage/summaries",
         params=build_params(
             limit=limit,
             cursor=cursor,
@@ -200,7 +200,7 @@ async def list_usage_records(
     """
     return await check_api_list(
         ctx,
-        "/usage_records",
+        "/usage/records",
         params=build_params(
             limit=limit,
             cursor=cursor,

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -93,7 +93,7 @@ async def test_create_communication(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_usage_summaries(mock_api, ctx):
-    mock_api.get("/usage_summaries").mock(
+    mock_api.get("/usage/summaries").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "us_001"}]},
@@ -105,7 +105,7 @@ async def test_list_usage_summaries(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_usage_summaries_with_filters(mock_api, ctx):
-    mock_api.get("/usage_summaries").mock(
+    mock_api.get("/usage/summaries").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "us_001"}]},
@@ -115,7 +115,7 @@ async def test_list_usage_summaries_with_filters(mock_api, ctx):
         ctx, company="com_123", category="payroll", period_start="2026-01-01"
     )
     assert result["results"] == [{"id": "us_001"}]
-    req = mock_api.get("/usage_summaries").calls.last.request
+    req = mock_api.get("/usage/summaries").calls.last.request
     assert req.url.params["company"] == "com_123"
     assert req.url.params["category"] == "payroll"
     assert req.url.params["period_start"] == "2026-01-01"
@@ -124,7 +124,7 @@ async def test_list_usage_summaries_with_filters(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_usage_records_with_filters(mock_api, ctx):
-    mock_api.get("/usage_records").mock(
+    mock_api.get("/usage/records").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "ur_001"}]},
@@ -134,7 +134,7 @@ async def test_list_usage_records_with_filters(mock_api, ctx):
         ctx, company="com_123", resource_type="employee", period_start="2026-01-01"
     )
     assert result["results"] == [{"id": "ur_001"}]
-    req = mock_api.get("/usage_records").calls.last.request
+    req = mock_api.get("/usage/records").calls.last.request
     assert req.url.params["company"] == "com_123"
     assert req.url.params["resource_type"] == "employee"
     assert req.url.params["period_start"] == "2026-01-01"


### PR DESCRIPTION
## Summary
- Fix `list_usage_records` and `list_usage_summaries` endpoint paths from `/usage_records` and `/usage_summaries` (underscores) to `/usage/records` and `/usage/summaries` (slashes)
- The incorrect paths caused the Check API to return 302 redirects, making both tools unusable
- Reported by a user in #hb-check-mcp-feedback who was trying to pull refiling fee data via `category=refile_attempt`

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 460 tests pass (test mocks updated to match corrected paths)
- [ ] Manual smoke test: call `list_usage_records` with `category=refile_attempt` and confirm it returns data instead of a 302

🤖 Generated with [Claude Code](https://claude.com/claude-code)