### PR TITLE
feat(logs): add id filter to list_logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Pay schedules, benefits, post-tax deductions, company benefits, earning rates, e
 
 | Tool | Method | Description |
 |---|---|---|
-| `list_logs` | GET | List API request logs; filter by path, method, status code/class, idempotency key, and time range |
+| `list_logs` | GET | List API request logs; filter by path, method, status code/class, log ID, idempotency key, and time range |
 | `get_log` | GET | Get the full record for a single API request log |
 
 ### Payments (6 tools)

--- a/src/mcp_server_check/tools/logs.py
+++ b/src/mcp_server_check/tools/logs.py
@@ -20,6 +20,7 @@ async def list_logs(
     path: str | None = None,
     method: list[str] | None = None,
     status_code: list[str] | None = None,
+    id: list[str] | None = None,
     idempotency_key: str | None = None,
     created_after: str | None = None,
     created_before: str | None = None,
@@ -42,6 +43,8 @@ async def list_logs(
         status_code: Filter by exact status code(s) and/or class(es). Accepts
             exact codes ("404") and the classes "2xx", "3xx", "4xx", "5xx".
             Multiple values are OR'd, so ["4xx", "500"] returns all 4xx plus 500.
+        id: Filter to specific log IDs (e.g. ["log_xxxxx"]). Repeated values
+            are OR'd.
         idempotency_key: Filter to requests sent with this idempotency key.
         created_after: ISO-8601 datetime lower bound on created_at (inclusive),
             e.g. "2026-06-01T00:00:00Z".
@@ -56,6 +59,7 @@ async def list_logs(
             path=path,
             method=method,
             status_code=status_code,
+            id=id,
             idempotency_key=idempotency_key,
             created_after=created_after,
             created_before=created_before,

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -59,6 +59,21 @@ async def test_list_logs_status_class_filter(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_logs_id_filter(mock_api, ctx):
+    route = mock_api.get("/logs").mock(
+        return_value=httpx.Response(
+            200, json={"next": None, "previous": None, "results": []}
+        )
+    )
+    await list_logs(ctx, id=["log_abc", "log_def"])
+    # Multi-value filters are sent as repeated params, not comma-joined.
+    assert route.calls[0].request.url.params.get_list("id") == [
+        "log_abc",
+        "log_def",
+    ]
+
+
+@pytest.mark.anyio
 async def test_list_logs_multi_method_and_time_range(mock_api, ctx):
     route = mock_api.get("/logs").mock(
         return_value=httpx.Response(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Syncs `list_logs` with [check-api PR #8583](https://github.com/check-technologies/check-api-primary/pull/8583), which added an optional `id` query param to `GET /logs` for filtering to specific log IDs (repeated `?id=log_xxx`, OR'd).

## Changes

- **`list_logs`**: add optional `id: list[str] | None` parameter, passed through to the API as repeated `id` query params
- **Tests**: assert multi-value `id` serialization (repeated params, not comma-joined)
- **README**: document the new filter on the logs toolset table

## Backwards compatibility

Backwards-compatible — new optional query param only.

## Verification

- `uv run pytest tests/test_logs.py` — pass
- `uv run pytest tests/` — 478 passed
- `uv run check logs list --help` — shows `--id CSV`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb9735bd-3a00-435d-9397-33888c891544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb9735bd-3a00-435d-9397-33888c891544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

