### PR TITLE
Fix document tool paths to use /documents/ prefix

### DIFF
--- a/src/mcp_server_check/tools/documents.py
+++ b/src/mcp_server_check/tools/documents.py
@@ -37,7 +37,7 @@ async def list_company_tax_documents(
     """
     return await check_api_list(
         ctx,
-        "/company_tax_documents",
+        "/documents/company_tax_documents",
         params=build_params(
             limit=limit, cursor=cursor, company=company, year=year, quarter=quarter
         ),
@@ -50,7 +50,7 @@ async def get_company_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/company_tax_documents/{document_id}")
+    return await check_api_get(ctx, f"/documents/company_tax_documents/{document_id}")
 
 
 async def download_company_tax_document(ctx: Ctx, document_id: str) -> dict:
@@ -59,7 +59,7 @@ async def download_company_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/company_tax_documents/{document_id}/download")
+    return await check_api_get(ctx, f"/documents/company_tax_documents/{document_id}/download")
 
 
 # --- Company Authorization Documents ---
@@ -82,7 +82,7 @@ async def list_company_authorization_documents(
     """
     return await check_api_list(
         ctx,
-        "/company_authorization_documents",
+        "/documents/company_authorization_documents",
         params=build_params(limit=limit, cursor=cursor, company=company, year=year),
     )
 
@@ -93,7 +93,7 @@ async def get_company_authorization_document(ctx: Ctx, document_id: str) -> dict
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/company_authorization_documents/{document_id}")
+    return await check_api_get(ctx, f"/documents/company_authorization_documents/{document_id}")
 
 
 async def download_company_authorization_document(ctx: Ctx, document_id: str) -> dict:
@@ -103,7 +103,7 @@ async def download_company_authorization_document(ctx: Ctx, document_id: str) ->
         document_id: The document ID.
     """
     return await check_api_get(
-        ctx, f"/company_authorization_documents/{document_id}/download"
+        ctx, f"/documents/company_authorization_documents/{document_id}/download"
     )
 
 
@@ -129,7 +129,7 @@ async def list_employee_tax_documents(
     """
     return await check_api_list(
         ctx,
-        "/employee_tax_documents",
+        "/documents/employee_tax_documents",
         params=build_params(
             limit=limit, cursor=cursor, employee=employee, company=company, year=year
         ),
@@ -142,7 +142,7 @@ async def get_employee_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/employee_tax_documents/{document_id}")
+    return await check_api_get(ctx, f"/documents/employee_tax_documents/{document_id}")
 
 
 async def download_employee_tax_document(ctx: Ctx, document_id: str) -> dict:
@@ -151,7 +151,7 @@ async def download_employee_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/employee_tax_documents/{document_id}/download")
+    return await check_api_get(ctx, f"/documents/employee_tax_documents/{document_id}/download")
 
 
 # --- Contractor Tax Documents ---
@@ -176,7 +176,7 @@ async def list_contractor_tax_documents(
     """
     return await check_api_list(
         ctx,
-        "/contractor_tax_documents",
+        "/documents/contractor_tax_documents",
         params=build_params(
             limit=limit,
             cursor=cursor,
@@ -193,7 +193,7 @@ async def get_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/contractor_tax_documents/{document_id}")
+    return await check_api_get(ctx, f"/documents/contractor_tax_documents/{document_id}")
 
 
 async def download_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
@@ -202,7 +202,7 @@ async def download_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/contractor_tax_documents/{document_id}/download")
+    return await check_api_get(ctx, f"/documents/contractor_tax_documents/{document_id}/download")
 
 
 # --- Setup Documents ---
@@ -223,7 +223,7 @@ async def list_setup_documents(
     """
     return await check_api_list(
         ctx,
-        "/setup_documents",
+        "/documents/setup_documents",
         params=build_params(limit=limit, cursor=cursor, company=company),
     )
 
@@ -234,7 +234,7 @@ async def get_setup_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/setup_documents/{document_id}")
+    return await check_api_get(ctx, f"/documents/setup_documents/{document_id}")
 
 
 async def download_setup_document(ctx: Ctx, document_id: str) -> dict:
@@ -243,7 +243,7 @@ async def download_setup_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/setup_documents/{document_id}/download")
+    return await check_api_get(ctx, f"/documents/setup_documents/{document_id}/download")
 
 
 # --- Company Provided Documents ---

--- a/src/mcp_server_check/tools/documents.py
+++ b/src/mcp_server_check/tools/documents.py
@@ -59,7 +59,9 @@ async def download_company_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/documents/company_tax_documents/{document_id}/download")
+    return await check_api_get(
+        ctx, f"/documents/company_tax_documents/{document_id}/download"
+    )
 
 
 # --- Company Authorization Documents ---
@@ -93,7 +95,9 @@ async def get_company_authorization_document(ctx: Ctx, document_id: str) -> dict
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/documents/company_authorization_documents/{document_id}")
+    return await check_api_get(
+        ctx, f"/documents/company_authorization_documents/{document_id}"
+    )
 
 
 async def download_company_authorization_document(ctx: Ctx, document_id: str) -> dict:
@@ -151,7 +155,9 @@ async def download_employee_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/documents/employee_tax_documents/{document_id}/download")
+    return await check_api_get(
+        ctx, f"/documents/employee_tax_documents/{document_id}/download"
+    )
 
 
 # --- Contractor Tax Documents ---
@@ -193,7 +199,9 @@ async def get_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/documents/contractor_tax_documents/{document_id}")
+    return await check_api_get(
+        ctx, f"/documents/contractor_tax_documents/{document_id}"
+    )
 
 
 async def download_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
@@ -202,7 +210,9 @@ async def download_contractor_tax_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/documents/contractor_tax_documents/{document_id}/download")
+    return await check_api_get(
+        ctx, f"/documents/contractor_tax_documents/{document_id}/download"
+    )
 
 
 # --- Setup Documents ---
@@ -243,7 +253,9 @@ async def download_setup_document(ctx: Ctx, document_id: str) -> dict:
     Args:
         document_id: The document ID.
     """
-    return await check_api_get(ctx, f"/documents/setup_documents/{document_id}/download")
+    return await check_api_get(
+        ctx, f"/documents/setup_documents/{document_id}/download"
+    )
 
 
 # --- Company Provided Documents ---

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -19,7 +19,7 @@ from mcp_server_check.tools.documents import (
 
 @pytest.mark.anyio
 async def test_list_company_tax_documents(mock_api, ctx):
-    mock_api.get("/company_tax_documents").mock(
+    mock_api.get("/documents/company_tax_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "ctd_001"}]},
@@ -31,7 +31,7 @@ async def test_list_company_tax_documents(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_get_company_tax_document(mock_api, ctx):
-    mock_api.get("/company_tax_documents/ctd_001").mock(
+    mock_api.get("/documents/company_tax_documents/ctd_001").mock(
         return_value=httpx.Response(200, json={"id": "ctd_001"})
     )
     result = await get_company_tax_document(ctx, document_id="ctd_001")
@@ -40,7 +40,7 @@ async def test_get_company_tax_document(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_employee_tax_documents(mock_api, ctx):
-    mock_api.get("/employee_tax_documents").mock(
+    mock_api.get("/documents/employee_tax_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "etd_001"}]},
@@ -52,7 +52,7 @@ async def test_list_employee_tax_documents(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_setup_documents(mock_api, ctx):
-    mock_api.get("/setup_documents").mock(
+    mock_api.get("/documents/setup_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "sd_001"}]},
@@ -64,7 +64,7 @@ async def test_list_setup_documents(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_company_tax_documents_with_filters(mock_api, ctx):
-    mock_api.get("/company_tax_documents").mock(
+    mock_api.get("/documents/company_tax_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "ctd_001"}]},
@@ -74,7 +74,7 @@ async def test_list_company_tax_documents_with_filters(mock_api, ctx):
         ctx, company="com_123", year=2025, quarter="Q1"
     )
     assert result["results"] == [{"id": "ctd_001"}]
-    req = mock_api.get("/company_tax_documents").calls.last.request
+    req = mock_api.get("/documents/company_tax_documents").calls.last.request
     assert req.url.params["company"] == "com_123"
     assert req.url.params["year"] == "2025"
     assert req.url.params["quarter"] == "Q1"
@@ -82,7 +82,7 @@ async def test_list_company_tax_documents_with_filters(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_company_authorization_documents_with_filters(mock_api, ctx):
-    mock_api.get("/company_authorization_documents").mock(
+    mock_api.get("/documents/company_authorization_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "cad_001"}]},
@@ -92,14 +92,14 @@ async def test_list_company_authorization_documents_with_filters(mock_api, ctx):
         ctx, company="com_123", year=2025
     )
     assert result["results"] == [{"id": "cad_001"}]
-    req = mock_api.get("/company_authorization_documents").calls.last.request
+    req = mock_api.get("/documents/company_authorization_documents").calls.last.request
     assert req.url.params["company"] == "com_123"
     assert req.url.params["year"] == "2025"
 
 
 @pytest.mark.anyio
 async def test_list_employee_tax_documents_with_filters(mock_api, ctx):
-    mock_api.get("/employee_tax_documents").mock(
+    mock_api.get("/documents/employee_tax_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "etd_001"}]},
@@ -109,7 +109,7 @@ async def test_list_employee_tax_documents_with_filters(mock_api, ctx):
         ctx, employee="emp_123", company="com_456", year=2025
     )
     assert result["results"] == [{"id": "etd_001"}]
-    req = mock_api.get("/employee_tax_documents").calls.last.request
+    req = mock_api.get("/documents/employee_tax_documents").calls.last.request
     assert req.url.params["employee"] == "emp_123"
     assert req.url.params["company"] == "com_456"
     assert req.url.params["year"] == "2025"
@@ -117,7 +117,7 @@ async def test_list_employee_tax_documents_with_filters(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_contractor_tax_documents_with_filters(mock_api, ctx):
-    mock_api.get("/contractor_tax_documents").mock(
+    mock_api.get("/documents/contractor_tax_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "ctd_001"}]},
@@ -127,7 +127,7 @@ async def test_list_contractor_tax_documents_with_filters(mock_api, ctx):
         ctx, contractor="ctr_123", company="com_456", year=2025
     )
     assert result["results"] == [{"id": "ctd_001"}]
-    req = mock_api.get("/contractor_tax_documents").calls.last.request
+    req = mock_api.get("/documents/contractor_tax_documents").calls.last.request
     assert req.url.params["contractor"] == "ctr_123"
     assert req.url.params["company"] == "com_456"
     assert req.url.params["year"] == "2025"
@@ -135,7 +135,7 @@ async def test_list_contractor_tax_documents_with_filters(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_setup_documents_with_filters(mock_api, ctx):
-    mock_api.get("/setup_documents").mock(
+    mock_api.get("/documents/setup_documents").mock(
         return_value=httpx.Response(
             200,
             json={"next": None, "previous": None, "results": [{"id": "sd_001"}]},
@@ -143,7 +143,7 @@ async def test_list_setup_documents_with_filters(mock_api, ctx):
     )
     result = await list_setup_documents(ctx, company="com_123")
     assert result["results"] == [{"id": "sd_001"}]
-    req = mock_api.get("/setup_documents").calls.last.request
+    req = mock_api.get("/documents/setup_documents").calls.last.request
     assert req.url.params["company"] == "com_123"
 
 


### PR DESCRIPTION
## Summary

The Check API's document endpoints live under `/documents/*` (e.g. `/documents/company_tax_documents`), but the MCP was calling the legacy unprefixed paths. The API returns a 302 redirect to the new path and the httpx client used by the MCP does not follow redirects, so these tools fail with redirect errors instead of returning data.

This affects:
- `list_company_tax_documents`, `get_company_tax_document`, `download_company_tax_document`
- `list_company_authorization_documents`, `get_company_authorization_document`, `download_company_authorization_document`
- `list_employee_tax_documents`, `get_employee_tax_document`, `download_employee_tax_document`
- `list_contractor_tax_documents`, `get_contractor_tax_document`, `download_contractor_tax_document`
- `list_setup_documents`, `get_setup_document`, `download_setup_document`

`company_provided_documents` is intentionally untouched — it lives at the root and was not moved under `/documents/`.

Caught by AIO (self-hosted MCP partner) reporting 302s on `list_company_tax_documents` and `list_employee_tax_documents` 

