### PR TITLE
feat: add Taxes and Agencies API support (MCP tools + CLI)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,6 +1,6 @@
 # Check CLI
 
-A command-line interface for the [Check Payroll API](https://docs.checkhq.com/). The CLI exposes the same 263 endpoints as the MCP server, organized as resource-oriented commands similar to the [Stripe CLI](https://docs.stripe.com/cli).
+A command-line interface for the [Check Payroll API](https://docs.checkhq.com/). The CLI exposes the same 236 tools as the MCP server, organized as resource-oriented commands similar to the [Stripe CLI](https://docs.stripe.com/cli).
 
 ## Installation
 
@@ -65,7 +65,7 @@ Commands follow a `check <resource> <action>` pattern:
 check <group> <command> [ARGS] [OPTIONS]
 ```
 
-There are 17 resource groups, each with multiple commands:
+There are 20 resource groups, each with multiple commands:
 
 | Group | Examples |
 |---|---|
@@ -75,7 +75,8 @@ There are 17 resource groups, each with multiple commands:
 | `contractors` | `list`, `get`, `create`, `update`, `onboard` |
 | `bank-accounts` | `list`, `get`, `create`, `delete`, `reveal-number` |
 | `compensation` | `list-pay-schedules`, `create-benefit`, `list-earning-codes` |
-| `tax` | `get-company-params`, `list-employee-elections`, `list-filings` |
+| `tax` | `get-company-params`, `list-employee-elections`, `list-filings`, `list-taxes` |
+| `agencies` | `list`, `get` |
 | `payments` | `list`, `get`, `retry`, `refund`, `cancel` |
 | `payroll-items` | `list`, `get`, `create`, `update`, `delete` |
 | `contractor-payments` | `list`, `get`, `create`, `delete` |
@@ -86,6 +87,7 @@ There are 17 resource groups, each with multiple commands:
 | `forms` | `list`, `get`, `render`, `validate` |
 | `logs` | `list`, `get` |
 | `platform` | `list-notifications`, `validate-address`, `sync-accounting` |
+| `workflows` | `get-company-overview`, `get-employee-snapshot`, `diagnose-payment` |
 | `workplaces` | `list`, `get`, `create`, `update` |
 
 Use `check <group> --help` to see all commands in a group.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The server supports fine-grained tool filtering, configurable via environment va
 
 #### Toolsets
 
-There are 19 toolsets, one per API module: `bank_accounts`, `companies`, `compensation`, `components`, `contractor_payments`, `contractors`, `documents`, `employees`, `external_payrolls`, `forms`, `logs`, `payments`, `payroll_items`, `payrolls`, `platform`, `tax`, `webhooks`, `workflows`, `workplaces`.
+There are 20 toolsets, one per API module: `agencies`, `bank_accounts`, `companies`, `compensation`, `components`, `contractor_payments`, `contractors`, `documents`, `employees`, `external_payrolls`, `forms`, `logs`, `payments`, `payroll_items`, `payrolls`, `platform`, `tax`, `webhooks`, `workflows`, `workplaces`.
 
 Enable only specific toolsets:
 
@@ -391,9 +391,9 @@ Pay schedules, benefits, post-tax deductions, company benefits, earning rates, e
 | `refund_payment` | POST | Refund a payment |
 | `cancel_payment` | POST | Cancel a payment |
 
-### Tax (31 tools)
+### Tax (33 tools)
 
-Tax parameters, elections, filings, exempt status, exemptible taxes, statements, and packages.
+Tax parameters, elections, filings, exempt status, exemptible taxes, statements, packages, and tax reference data.
 
 | Tool | Method | Description |
 |---|---|---|
@@ -419,12 +419,11 @@ Tax parameters, elections, filings, exempt status, exemptible taxes, statements,
 | **Employee Tax Elections** | | |
 | `list_employee_tax_elections` | GET | List tax elections for an employee |
 | `update_employee_tax_elections` | PATCH | Update employee tax elections |
-| **Tax Filings** | | |
-| `list_tax_filings` | GET | List tax filings |
-| `get_tax_filing` | GET | Get a specific tax filing |
-| `request_tax_filing_refile` | POST | Request a refile |
-| **Tax Filing Events** | | |
-| `get_tax_filing_event` | GET | Get a specific tax filing event |
+| **Filings** | | |
+| `list_filings` | GET | List tax filings |
+| `get_filing` | GET | Get a specific tax filing |
+| `add_filing_blockers` | POST | Add blockers to a filing |
+| `remove_filing_blockers` | POST | Remove blockers from a filing |
 | **Exempt Status** | | |
 | `get_exempt_status` | GET | Get exempt status for an employee |
 | `update_exempt_status` | PATCH | Update exempt status |
@@ -438,6 +437,18 @@ Tax parameters, elections, filings, exempt status, exemptible taxes, statements,
 | **Tax Packages** | | |
 | `request_tax_package` | POST | Request a tax package |
 | `get_tax_package` | GET | Get a specific tax package |
+| **Taxes (reference data)** | | |
+| `list_taxes` | GET | List tax objects (payroll levies); filter by jurisdiction, payer, supported/remittable, effective status |
+| `get_tax` | GET | Get a specific tax object |
+
+### Agencies (2 tools)
+
+The counterparties Check files and remits to (IRS, state revenue departments). Global read-only reference data.
+
+| Tool | Method | Description |
+|---|---|---|
+| `list_agencies` | GET | List agencies; filter by jurisdiction or label |
+| `get_agency` | GET | Get a specific agency |
 
 ### Webhooks (7 tools)
 

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -63,6 +63,7 @@ sensitive employee/contractor data.
 - **Earning Rate** defines an employee's pay rate; **Earning Code** defines the type of earning (regular, overtime, bonus, etc.)
 - **Benefits** are pre-tax deductions (401k, health insurance); **Post-Tax Deductions** are after-tax (garnishments, Roth 401k)
 - **Tax Params** control withholding (W-4 info, state elections); they use `spa_*` IDs
+- **Taxes** (`tax_`) and **Agencies** (`agc_`) are global read-only reference data — the levies themselves and the authorities Check files/remits to; look them up with list_taxes/list_agencies
 - Payrolls must be **approved** before they process — approval triggers real money movement
 - All IDs use prefixes: `com_` (company), `emp_` (employee), `ctr_` (contractor), `prl_` (payroll), `pit_` (payroll item), `pmt_` (payment), `wrk_` (workplace), `bnk_` (bank account)
 

--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 TOOLSETS: frozenset[str] = frozenset(
     {
+        "agencies",
         "bank_accounts",
         "companies",
         "compensation",

--- a/src/mcp_server_check/tool_index.py
+++ b/src/mcp_server_check/tool_index.py
@@ -30,7 +30,7 @@ _SYNONYM_GROUPS: list[set[str]] = [
     {"list", "index", "all", "browse", "search", "find"},
     {"get", "show", "view", "read", "fetch", "retrieve", "detail", "details"},
     {"payment", "disbursement", "deposit", "transfer"},
-    {"tax", "withholding", "filing", "w2", "w4"},
+    {"tax", "withholding", "filing", "w2", "w4", "agency", "agencies"},
     {"bank", "account", "ach", "routing"},
     {"report", "summary", "journal", "export"},
     {"webhook", "callback", "event", "notification"},
@@ -84,6 +84,7 @@ def _first_line(docstring: str | None) -> str:
 
 # Toolset descriptions for the overview
 _TOOLSET_DESCRIPTIONS: dict[str, str] = {
+    "agencies": "Tax agencies — the counterparties Check files and remits to (IRS, state revenue departments).",
     "bank_accounts": "Create, update, delete, and view bank accounts for companies, employees, and contractors.",
     "companies": "Manage companies, signatories, enrollment profiles, reports, and EIN verifications.",
     "compensation": "Manage earning rates, earning codes, benefits, post-tax deductions, net pay splits, and pay schedules.",
@@ -99,7 +100,7 @@ _TOOLSET_DESCRIPTIONS: dict[str, str] = {
     "payroll_items": "Create, update, and delete individual payroll line items within a payroll.",
     "payrolls": "Create, preview, approve, and manage payroll runs. Includes sandbox simulation tools.",
     "platform": "Platform-level tools: notifications, communications, usage, integrations, accounting, setups, and requirements.",
-    "tax": "Manage company and employee tax parameters, elections, filings, exemptions, and tax statements.",
+    "tax": "Manage company and employee tax parameters, elections, filings, exemptions, and tax statements. Includes tax reference data (list_taxes/get_tax).",
     "webhooks": "Create, update, delete, and test webhook configurations.",
     "workflows": "Composite tools that combine multiple API calls: company overview, employee snapshot, contractor snapshot, payroll details, payment diagnostics, tax overview, onboarding status.",
     "workplaces": "Create, update, and view company workplace locations.",

--- a/src/mcp_server_check/tools/__init__.py
+++ b/src/mcp_server_check/tools/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastmcp import FastMCP
 
 from . import (
+    agencies,
     bank_accounts,
     companies,
     compensation,
@@ -30,6 +31,7 @@ from . import (
 )
 
 _TOOLSETS = {
+    "agencies": agencies,
     "bank_accounts": bank_accounts,
     "companies": companies,
     "compensation": compensation,

--- a/src/mcp_server_check/tools/agencies.py
+++ b/src/mcp_server_check/tools/agencies.py
@@ -1,0 +1,62 @@
+"""Agency tools for the Check API."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from mcp_server_check.annotations import add_annotated_tool
+from mcp_server_check.helpers import (
+    Ctx,
+    build_params,
+    check_api_get,
+    check_api_list,
+)
+
+
+async def list_agencies(
+    ctx: Ctx,
+    ids: list[str] | None = None,
+    jurisdiction: list[str] | None = None,
+    label_contains: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict:
+    """List agencies — the counterparties Check files and remits to.
+
+    An agency (e.g. the IRS or a state revenue department) is the authority
+    employers register with and the recipient of payments and filings. Agencies
+    are global reference data: the same across all companies and environments.
+
+    Args:
+        ids: Agency IDs to look up, for batch lookups (max 500 per request).
+        jurisdiction: Filter by lowercase region code(s), e.g. ["fed", "ny"].
+            Multiple values are OR'd.
+        label_contains: Case-insensitive substring match on the agency label.
+        limit: Maximum number of results to return (default 25, max 500).
+        cursor: Pagination cursor from a previous response.
+    """
+    return await check_api_list(
+        ctx,
+        "/agencies",
+        params=build_params(
+            id=ids,
+            jurisdiction=jurisdiction,
+            label_contains=label_contains,
+            limit=limit,
+            cursor=cursor,
+        ),
+    )
+
+
+async def get_agency(ctx: Ctx, agency_id: str) -> dict:
+    """Get a single agency by ID.
+
+    Args:
+        agency_id: The Check agency ID (e.g. "agc_xxxxx").
+    """
+    return await check_api_get(ctx, f"/agencies/{agency_id}")
+
+
+def register(mcp: FastMCP, *, read_only: bool = False) -> None:
+    add_annotated_tool(mcp, list_agencies)
+    add_annotated_tool(mcp, get_agency)

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -584,6 +584,64 @@ async def get_tax_package(ctx: Ctx, tax_package_id: str) -> dict:
     return await check_api_get(ctx, f"/tax_packages/{tax_package_id}")
 
 
+# --- Taxes (reference data) ---
+
+
+async def list_taxes(
+    ctx: Ctx,
+    ids: list[str] | None = None,
+    jurisdiction: list[str] | None = None,
+    supported: bool | None = None,
+    remittable: bool | None = None,
+    effective: bool | None = None,
+    label_contains: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict:
+    """List tax objects — the levies that arise when running payroll.
+
+    A tax (e.g. Federal Income Tax, a state's SUI) is global reference data:
+    the same across all companies and environments. Distinct from company/
+    employee tax *parameters* and *elections*, which configure how a given
+    company or employee relates to these taxes.
+
+    Args:
+        ids: Tax IDs to look up, for batch lookups (max 500 per request).
+        jurisdiction: Filter by lowercase region code(s), e.g. ["fed", "ny"].
+            Multiple values are OR'd.
+        supported: Filter by whether Check calculates and files the tax.
+        remittable: Filter by whether Check remits the tax to the agency.
+        effective: Filter by whether the tax obligation is currently in
+            effect (defaults to true on the API side).
+        label_contains: Case-insensitive substring match on the tax label.
+        limit: Maximum number of results to return (default 25, max 500).
+        cursor: Pagination cursor from a previous response.
+    """
+    return await check_api_list(
+        ctx,
+        "/taxes",
+        params=build_params(
+            id=ids,
+            jurisdiction=jurisdiction,
+            supported=supported,
+            remittable=remittable,
+            effective=effective,
+            label_contains=label_contains,
+            limit=limit,
+            cursor=cursor,
+        ),
+    )
+
+
+async def get_tax(ctx: Ctx, tax_id: str) -> dict:
+    """Get a single tax object by ID.
+
+    Args:
+        tax_id: The Check tax ID (e.g. "tax_xxxxx").
+    """
+    return await check_api_get(ctx, f"/taxes/{tax_id}")
+
+
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Company Tax Params
     add_annotated_tool(mcp, get_company_tax_params)
@@ -613,6 +671,9 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     add_annotated_tool(mcp, get_employee_tax_statement)
     # Tax Packages
     add_annotated_tool(mcp, get_tax_package)
+    # Taxes (reference data)
+    add_annotated_tool(mcp, list_taxes)
+    add_annotated_tool(mcp, get_tax)
     if not read_only:
         add_annotated_tool(mcp, update_company_tax_params)
         add_annotated_tool(mcp, update_employee_tax_params)

--- a/tests/test_agencies.py
+++ b/tests/test_agencies.py
@@ -1,0 +1,71 @@
+"""Tests for agency tools."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from mcp_server_check.tools.agencies import get_agency, list_agencies
+
+
+@pytest.mark.anyio
+async def test_list_agencies(mock_api, ctx):
+    mock_api.get("/agencies").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": "agc_001",
+                        "label": "Internal Revenue Service",
+                        "jurisdiction": "fed",
+                    }
+                ],
+            },
+        )
+    )
+    result = await list_agencies(ctx)
+    assert result["result_count"] == 1
+    assert result["results"][0]["id"] == "agc_001"
+    assert result["results"][0]["label"] == "Internal Revenue Service"
+
+
+@pytest.mark.anyio
+async def test_list_agencies_with_filters(mock_api, ctx):
+    route = mock_api.get("/agencies").mock(
+        return_value=httpx.Response(
+            200, json={"next": None, "previous": None, "results": []}
+        )
+    )
+    await list_agencies(
+        ctx,
+        ids=["agc_001", "agc_002"],
+        jurisdiction=["fed", "ny"],
+        label_contains="revenue",
+        limit=50,
+    )
+    params = route.calls[0].request.url.params
+    # Multi-value filters are sent as repeated params, not comma-joined.
+    assert params.get_list("id") == ["agc_001", "agc_002"]
+    assert params.get_list("jurisdiction") == ["fed", "ny"]
+    assert params["label_contains"] == "revenue"
+    assert params["limit"] == "50"
+
+
+@pytest.mark.anyio
+async def test_get_agency(mock_api, ctx):
+    mock_api.get("/agencies/agc_001").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "agc_001",
+                "label": "Internal Revenue Service",
+                "jurisdiction": "fed",
+            },
+        )
+    )
+    result = await get_agency(ctx, agency_id="agc_001")
+    assert result["id"] == "agc_001"
+    assert result["jurisdiction"] == "fed"

--- a/tests/test_cli_codegen.py
+++ b/tests/test_cli_codegen.py
@@ -118,6 +118,19 @@ class TestMakeCommandName:
             == "get-payroll-journal-report"
         )
 
+    def test_list_taxes(self):
+        """'taxes' doesn't match the 'tax' toolset token → full name kept."""
+        assert _make_command_name("list_taxes", "tax") == "list-taxes"
+
+    def test_get_tax(self):
+        assert _make_command_name("get_tax", "tax") == "get"
+
+    def test_list_agencies(self):
+        assert _make_command_name("list_agencies", "agencies") == "list"
+
+    def test_get_agency(self):
+        assert _make_command_name("get_agency", "agencies") == "get"
+
 
 # ---------------------------------------------------------------------------
 # _unwrap_optional
@@ -318,12 +331,13 @@ class TestBuildCommand:
 class TestCollectTools:
     def test_returns_all_toolsets(self):
         tools = collect_tools()
-        assert len(tools) == 19
+        assert len(tools) == 20
         assert "companies" in tools
         assert "employees" in tools
         assert "payrolls" in tools
         assert "bank_accounts" in tools
         assert "tax" in tools
+        assert "agencies" in tools
 
     def test_all_functions_are_async(self):
         tools = collect_tools()

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -8,12 +8,14 @@ import pytest
 from mcp_server_check.tools.tax import (
     get_company_tax_params,
     get_filing,
+    get_tax,
     list_company_tax_elections,
     list_company_tax_param_settings,
     list_employee_tax_param_settings,
     list_employee_tax_params,
     list_employee_tax_statements,
     list_filings,
+    list_taxes,
     update_company_tax_params,
 )
 
@@ -203,3 +205,82 @@ async def test_get_filing(mock_api, ctx):
     )
     result = await get_filing(ctx, filing_id="com_fil_001")
     assert result["id"] == "com_fil_001"
+
+
+@pytest.mark.anyio
+async def test_list_taxes(mock_api, ctx):
+    mock_api.get("/taxes").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": "tax_001",
+                        "label": "Federal Income Tax",
+                        "jurisdiction": "fed",
+                        "payer": "employee",
+                        "supported": True,
+                        "remittable": True,
+                        "effective_from": None,
+                        "effective_to": None,
+                    }
+                ],
+            },
+        )
+    )
+    result = await list_taxes(ctx)
+    assert result["result_count"] == 1
+    assert result["results"][0]["id"] == "tax_001"
+    assert result["results"][0]["payer"] == "employee"
+
+
+@pytest.mark.anyio
+async def test_list_taxes_with_filters(mock_api, ctx):
+    route = mock_api.get("/taxes").mock(
+        return_value=httpx.Response(
+            200, json={"next": None, "previous": None, "results": []}
+        )
+    )
+    await list_taxes(
+        ctx,
+        ids=["tax_001", "tax_002"],
+        jurisdiction=["fed", "ny"],
+        supported=True,
+        remittable=False,
+        effective=False,
+        label_contains="unemployment",
+        limit=100,
+    )
+    params = route.calls[0].request.url.params
+    # Multi-value filters are sent as repeated params, not comma-joined.
+    assert params.get_list("id") == ["tax_001", "tax_002"]
+    assert params.get_list("jurisdiction") == ["fed", "ny"]
+    assert params["supported"] == "true"
+    assert params["remittable"] == "false"
+    assert params["effective"] == "false"
+    assert params["label_contains"] == "unemployment"
+    assert params["limit"] == "100"
+
+
+@pytest.mark.anyio
+async def test_get_tax(mock_api, ctx):
+    mock_api.get("/taxes/tax_001").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "tax_001",
+                "label": "Federal Income Tax",
+                "jurisdiction": "fed",
+                "payer": "employee",
+                "supported": True,
+                "remittable": True,
+                "effective_from": None,
+                "effective_to": None,
+            },
+        )
+    )
+    result = await get_tax(ctx, tax_id="tax_001")
+    assert result["id"] == "tax_001"
+    assert result["jurisdiction"] == "fed"

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -436,11 +436,12 @@ class TestMerge:
 
 
 class TestToolsets:
-    def test_has_19_toolsets(self):
-        assert len(TOOLSETS) == 19
+    def test_has_20_toolsets(self):
+        assert len(TOOLSETS) == 20
 
     def test_known_toolsets(self):
         expected = {
+            "agencies",
             "bank_accounts",
             "companies",
             "compensation",


### PR DESCRIPTION
## Summary

Adds support for Check's [Taxes API](https://docs.checkhq.com/reference/the-tax-object) and [Agencies API](https://docs.checkhq.com/reference/the-agency-object) — both read-only, global reference data — to the MCP server and CLI.

### Taxes (added to the existing `tax` toolset)
- `list_taxes` — `GET /taxes` with `ids` and `jurisdiction` sent as repeated query params, plus `supported`, `remittable`, `effective`, `label_contains`, `limit`, `cursor`
- `get_tax` — `GET /taxes/{id}`
- CLI: `check tax list-taxes`, `check tax get TAX_ID`

Placed in the existing `tax` toolset (rather than a new `taxes` toolset) to avoid confusing sibling toolset names for `CHECK_TOOLSETS` filtering.

### Agencies (new `agencies` toolset)
- `list_agencies` — `GET /agencies` with `ids`, `jurisdiction`, `label_contains`, `limit`, `cursor`
- `get_agency` — `GET /agencies/{id}`
- CLI: `check agencies list`, `check agencies get AGENCY_ID` (commands auto-generated)

### Wiring & docs
- `agencies` registered in `_TOOLSETS` and the `ToolFilter` allowlist; tool-index description + `agency`/`agencies` search synonyms; `SERVER_INSTRUCTIONS` mentions the `tax_`/`agc_` reference data
- README: toolset list 19→20, new Agencies table, Tax section now 33 tools — also fixed four stale filing rows (`list_tax_filings` etc. → the real `list_filings`/`get_filing`/`add_filing_blockers`/`remove_filing_blockers`)
- CLI.md: added `agencies` and a previously missing `workflows` row; corrected the stale "263 endpoints" count to 236 tools

## Test plan

- [x] New `tests/test_agencies.py` and taxes tests in `tests/test_tax.py` (respx-mocked; assert repeated `id`/`jurisdiction` params and bool lowercasing)
- [x] CLI codegen naming cases (`list_taxes`→`list-taxes`, `get_tax`→`get`, `get_agency`→`get`)
- [x] Full suite: 475 passed; ruff check/format clean
- [x] CLI smoke: `check agencies --help`, `check agencies list --help`, `check tax --help` show expected commands/options
- [ ] Live sandbox call (no API key in my environment) — `check agencies list --limit 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
