### PR TITLE
feat(tax): add limit/cursor pagination to tax election list tools

### DIFF
--- a/src/mcp_server_check/tools/tax.py
+++ b/src/mcp_server_check/tools/tax.py
@@ -289,6 +289,8 @@ async def list_company_tax_elections(
     as_of: str | None = None,
     exemptible: bool | None = None,
     jurisdiction: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
     """List tax elections (exemption settings) for company-paid taxes.
 
@@ -296,12 +298,19 @@ async def list_company_tax_elections(
     endpoints. Each election has an ``exemptible`` flag and a ``setting``
     object holding the current ``exempt`` value and its effective dates.
 
+    Results are paginated. When ``next`` is non-null in the response, pass it
+    back as ``cursor`` to fetch the following page — required to enumerate
+    companies with many elections (e.g. heavy PA/OH local tax exposure), which
+    span more than one page.
+
     Args:
         company: Filter to this Check company ID (e.g. "com_xxxxx").
         tax: Filter to this Check tax ID (e.g. "tax_xxxxx").
         as_of: Return elections applicable on this date (defaults to today).
         exemptible: If true, only return taxes that qualify for exemption.
         jurisdiction: Filter by region code (e.g. "fed", "ny", "pa").
+        limit: Maximum number of results to return per page.
+        cursor: Pagination cursor from a previous response's ``next`` field.
     """
     return await check_api_list(
         ctx,
@@ -312,6 +321,8 @@ async def list_company_tax_elections(
             as_of=as_of,
             exemptible=exemptible,
             jurisdiction=jurisdiction,
+            limit=limit,
+            cursor=cursor,
         ),
     )
 
@@ -355,12 +366,17 @@ async def list_employee_tax_elections(
     as_of: str | None = None,
     exemptible: bool | None = None,
     jurisdiction: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
 ) -> dict:
     """List tax elections (exemption settings) for employee-paid taxes.
 
     Tax elections replace the former per-employee exempt status endpoint.
     Each election has an ``exemptible`` flag and a ``setting`` object holding
     the current ``exempt`` value and its effective dates.
+
+    Results are paginated. When ``next`` is non-null in the response, pass it
+    back as ``cursor`` to fetch the following page.
 
     Args:
         employee: Filter to this Check employee ID (e.g. "emp_xxxxx").
@@ -369,6 +385,8 @@ async def list_employee_tax_elections(
         as_of: Return elections applicable on this date (defaults to today).
         exemptible: If true, only return taxes that qualify for exemption.
         jurisdiction: Filter by region code (e.g. "fed", "ny", "pa").
+        limit: Maximum number of results to return per page.
+        cursor: Pagination cursor from a previous response's ``next`` field.
     """
     return await check_api_list(
         ctx,
@@ -380,6 +398,8 @@ async def list_employee_tax_elections(
             as_of=as_of,
             exemptible=exemptible,
             jurisdiction=jurisdiction,
+            limit=limit,
+            cursor=cursor,
         ),
     )
 

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -71,6 +71,24 @@ async def test_list_company_tax_elections(mock_api, ctx):
 
 
 @pytest.mark.anyio
+async def test_list_company_tax_elections_paginates(mock_api, ctx):
+    mock_api.get("/company_tax_elections").mock(
+        return_value=httpx.Response(
+            200,
+            json={"next": None, "previous": None, "results": [{"id": "txe_001"}]},
+        )
+    )
+    await list_company_tax_elections(
+        ctx, company="com_001", jurisdiction="pa", limit=100, cursor="abc123"
+    )
+    params = mock_api.get("/company_tax_elections").calls.last.request.url.params
+    assert params["company"] == "com_001"
+    assert params["jurisdiction"] == "pa"
+    assert params["limit"] == "100"
+    assert params["cursor"] == "abc123"
+
+
+@pytest.mark.anyio
 async def test_list_employee_tax_elections_with_filters(mock_api, ctx):
     mock_api.get("/employee_tax_elections").mock(
         return_value=httpx.Response(
@@ -79,13 +97,20 @@ async def test_list_employee_tax_elections_with_filters(mock_api, ctx):
         )
     )
     result = await list_employee_tax_elections(
-        ctx, employee="emp_123", exemptible=True, jurisdiction="fed"
+        ctx,
+        employee="emp_123",
+        exemptible=True,
+        jurisdiction="fed",
+        limit=50,
+        cursor="xyz789",
     )
     assert result["results"] == [{"id": "txe_001"}]
     req = mock_api.get("/employee_tax_elections").calls.last.request
     assert req.url.params["employee"] == "emp_123"
     assert req.url.params["exemptible"] == "true"
     assert req.url.params["jurisdiction"] == "fed"
+    assert req.url.params["limit"] == "50"
+    assert req.url.params["cursor"] == "xyz789"
     assert "as_of" not in req.url.params
 
 


### PR DESCRIPTION
## Summary

`list_company_tax_elections` and `list_employee_tax_elections` were the **only** list tools missing `limit`/`cursor` passthrough. Every call capped at 25 rows and returned a `next` cursor that there was no parameter to send back, so callers couldn't page past the first 25 results.

This blocks a real partner audit: for a company with heavy multi-state local tax exposure (PA EIT/LST, OH city/school district), a single company can span **hundreds** of tax elections across many jurisdictions. There was no way to enumerate them through the MCP — the reporting partner hit exactly this on a company with ~580 elections.

## Change

Add `limit` and `cursor` parameters to both tools and pass them through via `build_params` to the underlying `/company_tax_elections` and `/employee_tax_elections` endpoints, which already support cursor pagination. This mirrors the existing pattern in `list_company_tax_param_settings`, `list_filings`, `list_taxes`, etc., and makes the tools consistent with the README's promise (line 144) that *"all list tools support `limit` and `cursor` parameters."*

## Important nuance

The `/company_tax_elections` endpoint caps its page size at 25 (`CursorPagination.max_page_size = PAGE_SIZE = 25` in check-api), and DRF clamps any larger `limit` back down to 25. So **`cursor` — not a bigger `limit` — is what actually enables full enumeration.** Callers should follow the `next` value from each response to page through all results. `limit` is still accepted (it can shrink the page) and added here for consistency across tools.

## Testing

- `uv run pytest tests/` — **480 passed**
- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check src/ tests/` — clean
- Added `test_list_company_tax_elections_paginates` and extended the employee elections test to assert `limit`/`cursor` are forwarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)