### PR TITLE
feat(companies): add include_contractor_id to get_company_report

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ Then set the `CHECK_API_KEY` environment variable in your shell before running C
 | `get_company_paydays` | GET | Get upcoming paydays for a company |
 | `list_company_tax_deposits` | GET | List tax deposits for a company |
 | `get_company_benefit_aggregations` | GET | Get benefit aggregations for a company |
-| `get_payroll_journal_report` | GET | Get payroll journal report |
-| `get_payroll_summary_report` | GET | Get payroll summary report |
+| `get_payroll_journal_report` | GET | Get payroll journal report; optional `include_contractor_id` for CSV |
+| `get_payroll_summary_report` | GET | Get payroll summary report; optional `include_contractor_id` for CSV |
 | `get_tax_liabilities_report` | GET | Get tax liabilities report |
 | `get_contractor_payments_report` | GET | Get contractor payments report |
 | `get_child_support_payments_report` | GET | Get child support payments report |
@@ -268,7 +268,7 @@ Then set the `CHECK_API_KEY` environment variable in your shell before running C
 
 | Tool | Method | Description |
 |---|---|---|
-| `list_external_payrolls` | GET | List external payrolls |
+| `list_external_payrolls` | GET | List external payrolls; optionally omit line items with `include_items=false` |
 | `get_external_payroll` | GET | Get details for a specific external payroll |
 | `create_external_payroll` | POST | Create a new external payroll |
 | `update_external_payroll` | PATCH | Update an external payroll |
@@ -377,7 +377,7 @@ Pay schedules, benefits, post-tax deductions, company benefits, earning rates, e
 
 | Tool | Method | Description |
 |---|---|---|
-| `list_logs` | GET | List API request logs; filter by path, method, status code/class, idempotency key, and time range |
+| `list_logs` | GET | List API request logs; filter by path, method, status code/class, log ID, idempotency key, and time range |
 | `get_log` | GET | Get the full record for a single API request log |
 
 ### Payments (6 tools)

--- a/src/mcp_server_check/tools/companies.py
+++ b/src/mcp_server_check/tools/companies.py
@@ -294,6 +294,7 @@ async def get_company_report(
     start_date: str | None = None,
     end_date: str | None = None,
     year: str | None = None,
+    include_contractor_id: bool | None = None,
 ) -> dict:
     """Get a report for a company.
 
@@ -306,6 +307,8 @@ async def get_company_report(
             payroll_summary, tax_liabilities, contractor_payments, child_support_payments.
         end_date: Report end date (YYYY-MM-DD). Required for the same reports as start_date.
         year: Tax year (e.g. "2025"). Required for w2_preview.
+        include_contractor_id: For payroll_journal and payroll_summary reports,
+            include the Contractor ID column in CSV output.
     """
     if report_type not in COMPANY_REPORT_TYPES:
         return {
@@ -318,7 +321,12 @@ async def get_company_report(
     return await check_api_get(
         ctx,
         f"/companies/{company_id}/reports/{report_type}",
-        params=build_params(start_date=start_date, end_date=end_date, year=year),
+        params=build_params(
+            start_date=start_date,
+            end_date=end_date,
+            year=year,
+            include_contractor_id=include_contractor_id,
+        ),
     )
 
 

--- a/tests/test_companies.py
+++ b/tests/test_companies.py
@@ -99,9 +99,11 @@ async def test_get_company_report_with_dates(mock_api, ctx):
         report_type="payroll_journal",
         start_date="2026-01-01",
         end_date="2026-01-31",
+        include_contractor_id=True,
     )
     assert result["report"] == "data"
     assert "start_date=2026-01-01" in str(route.calls[0].request.url)
+    assert route.calls[0].request.url.params["include_contractor_id"] == "true"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Syncs `get_company_report` with [check-api PR #9037](https://github.com/check-technologies/check-api-primary/pull/9037), which added an optional `include_contractor_id` query param to payroll journal and payroll summary company reports. When `true`, CSV output includes a Contractor ID column.

## Changes

- **`get_company_report`**: add optional `include_contractor_id: bool | None` parameter, passed through to the API as `include_contractor_id=true|false`
- **Tests**: assert `include_contractor_id=true` serialization in the payroll journal report test
- **README**: document the new option on payroll journal and payroll summary report rows

## Backwards compatibility

Backwards-compatible — new optional query param only; default behavior is unchanged.

## Verification

- `uv run pytest tests/test_companies.py` — pass
- `uv run pytest tests/` — 477 passed
- `uv run check companies get-report --help` — shows `--include-contractor-id / --no-include-contractor-id`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb9735bd-3a00-435d-9397-33888c891544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb9735bd-3a00-435d-9397-33888c891544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

