### PR TITLE
feat(webhooks): add webhook delivery tools; remove broken bulk retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,9 @@ The counterparties Check files and remits to (IRS, state revenue departments). G
 | `update_webhook_config` | PATCH | Update a webhook configuration |
 | `delete_webhook_config` | DELETE | Delete a webhook configuration |
 | `ping_webhook_config` | POST | Send a test ping |
-| `retry_webhook_events` | POST | Retry failed webhook events |
+| `list_webhook_deliveries` | GET | List webhook deliveries with status + attempts |
+| `get_webhook_delivery` | GET | Get a webhook delivery |
+| `retry_webhook_delivery` | POST | Re-enqueue a webhook delivery (sandbox only) |
 
 ### Platform (29 tools)
 

--- a/src/mcp_server_check/helpers.py
+++ b/src/mcp_server_check/helpers.py
@@ -202,10 +202,13 @@ async def _check_api_request(
     path: str,
     params: dict | None = None,
     data: dict | list | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> dict:
     """Make a request to the Check API with shared error handling."""
     check_ctx = ctx.request_context.lifespan_context
     headers: dict[str, str] = {"User-Agent": check_ctx.user_agent}
+    if extra_headers:
+        headers.update(extra_headers)
     if check_ctx.token_resolver is not None:
         headers["Authorization"] = f"Bearer {check_ctx.token_resolver()}"
     try:
@@ -235,9 +238,14 @@ async def check_api_get(ctx: Ctx, path: str, params: dict | None = None) -> dict
     return await _check_api_request(ctx, "GET", path, params=params)
 
 
-async def check_api_post(ctx: Ctx, path: str, data: dict | list | None = None) -> dict:
+async def check_api_post(
+    ctx: Ctx,
+    path: str,
+    data: dict | list | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict:
     """Make a POST request to the Check API."""
-    return await _check_api_request(ctx, "POST", path, data=data)
+    return await _check_api_request(ctx, "POST", path, data=data, extra_headers=headers)
 
 
 async def check_api_patch(ctx: Ctx, path: str, data: dict | list) -> dict:

--- a/src/mcp_server_check/tool_index.py
+++ b/src/mcp_server_check/tool_index.py
@@ -101,7 +101,7 @@ _TOOLSET_DESCRIPTIONS: dict[str, str] = {
     "payrolls": "Create, preview, approve, and manage payroll runs. Includes sandbox simulation tools.",
     "platform": "Platform-level tools: notifications, communications, usage, integrations, accounting, setups, and requirements.",
     "tax": "Manage company and employee tax parameters, elections, filings, exemptions, and tax statements. Includes tax reference data (list_taxes/get_tax).",
-    "webhooks": "Create, update, delete, and test webhook configurations.",
+    "webhooks": "Create, update, delete, and test webhook configurations; inspect and retry webhook deliveries.",
     "workflows": "Composite tools that combine multiple API calls: company overview, employee snapshot, contractor snapshot, payroll details, payment diagnostics, tax overview, onboarding status.",
     "workplaces": "Create, update, and view company workplace locations.",
 }

--- a/src/mcp_server_check/tools/webhooks.py
+++ b/src/mcp_server_check/tools/webhooks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 from fastmcp import FastMCP
 
 from mcp_server_check.annotations import add_annotated_tool
@@ -93,24 +95,80 @@ async def ping_webhook_config(ctx: Ctx, webhook_config_id: str) -> dict:
     return await check_api_post(ctx, f"/webhook_configs/{webhook_config_id}/ping")
 
 
-async def retry_webhook_events(ctx: Ctx, data: dict) -> dict:
-    """Retry failed webhook events.
-
-    The payload structure varies — pass the full request body as a dict with
-    event IDs or filters.
+async def list_webhook_deliveries(
+    ctx: Ctx,
+    webhook_config: str | None = None,
+    company: str | None = None,
+    topic: str | None = None,
+    status: str | None = None,
+    created_after: str | None = None,
+    created_before: str | None = None,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict:
+    """List webhook deliveries — the webhooks Check generated for your provider,
+    newest first, with their delivery status and embedded delivery attempts.
 
     Args:
-        data: Retry configuration (event IDs or filters).
+        webhook_config: Filter to deliveries sent to this webhook config (e.g. "whc_xxxxx").
+        company: Filter to deliveries associated with this Check company ID (e.g. "com_xxxxx").
+        topic: Filter by webhook topic (e.g. "payroll", "employee"); invalid topics
+            return a validation error.
+        status: Filter by delivery status: "pending", "retrying", "delivered", or "failed".
+        created_after: ISO-8601 lower bound on when the delivery was created.
+        created_before: ISO-8601 upper bound on when the delivery was created.
+        limit: Maximum number of results to return (max 100).
+        cursor: Pagination cursor.
     """
-    return await check_api_post(ctx, "/webhook_events/retry", data=data)
+    return await check_api_list(
+        ctx,
+        "/webhook_deliveries",
+        params=build_params(
+            webhook_config=webhook_config,
+            company=company,
+            topic=topic,
+            status=status,
+            created_after=created_after,
+            created_before=created_before,
+            limit=limit,
+            cursor=cursor,
+        ),
+    )
+
+
+async def get_webhook_delivery(ctx: Ctx, webhook_delivery_id: str) -> dict:
+    """Get a webhook delivery, including its delivery status and the attempts
+    made to deliver it (a null attempt status_code means no HTTP response was
+    received — e.g. a timeout or TLS failure).
+
+    Args:
+        webhook_delivery_id: The Check webhook delivery ID (e.g. "whe_xxxxx").
+    """
+    return await check_api_get(ctx, f"/webhook_deliveries/{webhook_delivery_id}")
+
+
+async def retry_webhook_delivery(ctx: Ctx, webhook_delivery_id: str) -> dict:
+    """Re-enqueue a webhook delivery. Sandbox only — returns a 400 in the live
+    environment, where Check's automatic retry schedule handles redelivery.
+
+    Args:
+        webhook_delivery_id: The Check webhook delivery ID (e.g. "whe_xxxxx").
+    """
+    return await check_api_post(
+        ctx,
+        f"/webhook_deliveries/{webhook_delivery_id}/retry",
+        headers={"X-Idempotency-Key": str(uuid.uuid4())},
+    )
 
 
 def register(mcp: FastMCP, *, read_only: bool = False) -> None:
     add_annotated_tool(mcp, list_webhook_configs)
     add_annotated_tool(mcp, get_webhook_config)
+    add_annotated_tool(mcp, list_webhook_deliveries)
+    add_annotated_tool(mcp, get_webhook_delivery)
     if not read_only:
         add_annotated_tool(mcp, create_webhook_config)
         add_annotated_tool(mcp, update_webhook_config)
         add_annotated_tool(mcp, delete_webhook_config)
         add_annotated_tool(mcp, ping_webhook_config)
-        add_annotated_tool(mcp, retry_webhook_events)
+        add_annotated_tool(mcp, retry_webhook_delivery)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -8,8 +8,11 @@ import pytest
 from mcp_server_check.tools.webhooks import (
     create_webhook_config,
     delete_webhook_config,
+    get_webhook_delivery,
     list_webhook_configs,
+    list_webhook_deliveries,
     ping_webhook_config,
+    retry_webhook_delivery,
 )
 
 
@@ -48,3 +51,65 @@ async def test_ping_webhook_config(mock_api, ctx):
     )
     result = await ping_webhook_config(ctx, webhook_config_id="whc_001")
     assert result["success"] is True
+
+
+@pytest.mark.anyio
+async def test_list_webhook_deliveries(mock_api, ctx):
+    route = mock_api.get("/webhook_deliveries").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": "whe_001",
+                        "status": "delivered",
+                        "attempts": [
+                            {"status_code": 200, "created_at": "2026-08-01T00:00:00Z"}
+                        ],
+                    }
+                ],
+            },
+        )
+    )
+    result = await list_webhook_deliveries(
+        ctx,
+        webhook_config="whc_001",
+        status="delivered",
+        created_after="2026-08-01T00:00:00Z",
+    )
+    assert result["results"][0]["id"] == "whe_001"
+    params = route.calls.last.request.url.params
+    assert params["webhook_config"] == "whc_001"
+    assert params["status"] == "delivered"
+    assert params["created_after"] == "2026-08-01T00:00:00Z"
+
+
+@pytest.mark.anyio
+async def test_get_webhook_delivery(mock_api, ctx):
+    mock_api.get("/webhook_deliveries/whe_001").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "whe_001",
+                "status": "failed",
+                "attempts": [
+                    {"status_code": None, "created_at": "2026-08-01T00:00:00Z"}
+                ],
+            },
+        )
+    )
+    result = await get_webhook_delivery(ctx, webhook_delivery_id="whe_001")
+    assert result["status"] == "failed"
+    assert result["attempts"][0]["status_code"] is None
+
+
+@pytest.mark.anyio
+async def test_retry_webhook_delivery_sends_idempotency_key(mock_api, ctx):
+    route = mock_api.post("/webhook_deliveries/whe_001/retry").mock(
+        return_value=httpx.Response(202, json={"id": "whe_001", "status": "pending"})
+    )
+    result = await retry_webhook_delivery(ctx, webhook_delivery_id="whe_001")
+    assert result["id"] == "whe_001"
+    assert route.calls.last.request.headers.get("X-Idempotency-Key")


### PR DESCRIPTION
Completes the MCP piece of the webhook deliveries rollout (check-api-primary#9522; docs guide api-docs#108 calls out MCP availability).

## Added

- **list_webhook_deliveries** — filters (webhook_config, company, topic, status, created_after/created_before) documented in the docstring so agents can discover them, plus limit/cursor pagination.
- **get_webhook_delivery** — status + embedded attempts, with null-status_code semantics explained.
- **retry_webhook_delivery** — sandbox-only re-enqueue, write-gated (hidden in read-only mode), sends the required X-Idempotency-Key header. check_api_post grew an optional headers kwarg to support it.

## Removed

- **retry_webhook_events** — it POSTed to /webhook_events/retry, a bulk route that has never existed on the API (retry has always been per-event, and the legacy /webhook_events surface is being deleted). Any call to this tool has always failed.

## Also

- webhooks toolset description now mentions deliveries; README tool table updated.

## Testing

- uv run pytest tests/ — 483 passed (new: filter param assertions on list, null status_code on get, idempotency header on retry).
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)