### PR TITLE
Migrate tax election tools to new top-level endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,9 +391,9 @@ Pay schedules, benefits, post-tax deductions, company benefits, earning rates, e
 | `refund_payment` | POST | Refund a payment |
 | `cancel_payment` | POST | Cancel a payment |
 
-### Tax (33 tools)
+### Tax (28 tools)
 
-Tax parameters, elections, filings, exempt status, exemptible taxes, statements, packages, and tax reference data.
+Tax parameters, elections (including tax exemptions), filings, statements, packages, and tax reference data.
 
 | Tool | Method | Description |
 |---|---|---|
@@ -413,24 +413,17 @@ Tax parameters, elections, filings, exempt status, exemptible taxes, statements,
 | `bulk_get_employee_tax_param_settings` | POST | Bulk get tax param settings |
 | `bulk_update_employee_tax_param_settings` | POST | Bulk update tax param settings |
 | **Company Tax Elections** | | |
-| `list_company_tax_elections` | GET | List tax elections for a company |
+| `list_company_tax_elections` | GET | List tax elections (exemption settings); filter by company, tax, exemptible, jurisdiction |
 | `create_company_tax_elections` | POST | Create company tax elections |
-| `update_company_tax_elections` | PATCH | Update company tax elections |
+| `update_company_tax_elections` | PATCH | Update company tax elections (incl. exemptions) |
 | **Employee Tax Elections** | | |
-| `list_employee_tax_elections` | GET | List tax elections for an employee |
-| `update_employee_tax_elections` | PATCH | Update employee tax elections |
+| `list_employee_tax_elections` | GET | List tax elections (exemption settings); filter by employee, company, tax, exemptible, jurisdiction |
+| `update_employee_tax_elections` | PATCH | Update employee tax elections (incl. exemptions) |
 | **Filings** | | |
 | `list_filings` | GET | List tax filings |
 | `get_filing` | GET | Get a specific tax filing |
 | `add_filing_blockers` | POST | Add blockers to a filing |
 | `remove_filing_blockers` | POST | Remove blockers from a filing |
-| **Exempt Status** | | |
-| `get_exempt_status` | GET | Get exempt status for an employee |
-| `update_exempt_status` | PATCH | Update exempt status |
-| **Exemptible Taxes** | | |
-| `list_exemptible_taxes` | GET | List exemptible taxes |
-| `update_exemptible_tax` | PATCH | Update an exemptible tax |
-| `bulk_update_exemptible_taxes` | PATCH | Bulk update exemptible taxes |
 | **Employee Tax Statements** | | |
 | `list_employee_tax_statements` | GET | List employee tax statements |
 | `get_employee_tax_statement` | GET | Get a specific tax statement |

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -235,7 +235,7 @@ async def check_api_get(ctx: Ctx, path: str, params: dict | None = None) -> dict
     return await _check_api_request(ctx, "GET", path, params=params)
 
 
-async def check_api_post(ctx: Ctx, path: str, data: dict | None = None) -> dict:
+async def check_api_post(ctx: Ctx, path: str, data: dict | list | None = None) -> dict:
     """Make a POST request to the Check API."""
     return await _check_api_request(ctx, "POST", path, data=data)
 

--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -284,50 +284,64 @@ async def bulk_update_employee_tax_param_settings(ctx: Ctx, data: dict) -> dict:
 
 async def list_company_tax_elections(
     ctx: Ctx,
-    company_id: str,
-    limit: int | None = None,
-    cursor: str | None = None,
+    company: str | None = None,
+    tax: str | None = None,
+    as_of: str | None = None,
+    exemptible: bool | None = None,
+    jurisdiction: str | None = None,
 ) -> dict:
-    """List tax elections for a company.
+    """List tax elections (exemption settings) for company-paid taxes.
+
+    Tax elections replace the former exempt status and exemptible taxes
+    endpoints. Each election has an ``exemptible`` flag and a ``setting``
+    object holding the current ``exempt`` value and its effective dates.
 
     Args:
-        company_id: The Check company ID.
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
+        company: Filter to this Check company ID (e.g. "com_xxxxx").
+        tax: Filter to this Check tax ID (e.g. "tax_xxxxx").
+        as_of: Return elections applicable on this date (defaults to today).
+        exemptible: If true, only return taxes that qualify for exemption.
+        jurisdiction: Filter by region code (e.g. "fed", "ny", "pa").
     """
     return await check_api_list(
         ctx,
-        f"/companies/{company_id}/tax_elections",
-        params=build_params(limit=limit, cursor=cursor),
+        "/company_tax_elections",
+        params=build_params(
+            company=company,
+            tax=tax,
+            as_of=as_of,
+            exemptible=exemptible,
+            jurisdiction=jurisdiction,
+        ),
     )
 
 
-async def create_company_tax_elections(ctx: Ctx, company_id: str, data: dict) -> dict:
+async def create_company_tax_elections(ctx: Ctx, data: list[dict]) -> dict:
     """Create tax elections for a company.
 
-    The payload is a complex nested structure — pass the full request body as a dict.
+    The request body is a JSON array of tax elections. Each item requires
+    ``id`` (the ``txe_*`` tax election ID) and ``company`` (the ``com_*``
+    company ID), plus a ``setting`` object with ``exempt`` (bool),
+    ``effective_start`` (date), and optionally ``effective_end`` (date).
 
     Args:
-        company_id: The Check company ID.
-        data: Tax election data.
+        data: List of tax elections to create.
     """
-    return await check_api_post(
-        ctx, f"/companies/{company_id}/tax_elections", data=data
-    )
+    return await check_api_post(ctx, "/company_tax_elections", data=data)
 
 
-async def update_company_tax_elections(ctx: Ctx, company_id: str, data: dict) -> dict:
-    """Update tax elections for a company.
+async def update_company_tax_elections(ctx: Ctx, data: list[dict]) -> dict:
+    """Update tax elections (exemption settings) for a company.
 
-    The payload is a complex nested structure — pass the full request body as a dict.
+    The request body is a JSON array of tax election updates. Each item
+    requires ``id`` (the ``txe_*`` tax election ID) and ``company`` (the
+    ``com_*`` company ID), plus a ``setting`` object with ``exempt`` (bool),
+    ``effective_start`` (date), and optionally ``effective_end`` (date).
 
     Args:
-        company_id: The Check company ID.
-        data: Tax election fields to update.
+        data: List of tax election updates.
     """
-    return await check_api_patch(
-        ctx, f"/companies/{company_id}/tax_elections", data=data
-    )
+    return await check_api_patch(ctx, "/company_tax_elections", data=data)
 
 
 # --- Employee Tax Elections ---
@@ -335,36 +349,53 @@ async def update_company_tax_elections(ctx: Ctx, company_id: str, data: dict) ->
 
 async def list_employee_tax_elections(
     ctx: Ctx,
-    employee_id: str,
-    limit: int | None = None,
-    cursor: str | None = None,
+    employee: str | None = None,
+    company: str | None = None,
+    tax: str | None = None,
+    as_of: str | None = None,
+    exemptible: bool | None = None,
+    jurisdiction: str | None = None,
 ) -> dict:
-    """List tax elections for an employee.
+    """List tax elections (exemption settings) for employee-paid taxes.
+
+    Tax elections replace the former per-employee exempt status endpoint.
+    Each election has an ``exemptible`` flag and a ``setting`` object holding
+    the current ``exempt`` value and its effective dates.
 
     Args:
-        employee_id: The Check employee ID.
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
+        employee: Filter to this Check employee ID (e.g. "emp_xxxxx").
+        company: Filter to this Check company ID (e.g. "com_xxxxx").
+        tax: Filter to this Check tax ID (e.g. "tax_xxxxx").
+        as_of: Return elections applicable on this date (defaults to today).
+        exemptible: If true, only return taxes that qualify for exemption.
+        jurisdiction: Filter by region code (e.g. "fed", "ny", "pa").
     """
     return await check_api_list(
         ctx,
-        f"/employees/{employee_id}/tax_elections",
-        params=build_params(limit=limit, cursor=cursor),
+        "/employee_tax_elections",
+        params=build_params(
+            employee=employee,
+            company=company,
+            tax=tax,
+            as_of=as_of,
+            exemptible=exemptible,
+            jurisdiction=jurisdiction,
+        ),
     )
 
 
-async def update_employee_tax_elections(ctx: Ctx, employee_id: str, data: dict) -> dict:
-    """Update tax elections for an employee.
+async def update_employee_tax_elections(ctx: Ctx, data: list[dict]) -> dict:
+    """Update tax elections (exemption settings) for an employee.
 
-    The payload is a complex nested structure — pass the full request body as a dict.
+    The request body is a JSON array of tax election updates. Each item
+    requires ``id`` (the ``txe_*`` tax election ID) and ``employee`` (the
+    ``emp_*`` employee ID), plus a ``setting`` object with ``exempt`` (bool),
+    ``effective_start`` (date), and optionally ``effective_end`` (date).
 
     Args:
-        employee_id: The Check employee ID.
-        data: Tax election fields to update.
+        data: List of tax election updates.
     """
-    return await check_api_patch(
-        ctx, f"/employees/{employee_id}/tax_elections", data=data
-    )
+    return await check_api_patch(ctx, "/employee_tax_elections", data=data)
 
 
 # --- Filings ---
@@ -444,78 +475,6 @@ async def remove_filing_blockers(ctx: Ctx, filing_id: str, data: dict) -> dict:
         data: Request body with blocked_reasons to remove (e.g. {"blocked_reasons": ["held_by_customer"]}).
     """
     return await check_api_post(ctx, f"/filings/{filing_id}/remove_blockers", data=data)
-
-
-# --- Exempt Status ---
-
-
-async def get_exempt_status(ctx: Ctx, employee_id: str) -> dict:
-    """Get exempt status for an employee.
-
-    Args:
-        employee_id: The Check employee ID.
-    """
-    return await check_api_get(ctx, f"/employees/{employee_id}/exempt_status")
-
-
-async def update_exempt_status(ctx: Ctx, employee_id: str, data: dict) -> dict:
-    """Update exempt status for an employee.
-
-    The payload is a complex structure — pass the full request body as a dict.
-
-    Args:
-        employee_id: The Check employee ID.
-        data: Exempt status fields to update.
-    """
-    return await check_api_patch(
-        ctx, f"/employees/{employee_id}/exempt_status", data=data
-    )
-
-
-# --- Exemptible Taxes ---
-
-
-async def list_exemptible_taxes(
-    ctx: Ctx,
-    company: str | None = None,
-    limit: int | None = None,
-    cursor: str | None = None,
-) -> dict:
-    """List exemptible taxes, optionally filtered by company.
-
-    Args:
-        company: Filter to exemptible taxes belonging to this Check company ID (e.g. "com_xxxxx").
-        limit: Maximum number of results to return.
-        cursor: Pagination cursor.
-    """
-    return await check_api_list(
-        ctx,
-        "/exemptible_taxes",
-        params=build_params(company=company, limit=limit, cursor=cursor),
-    )
-
-
-async def update_exemptible_tax(ctx: Ctx, tax_id: str, data: dict) -> dict:
-    """Update an exemptible tax.
-
-    The payload is a complex structure — pass the full request body as a dict.
-
-    Args:
-        tax_id: The exemptible tax ID.
-        data: Fields to update.
-    """
-    return await check_api_patch(ctx, f"/exemptible_taxes/{tax_id}", data=data)
-
-
-async def bulk_update_exemptible_taxes(ctx: Ctx, data: dict) -> dict:
-    """Bulk update exemptible taxes.
-
-    The payload is a complex bulk structure — pass the full request body as a dict.
-
-    Args:
-        data: Bulk update payload.
-    """
-    return await check_api_patch(ctx, "/exemptible_taxes", data=data)
 
 
 # --- Employee Tax Statements ---
@@ -662,10 +621,6 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     # Filings
     add_annotated_tool(mcp, list_filings)
     add_annotated_tool(mcp, get_filing)
-    # Exempt Status
-    add_annotated_tool(mcp, get_exempt_status)
-    # Exemptible Taxes
-    add_annotated_tool(mcp, list_exemptible_taxes)
     # Employee Tax Statements
     add_annotated_tool(mcp, list_employee_tax_statements)
     add_annotated_tool(mcp, get_employee_tax_statement)
@@ -683,7 +638,4 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
         add_annotated_tool(mcp, update_employee_tax_elections)
         add_annotated_tool(mcp, add_filing_blockers)
         add_annotated_tool(mcp, remove_filing_blockers)
-        add_annotated_tool(mcp, update_exempt_status)
-        add_annotated_tool(mcp, update_exemptible_tax)
-        add_annotated_tool(mcp, bulk_update_exemptible_taxes)
         add_annotated_tool(mcp, request_tax_package)

--- a/src/mcp_server_check/tools/workflows.py
+++ b/src/mcp_server_check/tools/workflows.py
@@ -244,7 +244,8 @@ async def get_company_tax_overview(
     if include_elections:
         calls["tax_elections"] = check_api_list(
             ctx,
-            f"/companies/{company_id}/tax_elections",
+            "/company_tax_elections",
+            params={"company": company_id},
         )
     if include_filings:
         calls["filings"] = check_api_list(

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
@@ -11,12 +13,14 @@ from mcp_server_check.tools.tax import (
     get_tax,
     list_company_tax_elections,
     list_company_tax_param_settings,
+    list_employee_tax_elections,
     list_employee_tax_param_settings,
     list_employee_tax_params,
     list_employee_tax_statements,
     list_filings,
     list_taxes,
     update_company_tax_params,
+    update_employee_tax_elections,
 )
 
 
@@ -54,14 +58,50 @@ async def test_list_employee_tax_params(mock_api, ctx):
 
 @pytest.mark.anyio
 async def test_list_company_tax_elections(mock_api, ctx):
-    mock_api.get("/companies/com_001/tax_elections").mock(
+    mock_api.get("/company_tax_elections").mock(
         return_value=httpx.Response(
             200,
-            json={"next": None, "previous": None, "results": [{"id": "te_001"}]},
+            json={"next": None, "previous": None, "results": [{"id": "txe_001"}]},
         )
     )
-    result = await list_company_tax_elections(ctx, company_id="com_001")
-    assert result["results"] == [{"id": "te_001"}]
+    result = await list_company_tax_elections(ctx, company="com_001")
+    assert result["results"] == [{"id": "txe_001"}]
+    req = mock_api.get("/company_tax_elections").calls.last.request
+    assert req.url.params["company"] == "com_001"
+
+
+@pytest.mark.anyio
+async def test_list_employee_tax_elections_with_filters(mock_api, ctx):
+    mock_api.get("/employee_tax_elections").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "txe_001"}]},
+        )
+    )
+    result = await list_employee_tax_elections(
+        ctx, employee="emp_123", exemptible=True, jurisdiction="fed"
+    )
+    assert result["results"] == [{"id": "txe_001"}]
+    req = mock_api.get("/employee_tax_elections").calls.last.request
+    assert req.url.params["employee"] == "emp_123"
+    assert req.url.params["exemptible"] == "true"
+    assert req.url.params["jurisdiction"] == "fed"
+    assert "as_of" not in req.url.params
+
+
+@pytest.mark.anyio
+async def test_update_employee_tax_elections(mock_api, ctx):
+    route = mock_api.patch("/employee_tax_elections").mock(
+        return_value=httpx.Response(200, json={"results": [{"id": "txe_001"}]})
+    )
+    election = {
+        "id": "txe_001",
+        "employee": "emp_123",
+        "setting": {"exempt": True, "effective_start": "2026-01-01"},
+    }
+    result = await update_employee_tax_elections(ctx, data=[election])
+    assert result["results"] == [{"id": "txe_001"}]
+    assert json.loads(route.calls.last.request.content) == [election]
 
 
 @pytest.mark.anyio

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -218,8 +218,8 @@ async def test_get_company_tax_overview(mock_api, ctx):
     mock_api.get("/company_tax_params/com_001").mock(
         return_value=httpx.Response(200, json={"id": "com_001", "params": []})
     )
-    mock_api.get("/companies/com_001/tax_elections").mock(
-        return_value=httpx.Response(200, json=_list_response([{"id": "ele_001"}]))
+    mock_api.get("/company_tax_elections").mock(
+        return_value=httpx.Response(200, json=_list_response([{"id": "txe_001"}]))
     )
     mock_api.get("/filings").mock(
         return_value=httpx.Response(
@@ -230,7 +230,7 @@ async def test_get_company_tax_overview(mock_api, ctx):
     result = await get_company_tax_overview(ctx, company_id="com_001")
 
     assert result["tax_params"]["id"] == "com_001"
-    assert result["tax_elections"]["results"][0]["id"] == "ele_001"
+    assert result["tax_elections"]["results"][0]["id"] == "txe_001"
     assert result["filings"]["results"][0]["id"] == "fil_001"
 
 


### PR DESCRIPTION
## Why

A Square developer [reported in Slack](https://checkpayroll.slack.com/archives/C0ASZMJPGBV/p1784839228064249) that the CLI gets HTTP 302s on `/employees/{id}/exempt_status`, `/exemptible_taxes`, and `/employees/{id}/tax_elections`. The Check API consolidated these into the new [Tax Elections API](https://docs.checkhq.com/reference/the-tax-election-object); the old routes were removed and unmatched paths 302-redirect to docs.checkhq.com (confirmed against the live sandbox and via sandbox API logs).

## What changed

- `list/create/update_company_tax_elections` → `GET/POST/PATCH /company_tax_elections`, `list/update_employee_tax_elections` → `GET/PATCH /employee_tax_elections`, with the new `company`/`employee`/`tax`/`as_of`/`exemptible`/`jurisdiction` filters and array-of-elections write payload (per the current OpenAPI spec)
- Removed `get/update_exempt_status` and `list/update/bulk_update_exemptible_taxes` — the API folded these into tax elections (`exemptible=true` filter; exemptions written via each election's `setting.exempt` + effective dates)
- `get_company_tax_overview` workflow now uses `/company_tax_elections?company=...`
- `check_api_post` accepts a list body; README and tests updated

## Testing

- Full suite passes (477 tests), ruff clean
- Verified end-to-end against the live sandbox through the real MCP server (stdio, dynamic mode) with an authenticated key:
  - `list_company_tax_elections` (with and without `exemptible=true`) → 200
  - `list_employee_tax_elections` → 200 (9 elections)
  - `update_employee_tax_elections` → 200; PATCH of `setting {exempt, effective_start}` on an exemptible election returned the updated object with the new `setting_timeline` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnpUjYLGuGjLB9iNFY4qL8