### PR TITLE
Gate destructive tools behind user-visible MCP elicitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ CHECK_API_KEY=your-key uv run mcp-server-check
 | `CHECK_TOOLS` | No | — | Comma-separated allowlist of individual tool names |
 | `CHECK_EXCLUDE_TOOLS` | No | — | Comma-separated list of tool names to hide |
 | `CHECK_READ_ONLY` | No | — | Set to `1`, `true`, or `yes` to disable all write/mutating tools |
+| `CHECK_CONFIRM_DESTRUCTIVE` | No | `true` | Destructive tools prompt the user for approval via MCP elicitation. Set to `false` to disable (self-hosted automation only — not recommended) |
 | `CHECK_TRANSPORT` | No | `stdio` | Transport protocol: `stdio`, `sse`, or `streamable-http` |
 
 ### Sandbox vs Production
@@ -84,6 +85,14 @@ Set `CHECK_READ_ONLY=1` to run the server with only read-only tools (list, get, 
 ```bash
 CHECK_READ_ONLY=1 CHECK_API_KEY=your-key uv run mcp-server-check
 ```
+
+#### Destructive-Tool Confirmation
+
+Tools that move money (`approve_payroll`, `retry_payment`, `cancel_payment`, `refund_payment`), change funding or payout destinations (`create_bank_account`, `update_bank_account`, `delete_bank_account`), shape what a payroll disburses (`create_payroll`, `create_payroll_item`, `create_contractor_payment`, `create_net_pay_split`, and their update variants), or delete data (`delete_*`, `bulk_delete_*`, `cancel_*`) require an explicit, user-visible confirmation before they execute.
+
+The confirmation uses [MCP elicitation](https://modelcontextprotocol.io/specification/draft/client/elicitation): the server sends the tool name and full arguments to the client, which renders an approve/decline prompt to the human user. The model cannot answer the prompt itself, and clients cannot disable the gate over HTTP (the `X-MCP-Confirm-Destructive` header can only turn it on when the server has opted out). If the connected client does not support elicitation, destructive calls fail closed with an explanatory error.
+
+This gate is **on by default**. Self-hosted deployments running trusted automation can opt out with `CHECK_CONFIRM_DESTRUCTIVE=false`, which logs a warning at startup.
 
 #### HTTP Headers (Remote Transport)
 

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -12,6 +12,7 @@ from typing import Any
 import httpx
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools import FunctionTool
 
 from mcp_server_check.helpers import CheckContext
@@ -31,6 +32,12 @@ and payments programmatically.
 using their credentials, including actions taken by AI agents. Always confirm \
 before executing write operations that affect payroll, money movement, or \
 sensitive employee/contractor data.
+
+Tools that move money, change funding/payout destinations, or make \
+irreversible changes (approve, delete, cancel, refund, retry, bank account \
+changes, payroll/payment creation) automatically prompt the user for \
+approval via MCP elicitation before executing. This confirmation comes from \
+the user directly and cannot be provided on their behalf.
 
 ## Entity Model
 - **Company** → has Workplaces, Employees, Contractors, Pay Schedules, Bank Accounts
@@ -96,6 +103,67 @@ async def lifespan(server: FastMCP) -> AsyncIterator[CheckContext]:
         timeout=30.0,
     ) as client:
         yield CheckContext(client=client, base_url=base_url)
+
+
+async def _confirm_destructive(
+    ctx: Context, tool_name: str, arguments: dict | None
+) -> str | None:
+    """Ask the user to approve a destructive tool call via MCP elicitation.
+
+    Returns None when the user approves, otherwise a human-readable reason
+    the call was blocked. Fails closed: if the client does not support
+    elicitation, the call is blocked rather than allowed through.
+    """
+    details = json.dumps(arguments or {}, indent=2, sort_keys=True)
+    message = (
+        f"'{tool_name}' can move money or make irreversible changes.\n\n"
+        f"Arguments:\n{details}\n\n"
+        f"Approve this operation?"
+    )
+    try:
+        result = await ctx.elicit(message, response_type=None)
+    except Exception:
+        return (
+            f"'{tool_name}' requires user confirmation, but this client does not "
+            "support MCP elicitation, so the call was blocked. Run this operation "
+            "from a client that supports elicitation, or from the Check dashboard."
+        )
+    if result.action == "accept":
+        return None
+    verb = "declined" if result.action == "decline" else "cancelled"
+    return (
+        f"The user {verb} the confirmation prompt for '{tool_name}'. "
+        "Do not retry unless the user explicitly asks you to."
+    )
+
+
+class ConfirmDestructiveMiddleware(Middleware):
+    """Gate destructive tools behind a user-visible confirmation prompt.
+
+    Covers individually registered tools (all-tools mode and hosted mounts).
+    In dynamic mode the target tool name arrives as an argument to run_tool,
+    which applies the same gate itself.
+    """
+
+    def __init__(self, server: CheckMCP) -> None:
+        self._server = server
+
+    async def on_call_tool(
+        self, context: MiddlewareContext, call_next: CallNext
+    ) -> Any:
+        name = context.message.name
+        tf = self._server._get_active_filter()
+        if tf.requires_confirmation(name):
+            ctx = context.fastmcp_context
+            if ctx is None:
+                raise ToolError(
+                    f"'{name}' requires user confirmation, but no request "
+                    "context is available, so the call was blocked."
+                )
+            denial = await _confirm_destructive(ctx, name, context.message.arguments)
+            if denial is not None:
+                raise ToolError(denial)
+        return await call_next(context)
 
 
 class CheckMCP(FastMCP):
@@ -226,18 +294,19 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
         ctx: Context,
         tool_name: str,
         arguments: str | dict | None = None,
-        confirm: bool = False,
     ) -> str:
         """Execute an API tool by name with the given arguments.
 
         Use search_tools first to find the tool name and its parameter schema.
 
+        Destructive tools (approve, delete, cancel, refund, retry, bank account
+        changes, payroll/payment creation) prompt the user for approval via MCP
+        elicitation before executing; the confirmation comes from the user
+        directly and cannot be supplied by the model.
+
         tool_name: The exact tool name (e.g. "list_companies", "get_employee").
         arguments: Tool arguments as a JSON string or dict (e.g. '{"company_id": "com_xxx"}'
             or {"company_id": "com_xxx"}).
-        confirm: Set to true to confirm execution of a destructive tool (approve,
-            delete, simulate, refund, cancel). Required when CHECK_CONFIRM_DESTRUCTIVE
-            is enabled and the tool is destructive.
         """
         tf = server._get_active_filter()
         parsed_args: dict = {}
@@ -256,19 +325,16 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
                     {"error": "Arguments must be a JSON string or object"}
                 )
 
-        if tf.requires_confirmation(tool_name) and not confirm:
-            return json.dumps(
-                {
-                    "confirmation_required": True,
-                    "tool_name": tool_name,
-                    "arguments": parsed_args,
-                    "message": (
-                        f"⚠️  '{tool_name}' is a destructive operation that may "
-                        f"trigger irreversible effects (money movement, data deletion, "
-                        f"etc.). Call run_tool again with confirm=true to proceed."
-                    ),
-                }
-            )
+        if tf.requires_confirmation(tool_name):
+            denial = await _confirm_destructive(ctx, tool_name, parsed_args)
+            if denial is not None:
+                return json.dumps(
+                    {
+                        "error": denial,
+                        "confirmation_required": True,
+                        "tool_name": tool_name,
+                    }
+                )
 
         try:
             result = await index.run(
@@ -393,6 +459,7 @@ def setup_tools(server: CheckMCP, tool_mode: str = "dynamic") -> None:
         register_all(server, registry=server._registry)
     else:
         _setup_dynamic_mode(server)
+    server.add_middleware(ConfirmDestructiveMiddleware(server))
     _register_resources(server)
 
 
@@ -420,6 +487,17 @@ def main():
         print("Running in all-tools mode (legacy)", file=sys.stderr)
     if mcp._static_filter.read_only:
         print("Running in read-only mode (CHECK_READ_ONLY is set)", file=sys.stderr)
+    if mcp._static_filter.confirm_destructive:
+        print(
+            "Destructive tools require user confirmation via MCP elicitation",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            "WARNING: destructive-tool confirmation is DISABLED "
+            "(CHECK_CONFIRM_DESTRUCTIVE=false)",
+            file=sys.stderr,
+        )
     if mcp._static_filter.toolsets:
         print(
             f"Active toolsets: {', '.join(sorted(mcp._static_filter.toolsets))}",

--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -67,8 +67,10 @@ _WRITE_KEYWORDS = (
     "remove_",
 )
 
-# Tools that trigger irreversible real-world effects (money movement, deletion).
-# These require explicit confirmation when CHECK_CONFIRM_DESTRUCTIVE is enabled.
+# Tools that trigger irreversible real-world effects (money movement, deletion)
+# or shape the amounts/recipients/destinations of money movement.
+# These always require explicit user confirmation (via MCP elicitation) unless
+# the server operator opts out with CHECK_CONFIRM_DESTRUCTIVE=false.
 _DESTRUCTIVE_PREFIXES = (
     "approve_",
     "delete_",
@@ -81,6 +83,22 @@ _DESTRUCTIVE_EXACT = frozenset(
     {
         "start_implementation",
         "cancel_implementation",
+        # Money movement: re-initiates a failed transfer.
+        "retry_payment",
+        # Funding/payout destinations: adding or repointing a bank account
+        # reroutes where pay is drawn from or sent to.
+        "create_bank_account",
+        "update_bank_account",
+        # Upstream instruction tools: these shape the amounts and recipients
+        # that an approved payroll then disburses.
+        "create_payroll",
+        "update_payroll",
+        "create_payroll_item",
+        "update_payroll_item",
+        "bulk_update_payroll_items",
+        "create_contractor_payment",
+        "update_contractor_payment",
+        "create_net_pay_split",
     }
 )
 
@@ -95,8 +113,8 @@ def is_write_tool(name: str) -> bool:
 def is_destructive_tool(name: str) -> bool:
     """Return True if the tool triggers irreversible effects (money movement, deletion).
 
-    These tools should require explicit confirmation when the confirmation
-    tier is enabled.
+    These tools require explicit user confirmation (via MCP elicitation)
+    unless the server operator disables the confirmation tier.
     """
     if name in _DESTRUCTIVE_EXACT:
         return True
@@ -116,6 +134,16 @@ def _parse_bool(value: str | None) -> bool:
     return (value or "").lower() in ("1", "true", "yes")
 
 
+def _parse_bool_default_true(value: str | None) -> bool:
+    """Parse a string as a boolean flag that defaults to True when unset.
+
+    Only an explicit "0"/"false"/"no" disables the flag.
+    """
+    if value is None or value.strip() == "":
+        return True
+    return value.lower() not in ("0", "false", "no")
+
+
 @dataclass(frozen=True)
 class ToolFilter:
     """Immutable filter configuration for tool visibility.
@@ -131,7 +159,10 @@ class ToolFilter:
     tools: frozenset[str] | None = None
     exclude_tools: frozenset[str] = frozenset()
     read_only: bool = False
-    confirm_destructive: bool = False
+    # Destructive tools require user-visible confirmation by default.  Server
+    # operators may opt out with CHECK_CONFIRM_DESTRUCTIVE=false; clients can
+    # never disable it (merge() takes the OR of both sides).
+    confirm_destructive: bool = True
 
     def __post_init__(self) -> None:
         if self.toolsets is not None:
@@ -210,7 +241,7 @@ class ToolFilter:
             exclude_tools=_parse_comma_set(os.environ.get("CHECK_EXCLUDE_TOOLS"))
             or frozenset(),
             read_only=_parse_bool(os.environ.get("CHECK_READ_ONLY")),
-            confirm_destructive=_parse_bool(
+            confirm_destructive=_parse_bool_default_true(
                 os.environ.get("CHECK_CONFIRM_DESTRUCTIVE")
             ),
         )
@@ -246,6 +277,10 @@ class ToolFilter:
         get = getattr(query_params, "get", None)
         if get is None:
             return cls()
+        # confirm_destructive is False here (not the dataclass default) so a
+        # client-derived filter stays neutral under merge()'s OR — it must
+        # never re-enable the gate when the server operator has opted out.
         return cls(
             read_only=_parse_bool(get("read_only")),
+            confirm_destructive=False,
         )

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -87,10 +87,17 @@ class TestDeriveAnnotations:
         assert a.idempotentHint is True
 
     def test_non_destructive_bulk_update(self) -> None:
-        a = derive_annotations("bulk_update_payroll_items")
+        a = derive_annotations("bulk_update_exemptible_taxes")
         assert a.readOnlyHint is False
         assert a.destructiveHint is False
         assert a.idempotentHint is True
+
+    def test_destructive_bulk_update_payroll_items(self) -> None:
+        # Shapes the amounts a payroll disburses, so it carries the
+        # destructive hint and the confirmation gate.
+        a = derive_annotations("bulk_update_payroll_items")
+        assert a.readOnlyHint is False
+        assert a.destructiveHint is True
 
     def test_destructive_bulk_delete(self) -> None:
         a = derive_annotations("bulk_delete_payroll_items")

--- a/tests/test_consent_gate.py
+++ b/tests/test_consent_gate.py
@@ -1,0 +1,222 @@
+"""Tests for the destructive-tool consent gate (MCP elicitation)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+from fastmcp import Client
+from fastmcp.client.elicitation import ElicitResult
+from fastmcp.exceptions import ToolError
+from httpx import Response
+
+from mcp_server_check.server import CheckMCP, lifespan, setup_tools
+from mcp_server_check.tool_filter import ToolFilter
+
+BASE_URL = "https://sandbox.checkhq.com"
+
+
+@pytest.fixture(autouse=True)
+def api_key_env(monkeypatch):
+    monkeypatch.setenv("CHECK_API_KEY", "test-key")
+    monkeypatch.delenv("CHECK_API_BASE_URL", raising=False)
+    monkeypatch.delenv("CHECK_CONFIRM_DESTRUCTIVE", raising=False)
+
+
+@pytest.fixture
+def mock_api():
+    with respx.mock(base_url=BASE_URL, assert_all_called=False) as mock:
+        yield mock
+
+
+def _dynamic_server(tool_filter: ToolFilter | None = None) -> CheckMCP:
+    server = CheckMCP("Test Dynamic", lifespan=lifespan)
+    setup_tools(server, tool_mode="dynamic")
+    if tool_filter is not None:
+        server._static_filter = tool_filter
+    return server
+
+
+def _all_tools_server(tool_filter: ToolFilter | None = None) -> CheckMCP:
+    server = CheckMCP("Test All", lifespan=lifespan)
+    setup_tools(server, tool_mode="all")
+    if tool_filter is not None:
+        server._static_filter = tool_filter
+    return server
+
+
+def _make_handler(action: str, log: list | None = None):
+    async def handler(message, response_type, params, context):
+        if log is not None:
+            log.append(message)
+        if action == "accept":
+            return ElicitResult(action="accept", content={})
+        return ElicitResult(action=action)
+
+    return handler
+
+
+# --- Dynamic mode (run_tool) ---
+
+
+class TestDynamicModeGate:
+    async def test_accept_runs_the_tool(self, mock_api):
+        route = mock_api.post("/payments/pay_123/cancel").mock(
+            return_value=Response(200, json={"id": "pay_123", "status": "cancelled"})
+        )
+        prompts: list[str] = []
+        server = _dynamic_server()
+        async with Client(
+            server, elicitation_handler=_make_handler("accept", prompts)
+        ) as client:
+            result = await client.call_tool(
+                "run_tool",
+                {"tool_name": "cancel_payment", "arguments": {"payment_id": "pay_123"}},
+            )
+        assert route.called
+        assert "cancelled" in result.content[0].text
+        # The user-visible prompt names the tool and shows its arguments
+        assert len(prompts) == 1
+        assert "cancel_payment" in prompts[0]
+        assert "pay_123" in prompts[0]
+
+    async def test_decline_blocks_the_call(self, mock_api):
+        route = mock_api.post("/payments/pay_123/cancel").mock(
+            return_value=Response(200, json={})
+        )
+        server = _dynamic_server()
+        async with Client(
+            server, elicitation_handler=_make_handler("decline")
+        ) as client:
+            result = await client.call_tool(
+                "run_tool",
+                {"tool_name": "cancel_payment", "arguments": {"payment_id": "pay_123"}},
+            )
+        assert not route.called
+        payload = json.loads(result.content[0].text)
+        assert payload["confirmation_required"] is True
+        assert "declined" in payload["error"]
+
+    async def test_no_elicitation_support_fails_closed(self, mock_api):
+        route = mock_api.post("/payments/pay_123/cancel").mock(
+            return_value=Response(200, json={})
+        )
+        server = _dynamic_server()
+        async with Client(server) as client:  # no elicitation handler
+            result = await client.call_tool(
+                "run_tool",
+                {"tool_name": "cancel_payment", "arguments": {"payment_id": "pay_123"}},
+            )
+        assert not route.called
+        payload = json.loads(result.content[0].text)
+        assert payload["confirmation_required"] is True
+        assert "does not support MCP elicitation" in payload["error"]
+
+    async def test_non_destructive_tool_skips_prompt(self, mock_api):
+        route = mock_api.get("/companies").mock(
+            return_value=Response(200, json={"results": [], "next": None})
+        )
+        prompts: list[str] = []
+        server = _dynamic_server()
+        async with Client(
+            server, elicitation_handler=_make_handler("accept", prompts)
+        ) as client:
+            await client.call_tool("run_tool", {"tool_name": "list_companies"})
+        assert route.called
+        assert prompts == []
+
+    async def test_operator_opt_out_disables_gate(self, mock_api):
+        route = mock_api.post("/payments/pay_123/cancel").mock(
+            return_value=Response(200, json={"id": "pay_123"})
+        )
+        prompts: list[str] = []
+        server = _dynamic_server(ToolFilter(confirm_destructive=False))
+        async with Client(
+            server, elicitation_handler=_make_handler("accept", prompts)
+        ) as client:
+            await client.call_tool(
+                "run_tool",
+                {"tool_name": "cancel_payment", "arguments": {"payment_id": "pay_123"}},
+            )
+        assert route.called
+        assert prompts == []
+
+    async def test_gates_upstream_instruction_tools(self, mock_api):
+        """create_payroll (shapes disbursements) is gated, not just money movers."""
+        route = mock_api.post("/payrolls").mock(
+            return_value=Response(200, json={"id": "prl_1"})
+        )
+        server = _dynamic_server()
+        async with Client(
+            server, elicitation_handler=_make_handler("decline")
+        ) as client:
+            result = await client.call_tool(
+                "run_tool",
+                {
+                    "tool_name": "create_payroll",
+                    "arguments": {
+                        "company": "com_1",
+                        "period_start": "2026-07-01",
+                        "period_end": "2026-07-15",
+                        "payday": "2026-07-18",
+                    },
+                },
+            )
+        assert not route.called
+        assert json.loads(result.content[0].text)["confirmation_required"] is True
+
+
+# --- All-tools mode (middleware) ---
+
+
+class TestAllToolsModeGate:
+    async def test_accept_runs_the_tool(self, mock_api):
+        route = mock_api.post("/payments/pay_123/cancel").mock(
+            return_value=Response(200, json={"id": "pay_123", "status": "cancelled"})
+        )
+        prompts: list[str] = []
+        server = _all_tools_server()
+        async with Client(
+            server, elicitation_handler=_make_handler("accept", prompts)
+        ) as client:
+            result = await client.call_tool("cancel_payment", {"payment_id": "pay_123"})
+        assert route.called
+        assert "cancelled" in result.content[0].text
+        assert len(prompts) == 1
+        assert "cancel_payment" in prompts[0]
+
+    async def test_decline_blocks_the_call(self, mock_api):
+        route = mock_api.post("/payments/pay_123/cancel").mock(
+            return_value=Response(200, json={})
+        )
+        server = _all_tools_server()
+        async with Client(
+            server, elicitation_handler=_make_handler("decline")
+        ) as client:
+            with pytest.raises(ToolError, match="declined"):
+                await client.call_tool("cancel_payment", {"payment_id": "pay_123"})
+        assert not route.called
+
+    async def test_no_elicitation_support_fails_closed(self, mock_api):
+        route = mock_api.post("/payments/pay_123/cancel").mock(
+            return_value=Response(200, json={})
+        )
+        server = _all_tools_server()
+        async with Client(server) as client:
+            with pytest.raises(ToolError, match="does not support MCP elicitation"):
+                await client.call_tool("cancel_payment", {"payment_id": "pay_123"})
+        assert not route.called
+
+    async def test_non_destructive_tool_skips_prompt(self, mock_api):
+        route = mock_api.get("/companies").mock(
+            return_value=Response(200, json={"results": [], "next": None})
+        )
+        prompts: list[str] = []
+        server = _all_tools_server()
+        async with Client(
+            server, elicitation_handler=_make_handler("accept", prompts)
+        ) as client:
+            await client.call_tool("list_companies", {})
+        assert route.called
+        assert prompts == []

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -134,8 +134,10 @@ class TestFromHeaders:
         assert tf.read_only is True
 
     def test_empty_headers(self):
+        # Client-derived filters carry confirm_destructive=False so they stay
+        # neutral under merge()'s OR; everything else matches the defaults.
         tf = ToolFilter.from_headers({})
-        assert tf == ToolFilter()
+        assert tf == ToolFilter(confirm_destructive=False)
 
     def test_no_get_method(self):
         tf = ToolFilter.from_headers(42)  # type: ignore[arg-type]
@@ -165,8 +167,10 @@ class TestFromQueryParams:
         assert tf.read_only is False
 
     def test_empty_query_params(self):
+        # Client-derived filters carry confirm_destructive=False so they stay
+        # neutral under merge()'s OR; everything else matches the defaults.
         tf = ToolFilter.from_query_params({})
-        assert tf == ToolFilter()
+        assert tf == ToolFilter(confirm_destructive=False)
 
     def test_no_get_method(self):
         tf = ToolFilter.from_query_params(42)  # type: ignore[arg-type]
@@ -174,7 +178,7 @@ class TestFromQueryParams:
 
     def test_unrelated_params_ignored(self):
         tf = ToolFilter.from_query_params({"foo": "bar", "baz": "1"})
-        assert tf == ToolFilter()
+        assert tf == ToolFilter(confirm_destructive=False)
 
     def test_only_read_only_is_parsed(self):
         """Query params for other filter fields (toolsets, confirm_destructive, etc.) are ignored."""
@@ -297,6 +301,21 @@ class TestIsDestructiveTool:
             "cancel_payment",
             "start_implementation",
             "cancel_implementation",
+            # Money movement
+            "retry_payment",
+            # Funding/payout destinations
+            "create_bank_account",
+            "update_bank_account",
+            "delete_bank_account",
+            # Upstream tools that shape what a payroll disburses
+            "create_payroll",
+            "update_payroll",
+            "create_payroll_item",
+            "update_payroll_item",
+            "bulk_update_payroll_items",
+            "create_contractor_payment",
+            "update_contractor_payment",
+            "create_net_pay_split",
         ],
     )
     def test_destructive_detected(self, name):
@@ -312,6 +331,8 @@ class TestIsDestructiveTool:
             "preview_payroll",
             "onboard_company",
             "submit_employee_form",
+            "retry_webhook_events",
+            "bulk_update_exemptible_taxes",
         ],
     )
     def test_non_destructive(self, name):
@@ -322,24 +343,37 @@ class TestIsDestructiveTool:
 
 
 class TestRequiresConfirmation:
-    def test_no_confirmation_by_default(self):
+    def test_confirmation_on_by_default(self):
         tf = ToolFilter()
-        assert tf.requires_confirmation("approve_payroll") is False
-
-    def test_confirmation_when_enabled(self):
-        tf = ToolFilter(confirm_destructive=True)
         assert tf.requires_confirmation("approve_payroll") is True
         assert tf.requires_confirmation("delete_payroll") is True
+        assert tf.requires_confirmation("retry_payment") is True
+        assert tf.requires_confirmation("create_bank_account") is True
+
+    def test_explicit_opt_out_disables_confirmation(self):
+        tf = ToolFilter(confirm_destructive=False)
+        assert tf.requires_confirmation("approve_payroll") is False
 
     def test_no_confirmation_for_safe_tools(self):
-        tf = ToolFilter(confirm_destructive=True)
+        tf = ToolFilter()
         assert tf.requires_confirmation("list_companies") is False
         assert tf.requires_confirmation("create_company") is False
 
-    def test_from_env_confirm_destructive(self):
+    def test_from_env_defaults_on(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CHECK_CONFIRM_DESTRUCTIVE", None)
+            tf = ToolFilter.from_env()
+        assert tf.confirm_destructive is True
+
+    def test_from_env_explicit_true(self):
         with mock.patch.dict(os.environ, {"CHECK_CONFIRM_DESTRUCTIVE": "true"}):
             tf = ToolFilter.from_env()
         assert tf.confirm_destructive is True
+
+    def test_from_env_explicit_false_opts_out(self):
+        with mock.patch.dict(os.environ, {"CHECK_CONFIRM_DESTRUCTIVE": "false"}):
+            tf = ToolFilter.from_env()
+        assert tf.confirm_destructive is False
 
     def test_from_headers_confirm_destructive(self):
         headers = {"x-mcp-confirm-destructive": "1"}


### PR DESCRIPTION
## Why

Anthropic's MCP directory review flagged that our destructive tools execute with no enforced consent gate (§4.A critical, §4.E, and the bank-account medium finding). The existing `confirm` parameter was a model-set boolean behind an opt-in env var — their behavioral probe confirmed `cancel_payment` ran with it unset. Their explicit ask: "Gate irreversible/fee-bearing operations behind an explicit user-visible confirmation, not a model-set boolean," with MCP elicitation listed as an acceptable mechanism.

## What

- **Replaces the model-set `confirm` boolean with MCP elicitation.** Destructive tools now send the tool name + full arguments to the client, which renders an approve/decline prompt to the human. The model cannot answer it on the user's behalf.
- **On by default, fail closed.** `CHECK_CONFIRM_DESTRUCTIVE` flips from opt-in to explicit server-side opt-out (`=false`, logs a startup warning). Clients can never disable the gate over HTTP — headers/query params can only tighten. Clients without elicitation support get a blocking error instead of execution.
- **Expanded destructive set per the review:**
  - Money movement: `retry_payment` (approve/cancel/refund already covered by prefix)
  - Funding/payout destinations: `create_bank_account`, `update_bank_account`
  - Upstream disbursement-shaping tools: `create/update_payroll`, `create/update_payroll_item`, `bulk_update_payroll_items`, `create/update_contractor_payment`, `create_net_pay_split`
- **Both modes covered:** the gate runs inside `run_tool` (dynamic mode) and via a new `ConfirmDestructiveMiddleware` (all-tools mode), so hosted mounts registered through `setup_tools` inherit it.
- README documents the gate and the opt-out; `bulk_update_payroll_items` now correctly carries `destructiveHint: true`.

## Verification

- 502 tests passing, including 10 new tests in `tests/test_consent_gate.py` covering accept/decline/fail-closed/opt-out in both modes.
- Exercised end-to-end over streamable HTTP against a stubbed Check API: declined and unsupported-client calls never reached the API; accepted calls did.

## Not covered here (remaining review items)

- Express written exception for money movement with Anthropic (business conversation, not code)
- Seeded reviewer sandbox + tax/forms read scopes (ops)
- Raw bank-credential handling documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJ7rSMfxrhi6dMMc3JdZ6y