### PR TITLE
Add blocked-filings-dashboard skill + fix filing list summarization

### DIFF
--- a/example-skills/README.md
+++ b/example-skills/README.md
@@ -8,6 +8,7 @@ Each skill is a self-contained directory with a `SKILL.md` file and optional `re
 
 | Skill | Description |
 |---|---|
+| [blocked-filings-dashboard](./blocked-filings-dashboard/) | Generate a partner-shareable HTML dashboard of blocked tax filings for a quarter. Shows an expected filing success rate, what-if projections per blocker, KPI cards, charts, and a sortable/filterable table of every blocked filing and its blocker reasons. |
 | [payroll-audit-report](./payroll-audit-report/) | Generate a comprehensive audit report for a company's payrolls over a date range. Summarizes totals by pay period, breaks down earnings/taxes/deductions, and flags anomalies. |
 | [prior-provider-worker-migration](./prior-provider-worker-migration/) | Import employees and contractors into Check from a prior payroll provider's worker report (CSV, XLS, XLSX, or PDF). Parses the report, creates workplaces and workers via the API, and verifies every record against the source data. |
 | [worker-census-report](./worker-census-report/) | Export a complete census of all employees and contractors for a company with full details including addresses, SSN last 4, start dates, workplace assignments, and active/terminated status. |

--- a/example-skills/blocked-filings-dashboard/SKILL.md
+++ b/example-skills/blocked-filings-dashboard/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: blocked-filings-dashboard
+model: claude-opus-4-6
+description: >
+  Generate a partner-shareable HTML dashboard of blocked tax filings for a quarter,
+  using the Check MCP filings API. Shows an expected filing success rate, what-if
+  projections per blocker, KPI cards, charts, and a sortable/filterable table of every
+  blocked filing with its blocker reasons. Use this skill when someone asks for a blocked
+  filings dashboard, a filing blocker report, a quarterly blockers summary, or wants to
+  see which filings are blocked and why for a partner.
+---
+
+# Blocked Filings Dashboard
+
+This skill builds a self-contained HTML dashboard of a partner's **blocked** tax filings
+for a given quarter. It pulls live data through the Check MCP filings API and writes a
+partner-shareable report to the Desktop.
+
+The Check MCP API key is already scoped to a **single partner**, so there is no partner
+name or UUID to look up — every filing the API returns belongs to that partner.
+
+## What this dashboard does and does not show
+
+The public filings API exposes each filing's `status` and `blocked_reasons`, but **not**
+operator-written issue notes or the internal/external issue split. Accordingly this
+dashboard:
+
+- **Has no "Notes" column** (the API does not return operator notes).
+- Shows **all** blocker reasons the API reports — there is no internal-issue filtering to
+  apply, because the API only returns externally-visible blockers.
+
+Mention these omissions briefly when you present the report so the audience knows it is
+API-sourced.
+
+## Step 0: Parse Inputs
+
+Collect a **quarter** and **year** (e.g. "Q2 2026" or `q2 2026`). If not provided, ask.
+
+Derive:
+
+- `period` — the quarter lowercased: `q1`, `q2`, `q3`, or `q4` (the `period` filter value
+  the API expects).
+- `period_start` / `period_end` — the calendar bounds of the quarter, used for labels and
+  the "First QE" window:
+  - Q1 = Jan 1 – Mar 31, Q2 = Apr 1 – Jun 30, Q3 = Jul 1 – Sep 30, Q4 = Oct 1 – Dec 31.
+- `year` — integer (e.g. `2026`).
+
+## Step 1: Pull Blocked Filings
+
+Fetch every blocked filing for the quarter:
+
+```
+run_tool: list_filings { "status": "blocked", "year": <year>, "period": "<period>", "limit": 500 }
+```
+
+Paginate: if the response has a non-null `next_cursor`, repeat with
+`"cursor": "<next_cursor>"` until it is null. Accumulate all results.
+
+Each filing record includes `id`, `company` (a `com_...` company ID), `status`,
+`blocked_reasons` (an array of blocker reason strings), `period`, `year`, and `name`.
+
+If zero blocked filings are returned, tell the user there are none for that quarter and
+stop.
+
+## Step 2: Pull Status Counts for the Success-Rate Denominator
+
+To compute the success rate you need the total **applicable** filing count, not just the
+blocked ones. Sweep all filings for the quarter and bucket by `status`:
+
+```
+run_tool: list_filings { "year": <year>, "period": "<period>", "limit": 500 }
+```
+
+Paginate as in Step 1. Then count filings per `status`.
+
+- `total_applicable` = count of all filings whose status is **not** `inapplicable`.
+- Statuses you may see: `pending`, `blocked`, `submitted`, `filed`, `inapplicable`.
+
+If this sweep returns a large number of filings, give the user a progress note while
+paginating.
+
+## Step 3: Enrich Companies (legal name + First QE)
+
+Collect the **unique** `company` IDs from the blocked filings. For each one, fetch the
+company to get its legal name and start date:
+
+```
+run_tool: get_company { "company_id": "<com_...>" }
+```
+
+Use `get_company` (not `list_companies`) — the company list view omits `start_date`.
+
+Read `legal_name` and `start_date`. A company is **First QE** (this is their first
+quarter-end on Check) when `start_date` falls within `[period_start, period_end]`.
+
+Cache results by company ID so you only fetch each company once. Give progress updates for
+large sets (e.g. "Fetched company details 12/40...").
+
+## Step 4: Build the HTML Dashboard
+
+Write a Python script that generates one self-contained HTML file and saves it to
+`~/Desktop/<partner_slug>_<period>_<year>_blocked_filings_report.html`, then open it with
+`open`. There is no partner name input — derive `<partner_slug>` from the data (e.g. the
+most common company name root) or use `partner`; let the user override the filename.
+
+### Dashboard specifications
+
+**Title:** "<Q#> <Year> Blocked Filings"
+**Subtitle:** "<Q#> period <period_start> to <period_end> · Snapshot as of {today's date} ·
+**First QE** = company start date <period_start> – <period_end> (this is their first
+quarter-end on Check)"
+
+**Theme:** Light:
+- Background `#f7f8fa`, Cards `#fff`, Border `#e5e7eb`, Text `#1c2024`, Muted `#6b7280`
+- Font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif
+
+**Hero — Expected Filing Success Rate** (top of page, above KPI cards):
+- Large percentage = `1 - (blocked_count / total_applicable)`, one decimal place.
+- Label: "Expected Filing Success Rate"
+- Subtitle: "Based on {blocked_count} blocked out of {total_applicable} applicable filings"
+- 48px bold percentage, 16px label/subtitle, centered, accent color by rate:
+  - ≥ 95%: green `#16a34a` · 90–94.9%: `#65a30d` · 80–89.9%: amber `#d97706` · < 80%: red `#dc2626`
+
+**What-If Projections** (below the hero, above KPI cards): for each blocker reason present,
+compute the success rate if **all filings whose sole blocker is that reason** were
+unblocked. A filing with multiple blockers stays blocked (conservative projection). Render
+as a flex-wrap row of ~180px cards sorted by highest projected rate first, each showing:
+- Human-readable blocker name (e.g. "Applied-for Tax ID")
+- Projected rate (e.g. "→ 93.1%")
+- Count of blocked filings with that reason (e.g. "42 filings")
+- Colored left border using the blocker color below.
+
+**KPI Cards (5):**
+1. <Q#> Applicable Filings — `total_applicable`
+2. Blocked — count from Step 1
+3. Companies Affected — unique company count from Step 1
+4. First QE — Blocked — blocked filings where the company is First QE (with company count + block rate in a context line)
+5. Not First QE — Blocked — the complement (with company count + block rate)
+
+**Charts (side by side, Chart.js 4.4.0 from CDN):**
+- Left: "Blocker reasons" — vertical stacked bar, split First QE (teal `#0d9488`) vs Not First QE (blue `#1976d2`).
+- Right: "Most affected companies" — horizontal bar, top 15 companies, colored by First QE (teal) vs Not (blue).
+
+**Blocker colors:**
+```
+applied_for_tax_id: #ff6f61
+invalid_tax_id: #c62828
+tpa_failure: #8e24aa
+inactive_account: #5e35b1
+already_filed: #fdd835
+not_liable: #7cb342
+filing_configuration_incomplete: #546e7a
+awaiting_tax_funds: #00695c
+incorrect_account_setup: #fb8c00
+company_bad_standing: #3949ab
+missing_tax_funds: #ef6c00
+invalid_ssn: #6d4c41
+correction_needed: #8d6e63
+missing_historical_data: #795548
+held_by_customer: #a1887f
+poa_failure: #d84315
+```
+For any blocker reason not in this map, fall back to a neutral gray (`#6b7280`).
+
+**Table: "<Q#> <Year> Blocked Filings"** with a row-count badge. Columns (no Status column —
+every row is blocked):
+1. Company (`legal_name`, sortable)
+2. Company ID (`company`, monospace, sortable)
+3. Filing (`name`, sortable)
+4. Blocker Reasons (tags colored from the palette, clickable to set the blocker filter)
+5. First QE (green "First QE" tag when true, sortable)
+6. Start Date (`start_date`, sortable)
+
+**Blocker tag styling:** solid background at 15% opacity of the blocker color.
+
+**Filters (one line):**
+- Search input — searches company name, company ID, and filing name.
+- Blocker reason dropdown — single-select, default "All blocker reasons", no counts.
+- First QE dropdown — "All companies" / "First QE only" / "Not First QE only", no counts.
+
+**Features:**
+- All columns sortable by clicking headers.
+- CSV export of the filtered rows: Company, Company ID, Filing, Blocker Reasons, Blocker Count, First QE, Start Date.
+- Blocker tags have hover tooltips (descriptions below) and click to set the blocker filter.
+- Footer: "<Q#> <Year> Blocked Filings — Snapshot {date} · Sourced from the Check filings API"
+
+**Blocker tooltip descriptions:**
+```
+applied_for_tax_id: "Company has applied for a tax ID with the agency but has not received it yet. Filing will proceed once the ID is issued."
+invalid_tax_id: "The tax ID on file was rejected by the agency or does not match their records."
+tpa_failure: "Third-party authorization was rejected or has expired. A new authorization needs to be submitted to the agency."
+already_filed: "This filing appears to have already been submitted, possibly filed directly with the agency."
+filing_configuration_incomplete: "Setup for this filing type is not yet complete."
+inactive_account: "Tax account appears to be inactive with the agency."
+not_liable: "Company does not appear to be liable for this tax in this jurisdiction."
+company_bad_standing: "Account is not in good standing with the tax agency."
+awaiting_tax_funds: "Waiting for sufficient funds to be available."
+incorrect_account_setup: "Configuration issue with this account that needs correction."
+held_by_customer: "A hold has been placed on this filing at the customer's request."
+missing_tax_funds: "Insufficient tax funds available for this filing period."
+invalid_ssn: "An employee SSN issue is preventing this filing."
+correction_needed: "Filing data needs a correction before submission."
+missing_historical_data: "Prior period data needed but currently unavailable."
+poa_failure: "Power of Attorney not accepted or rejected by the agency."
+```
+
+## Step 5: Output
+
+Save the HTML to `~/Desktop/<partner_slug>_<period>_<year>_blocked_filings_report.html`,
+open it, and report the total blocked filings count and number of companies affected.
+Remind the user this is sourced from the filings API and therefore omits operator notes.
+
+## Error Handling
+
+- **API error envelopes**: list/get tools may return `{"error": true, "status_code": ...,
+  "detail": ...}`. Surface the `detail`, skip the affected record, and continue; note any
+  companies whose details could not be fetched.
+- **Pagination**: always follow `next_cursor` until null on both list sweeps.
+- **No blocked filings**: report that the quarter is clean and stop before building HTML.
+- **Missing company fields**: if `start_date` is absent for a company, treat it as Not
+  First QE and note it.

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -72,7 +72,15 @@ _SUMMARY_FIELDS: dict[str, Sequence[str]] = {
     # Filings are prefixed "com_fil_". This entry must be matched before the
     # bare "com_" company entry — see _detect_entity_prefix for the longest-
     # prefix logic that makes that happen.
-    "com_fil_": ("id", "company", "status", "period", "year", "name", "blocked_reasons"),
+    "com_fil_": (
+        "id",
+        "company",
+        "status",
+        "period",
+        "year",
+        "name",
+        "blocked_reasons",
+    ),
 }
 
 

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -69,17 +69,29 @@ _SUMMARY_FIELDS: dict[str, Sequence[str]] = {
     ),
     "nps_": ("id", "employee", "contractor", "is_default"),
     "psc_": ("id", "name", "pay_frequency", "company"),
+    # Filings are prefixed "com_fil_". This entry must be matched before the
+    # bare "com_" company entry — see _detect_entity_prefix for the longest-
+    # prefix logic that makes that happen.
+    "com_fil_": ("id", "company", "status", "period", "year", "name", "blocked_reasons"),
 }
 
 
 def _detect_entity_prefix(results: list[dict]) -> str | None:
-    """Detect the entity type prefix from the first result's ID."""
+    """Detect the entity type prefix from the first result's ID.
+
+    Returns the longest known ``_SUMMARY_FIELDS`` prefix that the ID starts
+    with. Matching longest-first is essential for multi-segment prefixes like
+    ``com_fil_`` (filings), which would otherwise collide with ``com_``
+    (companies) and get summarized with the wrong field set.
+    """
     if not results:
         return None
     first_id = results[0].get("id", "")
-    if isinstance(first_id, str) and "_" in first_id:
-        prefix = first_id.split("_")[0] + "_"
-        return prefix
+    if not isinstance(first_id, str):
+        return None
+    for prefix in sorted(_SUMMARY_FIELDS, key=len, reverse=True):
+        if first_id.startswith(prefix):
+            return prefix
     return None
 
 

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -79,6 +79,30 @@ async def test_list_filings(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_filings_preserves_filing_fields(mock_api, ctx):
+    # Filing IDs ("com_fil_...") must not be summarized with the company field
+    # set, which would strip status/blocked_reasons/company. The longest-prefix
+    # match in _detect_entity_prefix keeps the filing-specific fields.
+    filing = {
+        "id": "com_fil_001",
+        "company": "com_123",
+        "status": "blocked",
+        "period": "q1",
+        "year": 2025,
+        "name": "CA DE 9 Q1 2025",
+        "blocked_reasons": ["applied_for_tax_id"],
+    }
+    mock_api.get("/filings").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [filing]},
+        )
+    )
+    result = await list_filings(ctx)
+    assert result["results"] == [filing]
+
+
+@pytest.mark.anyio
 async def test_list_employee_tax_params_with_filters(mock_api, ctx):
     mock_api.get("/employee_tax_params").mock(
         return_value=httpx.Response(


### PR DESCRIPTION
## Summary

Adds a new example skill, **`blocked-filings-dashboard`**, that builds a partner-shareable HTML dashboard of blocked tax filings for a quarter — sourced entirely through the Check MCP filings API (no direct DB access). It's the MCP-based counterpart to the DB-query version in `check-support`.

Also fixes a latent bug in list-response summarization that otherwise makes `list_filings` unusable.

## Part 1 — Fix `list_filings` response summarization

Filing IDs are prefixed `com_fil_`. `_detect_entity_prefix` split on the first `_`, yielding `com_`, which collided with the **company** summary-field set in `_SUMMARY_FIELDS`. Filing objects share none of those keys except `id`, so `list_filings` was returning `[{"id": "com_fil_…"}]` — stripping `status`, `blocked_reasons`, `company`, etc.

- Prefix detection now matches the **longest** known `_SUMMARY_FIELDS` prefix (general fix for multi-segment prefixes).
- Added a `com_fil_` entry: `(id, company, status, period, year, name, blocked_reasons)`.
- Added `test_list_filings_preserves_filing_fields` to lock it in.

## Part 2 — `blocked-filings-dashboard` skill

`example-skills/blocked-filings-dashboard/SKILL.md`, modeled on `payroll-audit-report`:

- **No partner lookup** — the MCP API key already scopes to one partner.
- `list_filings { status: blocked, year, period }` → blocked set; an unfiltered sweep → success-rate denominator (`total_applicable` = all but `inapplicable`).
- `get_company` per affected company for `legal_name` + `start_date` (First-QE flag) — `list_companies` drops `start_date`.
- Generates a self-contained HTML dashboard: hero success rate, what-if projections, KPI cards, Chart.js charts, blocker palette + tooltips, sortable/filterable table, CSV export.

**Differences from the DB version** (driven by the public API surface): no Notes column and no internal-issue filtering — the report notes these omissions.

## Test plan

- [x] `uv run pytest tests/ -v` — 461 passed
- [ ] Run `/blocked-filings-dashboard q2 2026` against a live partner MCP and confirm filings/KPIs/charts populate and the HTML opens

> Note: the `com_fil_` summary field names `period`/`year`/`name` are inferred from tool docstrings; `status`/`blocked_reasons`/`company` are well-attested. Worth confirming against one real `get_filing` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
