### PR TITLE
feat(external_payrolls): add include_items filter to list_external_payrolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Then set the `CHECK_API_KEY` environment variable in your shell before running C
 
 | Tool | Method | Description |
 |---|---|---|
-| `list_external_payrolls` | GET | List external payrolls |
+| `list_external_payrolls` | GET | List external payrolls; optionally omit line items with `include_items=false` |
 | `get_external_payroll` | GET | Get details for a specific external payroll |
 | `create_external_payroll` | POST | Create a new external payroll |
 | `update_external_payroll` | PATCH | Update an external payroll |
@@ -377,7 +377,7 @@ Pay schedules, benefits, post-tax deductions, company benefits, earning rates, e
 
 | Tool | Method | Description |
 |---|---|---|
-| `list_logs` | GET | List API request logs; filter by path, method, status code/class, idempotency key, and time range |
+| `list_logs` | GET | List API request logs; filter by path, method, status code/class, log ID, idempotency key, and time range |
 | `get_log` | GET | Get the full record for a single API request log |
 
 ### Payments (6 tools)

--- a/src/mcp_server_check/tools/external_payrolls.py
+++ b/src/mcp_server_check/tools/external_payrolls.py
@@ -22,6 +22,7 @@ async def list_external_payrolls(
     ids: list[str] | None = None,
     cursor: str | None = None,
     pay_schedule: str | None = None,
+    include_items: bool | None = None,
 ) -> dict:
     """List external payrolls, optionally filtered by company.
 
@@ -31,6 +32,8 @@ async def list_external_payrolls(
         ids: Filter to specific external payroll IDs.
         cursor: Pagination cursor from a previous response.
         pay_schedule: Filter by pay schedule ID.
+        include_items: When false, omit payroll line items from list responses
+            (faster for large companies). Items are included by default.
     """
     params: dict = {}
     if company is not None:
@@ -43,6 +46,8 @@ async def list_external_payrolls(
         params["cursor"] = cursor
     if pay_schedule is not None:
         params["pay_schedule"] = pay_schedule
+    if include_items is not None:
+        params["include_items"] = str(include_items).lower()
     return await check_api_list(ctx, "/external_payrolls", params=params or None)
 
 

--- a/tests/test_external_payrolls.py
+++ b/tests/test_external_payrolls.py
@@ -34,12 +34,13 @@ async def test_list_external_payrolls_with_filters(mock_api, ctx):
         )
     )
     result = await list_external_payrolls(
-        ctx, company="com_123", pay_schedule="psc_456"
+        ctx, company="com_123", pay_schedule="psc_456", include_items=False
     )
     assert result["results"] == [{"id": "ep_001"}]
     req = mock_api.get("/external_payrolls").calls.last.request
     assert req.url.params["company"] == "com_123"
     assert req.url.params["pay_schedule"] == "psc_456"
+    assert req.url.params["include_items"] == "false"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Syncs `list_external_payrolls` with [check-api PR #8963](https://github.com/check-technologies/check-api-primary/pull/8963), which added an optional `include_items` query param to `GET /external_payrolls`. When `include_items=false`, list responses omit embedded line items for faster responses on large companies. Items remain included by default (backwards-compatible).

## Changes

- **`list_external_payrolls`**: add optional `include_items: bool | None` parameter, serialized as `true`/`false`
- **Tests**: assert `include_items=false` is forwarded in the existing filters test
- **README**: document the new filter on the external payrolls toolset table

## Backwards compatibility

Backwards-compatible — new optional query param only; default behavior (items included) is unchanged.

## Verification

- `uv run pytest tests/test_external_payrolls.py` — pass
- `uv run pytest tests/` — 477 passed
- `uv run check external-payrolls list --help` — shows `--include-items / --no-include-items`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb9735bd-3a00-435d-9397-33888c891544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb9735bd-3a00-435d-9397-33888c891544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

