### PR TITLE
docs: note the check-api sync workflow as this environment's primary use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,26 @@ when a session starts. Run all commands through `uv run` (they execute inside `.
   and drive the in-memory server via `fastmcp`'s `Client(mcp)`.
 - `uv.lock` resolves `fastmcp` to a 3.x release even though `pyproject.toml` only pins
   `>=2.0.0`; use `uv sync --frozen` to stay consistent with CI.
+
+### Keeping this repo in sync with `check-api` (primary use of this environment)
+
+The main reason this environment pairs `mcp-server-check` with `check-api` is the
+**"Sync MCP Server & CLI"** workflow: when a change merges into `check-api`, decide whether it
+altered the **public** API surface (public serializers/views/routes — never `internal_api/`,
+`check/admin/`, or `/check-internal-admin-interface/`) and, if so, open a PR here that re-syncs
+the tool functions (which also regenerates the CLI). That workflow needs, and this environment
+provides:
+
+- **`check-api` checked out as a sibling** (default `/agent/repos/check-api-primary`) purely for
+  reading source and computing merge diffs (`git diff <base> <head>`). It does **not** need the
+  check-api Django/Postgres/webpack stack running — the classification is static (serializers,
+  views, `urls.py`, and `.cursor/rules/api-design-guidelines.mdc` for the back-compat call).
+- **Git write access to this repo** for branch + commit + push (base branch is `main`); PRs are
+  opened here and a human always reviews — never auto-merge.
+- **Slack** for the Phase 7 notification to **#api-docs** (`C01QLJECWUR`), tagging Ian
+  (`UN5UHR9HP`).
+
+Remember the CLI is generated from the tool functions (`cli/codegen.py`): editing a tool's
+signature + `Args:` docstring updates both the MCP schema and `uv run check <resource> <action>
+--help`. Response-only shape changes are usually a no-op here (responses pass through as raw
+dicts); the request surface (params/body/endpoints) is what drives edits.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a short, durable note to `AGENTS.md` capturing the **primary purpose** of this cloud environment: running the **"Sync MCP Server & CLI"** workflow that keeps `mcp-server-check` (and its generated CLI) in sync with public API changes merged into `check-api`.

This is a documentation-only change so future agents remember what the environment is for and which capabilities the workflow depends on.

## What the note records

- `check-api` is checked out as a **sibling** solely for reading source and computing merge diffs — the workflow's classification is **static** and does **not** require the check-api Django/Postgres/webpack stack to be running.
- This repo needs **git write** (branch + commit + push; base branch `main`); PRs are opened here for **human review** and never auto-merged.
- **Slack** is used for the Phase 7 notification to **#api-docs** (`C01QLJECWUR`), tagging Ian (`UN5UHR9HP`).
- Reminder that the CLI is generated from the tool functions, and that response-only shape changes are usually a no-op here.

## Verification

All prerequisites were exercised in the cloud environment before writing this note:

- `uv sync --frozen`, `uv run ruff check src/ tests/` (clean), `uv run pytest tests/` → **477 passed**.
- Generated CLI reflects tool signatures: `uv run check employees create --help` shows the expected flags.
- `uv run pre-commit run --files ...` passes (ruff check + format).
- `check-api` merge diff-gate produces `NO_PUBLIC_API_CHANGE` on recent infra/behavioral merges.
- Branch + commit + push to this repo confirmed (throwaway branch pushed and deleted).
- Slack `#api-docs` and the Ian user id resolve (no message sent).

## Please verify

- [ ] The description of the sync workflow's environment needs is accurate for your team's process.
- [ ] `#api-docs` channel id and the tagged user id are correct.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8a2f453-08e4-4a71-8064-62038bf645c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8a2f453-08e4-4a71-8064-62038bf645c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

