### PR TITLE
feat: opt-in per-request bearer token via X-Check-Token header

### DIFF
--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -90,12 +90,30 @@ Prefer the workflow tools when they fit — they combine multiple API calls in o
 async def lifespan(server: FastMCP) -> AsyncIterator[CheckContext]:
     base_url = os.environ.get("CHECK_API_BASE_URL", DEFAULT_BASE_URL).rstrip("/")
     api_key = os.environ["CHECK_API_KEY"]
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers={"Authorization": f"Bearer {api_key}"},
-        timeout=30.0,
-    ) as client:
-        yield CheckContext(client=client, base_url=base_url)
+    # Opt-in (off by default): allow a trusted caller to supply a per-request
+    # bearer token via the `X-Check-Token` header — e.g. a provider-scoped token
+    # so one server can serve many providers. Falls back to CHECK_API_KEY.
+    allow_token_header = os.environ.get("CHECK_ALLOW_TOKEN_HEADER", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+    def resolve_token() -> str:
+        if allow_token_header:
+            try:
+                request = server._mcp_server.request_context.request
+                forwarded = request.headers.get("X-Check-Token") if request else None
+                if forwarded:
+                    return forwarded
+            except Exception:
+                pass
+        return api_key
+
+    async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as client:
+        yield CheckContext(
+            client=client, base_url=base_url, token_resolver=resolve_token
+        )
 
 
 class CheckMCP(FastMCP):


### PR DESCRIPTION
## Summary
- Adds an opt-in `token_resolver` to `CheckContext` that reads a per-request bearer token from the `X-Check-Token` request header, falling back to `CHECK_API_KEY`.
- Gated behind the `CHECK_ALLOW_TOKEN_HEADER` env var (off by default), so existing partner deployments are unaffected.
- Lets a single server instance serve many providers when a trusted internal caller supplies a provider-scoped token.

## Notes
- The Authorization header is no longer set statically on the shared `httpx.AsyncClient`; it's resolved per request via `token_resolver`.
- If the header is missing, unreadable, or the feature flag is off, behavior is identical to today (`CHECK_API_KEY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dqhXAENhbaf1Dyx9iqCVk