### PR TITLE
Add money-movement and destructive category exclusions for a directory-safe profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ when a session starts. Run all commands through `uv run` (they execute inside `.
   otherwise). Defaults to stdio transport and "dynamic" tool mode (exposes 3 meta-tools:
   `search_tools`, `list_toolsets`, `run_tool`). Env knobs: `CHECK_TOOL_MODE=all` (legacy
   all-tools), `CHECK_TRANSPORT`, `CHECK_ENV` / `CHECK_API_BASE_URL`, `CHECK_READ_ONLY`,
-  `CHECK_TOOLSETS`, `CHECK_TOOLS`, `CHECK_EXCLUDE_TOOLS`.
+  `CHECK_TOOLSETS`, `CHECK_TOOLS`, `CHECK_EXCLUDE_TOOLS`, `CHECK_EXCLUDE_MONEY_MOVEMENT`,
+  `CHECK_EXCLUDE_DESTRUCTIVE`.
 - CLI: `uv run check ...` (see `CLI.md`). `check --help`, `check --version`, and
   `check init <target>` work without a key; any command that hits the API needs `CHECK_API_KEY`
   (passed via `--api-key` or env). Defaults to the **sandbox** environment.

--- a/CLI.md
+++ b/CLI.md
@@ -212,9 +212,13 @@ export CHECK_TOOLS=list_companies,get_company
 
 # Exclude specific tools
 export CHECK_EXCLUDE_TOOLS=delete_company,delete_employee
+
+# Exclude whole categories
+export CHECK_EXCLUDE_MONEY_MOVEMENT=1
+export CHECK_EXCLUDE_DESTRUCTIVE=1
 ```
 
-**Filtering precedence:** `CHECK_EXCLUDE_TOOLS` > `CHECK_READ_ONLY` > `CHECK_TOOLS` > `CHECK_TOOLSETS`.
+**Filtering precedence:** `CHECK_EXCLUDE_TOOLS` > `CHECK_EXCLUDE_MONEY_MOVEMENT` / `CHECK_EXCLUDE_DESTRUCTIVE` > `CHECK_READ_ONLY` > `CHECK_TOOLS` > `CHECK_TOOLSETS`.
 
 ## Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ CHECK_API_KEY=your-key uv run mcp-server-check
 | `CHECK_TOOLS` | No | — | Comma-separated allowlist of individual tool names |
 | `CHECK_EXCLUDE_TOOLS` | No | — | Comma-separated list of tool names to hide |
 | `CHECK_READ_ONLY` | No | — | Set to `1`, `true`, or `yes` to disable all write/mutating tools |
+| `CHECK_EXCLUDE_MONEY_MOVEMENT` | No | — | Set to `1`, `true`, or `yes` to remove tools that move funds or change funding/payout destinations |
+| `CHECK_EXCLUDE_DESTRUCTIVE` | No | — | Set to `1`, `true`, or `yes` to remove irreversible tools (delete, approve, cancel, refund, simulate) |
 | `CHECK_TRANSPORT` | No | `stdio` | Transport protocol: `stdio`, `sse`, or `streamable-http` |
 
 ### Sandbox vs Production
@@ -48,8 +50,10 @@ The server supports fine-grained tool filtering, configurable via environment va
 | Individual tools | `CHECK_TOOLS` | `X-MCP-Tools` |
 | Exclude tools | `CHECK_EXCLUDE_TOOLS` | `X-MCP-Exclude-Tools` |
 | Read-only | `CHECK_READ_ONLY` | `X-MCP-Readonly` |
+| Exclude money movement | `CHECK_EXCLUDE_MONEY_MOVEMENT` | `X-MCP-Exclude-Money-Movement` |
+| Exclude destructive | `CHECK_EXCLUDE_DESTRUCTIVE` | `X-MCP-Exclude-Destructive` |
 
-**Filtering precedence:** `exclude_tools` > `read_only` > `tools` > `toolsets`. Exclude always wins; if `tools` is set it acts as an allowlist independent of toolsets.
+**Filtering precedence:** `exclude_tools` > category exclusions (money movement, destructive) > `read_only` > `tools` > `toolsets`. Exclude always wins; category exclusions apply even to tools named in the `tools` allowlist; if `tools` is set it acts as an allowlist independent of toolsets.
 
 #### Toolsets
 
@@ -85,6 +89,20 @@ Set `CHECK_READ_ONLY=1` to run the server with only read-only tools (list, get, 
 CHECK_READ_ONLY=1 CHECK_API_KEY=your-key uv run mcp-server-check
 ```
 
+#### Category Exclusions
+
+Two flags remove whole categories of tools from a deployment. Unlike `CHECK_EXCLUDE_TOOLS`, they do not need updating as tools are added.
+
+`CHECK_EXCLUDE_MONEY_MOVEMENT=1` removes the tools that move funds or change where funds are drawn from and sent to: `approve_payroll`, `retry_payment`, `refund_payment`, `cancel_payment`, and `create`/`update`/`delete_bank_account`.
+
+`CHECK_EXCLUDE_DESTRUCTIVE=1` removes tools with irreversible effects — everything matching `delete_`, `bulk_delete_`, `approve_`, `cancel_`, `refund_`, `simulate_`, plus `start_implementation` and `cancel_implementation`.
+
+```bash
+CHECK_EXCLUDE_MONEY_MOVEMENT=1 CHECK_EXCLUDE_DESTRUCTIVE=1 CHECK_API_KEY=your-key uv run mcp-server-check
+```
+
+With both set, an agent can still prepare a payroll run (`create_payroll`, `create_payroll_item`, `create_contractor_payment`, `preview_payroll`) but cannot approve or disburse it, and cannot add or repoint a bank account. Excluded tools are hidden from `list_tools` and `search_tools`, and calling one directly returns an error before any API request is made.
+
 #### HTTP Headers (Remote Transport)
 
 When running with `CHECK_TRANSPORT=sse` or `CHECK_TRANSPORT=streamable-http`, clients can pass configuration via HTTP headers:
@@ -93,9 +111,11 @@ When running with `CHECK_TRANSPORT=sse` or `CHECK_TRANSPORT=streamable-http`, cl
 X-MCP-Toolsets: companies,employees
 X-MCP-Readonly: true
 X-MCP-Exclude-Tools: create_company,delete_company
+X-MCP-Exclude-Money-Movement: true
+X-MCP-Exclude-Destructive: true
 ```
 
-Header-based configuration takes precedence over environment variables when headers provide any filter settings.
+Header and environment settings are merged, taking the most restrictive value for each. A client can narrow what the server exposes but never widen it: if the server sets `CHECK_READ_ONLY=1` or a category exclusion, no header can turn it off.
 
 ### Dynamic Tool Mode (Default)
 

--- a/src/mcp_server_check/cli/__init__.py
+++ b/src/mcp_server_check/cli/__init__.py
@@ -29,12 +29,9 @@ def _build_filter(ctx: click.Context) -> ToolFilter:
     read_only = root.params.get("read_only", False) if root.params else False
     env_filter = ToolFilter.from_env()
     if read_only and not env_filter.read_only:
-        return ToolFilter(
-            toolsets=env_filter.toolsets,
-            tools=env_filter.tools,
-            exclude_tools=env_filter.exclude_tools,
-            read_only=True,
-        )
+        # Merge rather than rebuild field-by-field so filter fields added later
+        # are carried through automatically.
+        return env_filter.merge(ToolFilter(read_only=True))
     return env_filter
 
 

--- a/src/mcp_server_check/server.py
+++ b/src/mcp_server_check/server.py
@@ -226,7 +226,6 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
         ctx: Context,
         tool_name: str,
         arguments: str | dict | None = None,
-        confirm: bool = False,
     ) -> str:
         """Execute an API tool by name with the given arguments.
 
@@ -235,9 +234,6 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
         tool_name: The exact tool name (e.g. "list_companies", "get_employee").
         arguments: Tool arguments as a JSON string or dict (e.g. '{"company_id": "com_xxx"}'
             or {"company_id": "com_xxx"}).
-        confirm: Set to true to confirm execution of a destructive tool (approve,
-            delete, simulate, refund, cancel). Required when CHECK_CONFIRM_DESTRUCTIVE
-            is enabled and the tool is destructive.
         """
         tf = server._get_active_filter()
         parsed_args: dict = {}
@@ -255,20 +251,6 @@ def _setup_dynamic_mode(server: CheckMCP) -> None:
                 return json.dumps(
                     {"error": "Arguments must be a JSON string or object"}
                 )
-
-        if tf.requires_confirmation(tool_name) and not confirm:
-            return json.dumps(
-                {
-                    "confirmation_required": True,
-                    "tool_name": tool_name,
-                    "arguments": parsed_args,
-                    "message": (
-                        f"⚠️  '{tool_name}' is a destructive operation that may "
-                        f"trigger irreversible effects (money movement, data deletion, "
-                        f"etc.). Call run_tool again with confirm=true to proceed."
-                    ),
-                }
-            )
 
         try:
             result = await index.run(

--- a/src/mcp_server_check/tool_filter.py
+++ b/src/mcp_server_check/tool_filter.py
@@ -67,8 +67,8 @@ _WRITE_KEYWORDS = (
     "remove_",
 )
 
-# Tools that trigger irreversible real-world effects (money movement, deletion).
-# These require explicit confirmation when CHECK_CONFIRM_DESTRUCTIVE is enabled.
+# Tools that trigger irreversible real-world effects (deletion, approval, refunds).
+# CHECK_EXCLUDE_DESTRUCTIVE removes these from a deployment entirely.
 _DESTRUCTIVE_PREFIXES = (
     "approve_",
     "delete_",
@@ -84,6 +84,30 @@ _DESTRUCTIVE_EXACT = frozenset(
     }
 )
 
+# Tools that move funds or change where funds are drawn from / sent to.
+# CHECK_EXCLUDE_MONEY_MOVEMENT removes these from a deployment entirely.
+#
+# Matched by exact name rather than prefix: prefixes would sweep in unrelated
+# tools (retry_webhook_delivery) and read-only ones (list_payments), while
+# missing approve_payroll's real significance. tests/test_tool_drift.py asserts
+# every name here still exists and that no new money-path tool escapes
+# classification.
+_MONEY_MOVEMENT_EXACT = frozenset(
+    {
+        # Disburses a payroll: debits the company, credits workers.
+        "approve_payroll",
+        # Re-initiates, reverses, or halts an existing transfer.
+        "retry_payment",
+        "refund_payment",
+        "cancel_payment",
+        # Funding/payout destinations: adding or repointing a bank account
+        # reroutes where pay is drawn from or sent to.
+        "create_bank_account",
+        "update_bank_account",
+        "delete_bank_account",
+    }
+)
+
 
 def is_write_tool(name: str) -> bool:
     """Return True if the tool name matches a write/mutating pattern."""
@@ -93,14 +117,19 @@ def is_write_tool(name: str) -> bool:
 
 
 def is_destructive_tool(name: str) -> bool:
-    """Return True if the tool triggers irreversible effects (money movement, deletion).
+    """Return True if the tool triggers irreversible effects (deletion, approval).
 
-    These tools should require explicit confirmation when the confirmation
-    tier is enabled.
+    Also drives the ``destructiveHint`` MCP annotation (see annotations.py),
+    so changes here are visible to clients.
     """
     if name in _DESTRUCTIVE_EXACT:
         return True
     return any(name.startswith(p) for p in _DESTRUCTIVE_PREFIXES)
+
+
+def is_money_movement_tool(name: str) -> bool:
+    """Return True if the tool moves funds or changes a funding/payout destination."""
+    return name in _MONEY_MOVEMENT_EXACT
 
 
 def _parse_comma_set(value: str | None) -> frozenset[str] | None:
@@ -120,8 +149,11 @@ def _parse_bool(value: str | None) -> bool:
 class ToolFilter:
     """Immutable filter configuration for tool visibility.
 
-    Filtering precedence: exclude_tools > read_only > tools > toolsets.
+    Filtering precedence: exclude_tools > exclusion flags > read_only > tools
+    > toolsets.
     - exclude_tools always wins (tool is hidden).
+    - exclude_money_movement / exclude_destructive hide whole categories, and
+      apply even to tools named in the ``tools`` allowlist.
     - read_only hides write/mutating tools.
     - tools, when set, acts as an allowlist independent of toolsets.
     - toolsets, when set, limits tools to those in the named toolsets.
@@ -131,7 +163,8 @@ class ToolFilter:
     tools: frozenset[str] | None = None
     exclude_tools: frozenset[str] = frozenset()
     read_only: bool = False
-    confirm_destructive: bool = False
+    exclude_money_movement: bool = False
+    exclude_destructive: bool = False
 
     def __post_init__(self) -> None:
         if self.toolsets is not None:
@@ -146,6 +179,14 @@ class ToolFilter:
         """Determine whether a tool should be visible given this filter."""
         # Exclude always wins
         if tool_name in self.exclude_tools:
+            return False
+
+        # Category exclusions act as a policy floor: they are checked before
+        # the `tools` allowlist below, so an allowlisted tool stays hidden.
+        if self.exclude_money_movement and is_money_movement_tool(tool_name):
+            return False
+
+        if self.exclude_destructive and is_destructive_tool(tool_name):
             return False
 
         # Read-only hides write tools
@@ -194,12 +235,10 @@ class ToolFilter:
             tools=merged_tools,
             exclude_tools=self.exclude_tools | other.exclude_tools,
             read_only=self.read_only or other.read_only,
-            confirm_destructive=self.confirm_destructive or other.confirm_destructive,
+            exclude_money_movement=self.exclude_money_movement
+            or other.exclude_money_movement,
+            exclude_destructive=self.exclude_destructive or other.exclude_destructive,
         )
-
-    def requires_confirmation(self, tool_name: str) -> bool:
-        """Return True if this tool requires explicit confirmation before execution."""
-        return self.confirm_destructive and is_destructive_tool(tool_name)
 
     @classmethod
     def from_env(cls) -> ToolFilter:
@@ -210,8 +249,11 @@ class ToolFilter:
             exclude_tools=_parse_comma_set(os.environ.get("CHECK_EXCLUDE_TOOLS"))
             or frozenset(),
             read_only=_parse_bool(os.environ.get("CHECK_READ_ONLY")),
-            confirm_destructive=_parse_bool(
-                os.environ.get("CHECK_CONFIRM_DESTRUCTIVE")
+            exclude_money_movement=_parse_bool(
+                os.environ.get("CHECK_EXCLUDE_MONEY_MOVEMENT")
+            ),
+            exclude_destructive=_parse_bool(
+                os.environ.get("CHECK_EXCLUDE_DESTRUCTIVE")
             ),
         )
 
@@ -230,7 +272,8 @@ class ToolFilter:
             tools=_parse_comma_set(get("x-mcp-tools")),
             exclude_tools=_parse_comma_set(get("x-mcp-exclude-tools")) or frozenset(),
             read_only=_parse_bool(get("x-mcp-readonly")),
-            confirm_destructive=_parse_bool(get("x-mcp-confirm-destructive")),
+            exclude_money_movement=_parse_bool(get("x-mcp-exclude-money-movement")),
+            exclude_destructive=_parse_bool(get("x-mcp-exclude-destructive")),
         )
 
     @classmethod

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from fastmcp.exceptions import ToolError
 from mcp_server_check.helpers import (
     _extract_cursor,
     _format_list_response,
@@ -460,3 +461,63 @@ async def test_readonly_with_toolsets():
     assert "update_company" not in tool_names
     # Tools from other toolsets should also be excluded
     assert "list_employees" not in tool_names
+
+
+# --- Directory-safe profile (category exclusion flags) ---
+
+_DIRECTORY_SAFE = ToolFilter(exclude_money_movement=True, exclude_destructive=True)
+
+_EXCLUDED_ON_DIRECTORY = [
+    "approve_payroll",
+    "retry_payment",
+    "refund_payment",
+    "cancel_payment",
+    "create_bank_account",
+    "update_bank_account",
+    "delete_bank_account",
+    "delete_payroll",
+    "bulk_delete_payroll_items",
+]
+
+
+@pytest.mark.anyio
+async def test_directory_profile_hides_money_and_destructive_tools():
+    server = _make_all_tools_server(_DIRECTORY_SAFE)
+    tool_names = {t.name for t in await server.list_tools()}
+
+    for name in _EXCLUDED_ON_DIRECTORY:
+        assert name not in tool_names, f"'{name}' should be hidden"
+
+    # Payroll preparation stays available: agents can build a run, not disburse it.
+    for name in ("list_companies", "create_payroll", "create_payroll_item"):
+        assert name in tool_names, f"'{name}' should remain available"
+
+
+@pytest.mark.anyio
+async def test_directory_profile_blocks_execution():
+    """Hidden is not enough — calling the tool directly must fail too."""
+    server = _make_all_tools_server(_DIRECTORY_SAFE)
+    with pytest.raises(ToolError, match="not available in the current configuration"):
+        await server.call_tool("approve_payroll", {"payroll_id": "prl_test"})
+
+
+@pytest.mark.anyio
+async def test_directory_profile_hides_tools_from_search():
+    """Dynamic mode: excluded tools are absent from search_tools results."""
+    server = _make_dynamic_server(_DIRECTORY_SAFE)
+    result = await server.call_tool("search_tools", {"query": "approve payroll"})
+    payload = result.content[0].text
+
+    for name in _EXCLUDED_ON_DIRECTORY:
+        assert f'"{name}"' not in payload, f"'{name}' should not appear in search"
+
+
+@pytest.mark.anyio
+async def test_directory_profile_blocks_run_tool():
+    """Dynamic mode: run_tool refuses an excluded tool before any API call."""
+    server = _make_dynamic_server(_DIRECTORY_SAFE)
+    result = await server.call_tool(
+        "run_tool",
+        {"tool_name": "approve_payroll", "arguments": {"payroll_id": "prl_test"}},
+    )
+    assert "not available in the current configuration" in result.content[0].text

--- a/tests/test_tool_drift.py
+++ b/tests/test_tool_drift.py
@@ -1,0 +1,126 @@
+"""Guards against tool-classification drift.
+
+The Anthropic directory deployment relies on ``CHECK_EXCLUDE_MONEY_MOVEMENT``
+and ``CHECK_EXCLUDE_DESTRUCTIVE`` to keep fund-moving tools off that endpoint.
+Both flags classify tools by name, so a new tool with an unanticipated name
+would ship unclassified and reach the directory endpoint. These tests fail
+instead, forcing an explicit decision.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+from mcp_server_check.tool_filter import (
+    _MONEY_MOVEMENT_EXACT,
+    is_destructive_tool,
+    is_money_movement_tool,
+)
+from mcp_server_check.tools import collect_all_tools
+
+# Mutating Check API calls, e.g. ``check_api_post(ctx, f"/payments/{id}/retry")``.
+_MUTATING_CALL = re.compile(r"check_api_(post|patch|delete)\(")
+_LITERAL_PATH = re.compile(r'check_api_(?:post|patch|delete)\(\s*ctx,\s*f?"(/[^"]+)"')
+
+# API paths where a mutation moves funds or repoints where funds go.
+_MONEY_PATH = re.compile(r"^/(payments|bank_accounts)(/|$)")
+
+# Mutating money-path tools deliberately left available on every deployment.
+# Adding a name here is a policy decision, not a formality.
+_REVIEWED_AVAILABLE: frozenset[str] = frozenset()
+
+
+def _mutating_paths(fn) -> list[str]:
+    """Return the API paths a tool mutates, or [] if it only reads.
+
+    Hand-written tools carry the path as a literal in the call. Tools built by
+    ``generate_tools`` share a generic body, so the path arrives as a closure
+    cell instead.
+    """
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError):  # pragma: no cover - source always available
+        return []
+    if not _MUTATING_CALL.search(source):
+        return []
+    paths = _LITERAL_PATH.findall(source)
+    if not paths and fn.__closure__:
+        paths = [
+            cell.cell_contents
+            for cell in fn.__closure__
+            if isinstance(cell.cell_contents, str)
+            and cell.cell_contents.startswith("/")
+        ]
+    return paths
+
+
+def _all_tool_functions() -> list:
+    return [fn for fns in collect_all_tools().values() for fn in fns]
+
+
+def test_money_path_mutations_are_classified():
+    """Every tool that mutates a payments/bank-account endpoint is classified."""
+    unclassified = [
+        fn.__name__
+        for fn in _all_tool_functions()
+        if any(_MONEY_PATH.match(p) for p in _mutating_paths(fn))
+        and not is_money_movement_tool(fn.__name__)
+        and not is_destructive_tool(fn.__name__)
+        and fn.__name__ not in _REVIEWED_AVAILABLE
+    ]
+    assert not unclassified, (
+        "These tools mutate a money-related endpoint but are excluded by neither "
+        f"CHECK_EXCLUDE_MONEY_MOVEMENT nor CHECK_EXCLUDE_DESTRUCTIVE: {unclassified}. "
+        "Add them to _MONEY_MOVEMENT_EXACT, or to _REVIEWED_AVAILABLE with a rationale."
+    )
+
+
+def test_path_detection_finds_known_money_tools():
+    """The source-introspection above actually resolves paths (guards the guard)."""
+    detected = {
+        fn.__name__
+        for fn in _all_tool_functions()
+        if any(_MONEY_PATH.match(p) for p in _mutating_paths(fn))
+    }
+    assert {
+        "retry_payment",
+        "refund_payment",
+        "cancel_payment",
+        "create_bank_account",
+        "update_bank_account",
+        "delete_bank_account",
+    } <= detected
+
+
+def test_no_mutating_tool_has_an_unresolvable_path():
+    """A tool whose path can't be read would silently bypass the drift check."""
+    unresolvable = [
+        fn.__name__
+        for fn in _all_tool_functions()
+        if _MUTATING_CALL.search(inspect.getsource(fn)) and not _mutating_paths(fn)
+    ]
+    assert not unresolvable, (
+        "Could not determine which endpoint these tools mutate, so the money-path "
+        f"drift check cannot see them: {unresolvable}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_MONEY_MOVEMENT_EXACT))
+def test_money_movement_names_still_exist(name):
+    """A rename would silently empty the exclusion set."""
+    registered = {fn.__name__ for fn in _all_tool_functions()}
+    assert name in registered, (
+        f"'{name}' is in _MONEY_MOVEMENT_EXACT but no longer registered — it was "
+        "renamed or removed, and the exclusion no longer covers it."
+    )
+
+
+def test_approve_payroll_is_covered_despite_non_money_path():
+    """approve_payroll disburses funds but posts to /payrolls, not /payments.
+
+    The path heuristic cannot see it, which is why the exact set (guarded by
+    the rename test above) is the real protection.
+    """
+    assert is_money_movement_tool("approve_payroll")

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -10,6 +10,7 @@ from mcp_server_check.tool_filter import (
     TOOLSETS,
     ToolFilter,
     is_destructive_tool,
+    is_money_movement_tool,
     is_write_tool,
 )
 
@@ -177,18 +178,20 @@ class TestFromQueryParams:
         assert tf == ToolFilter()
 
     def test_only_read_only_is_parsed(self):
-        """Query params for other filter fields (toolsets, confirm_destructive, etc.) are ignored."""
+        """Query params for other filter fields (toolsets, exclusion flags, etc.) are ignored."""
         tf = ToolFilter.from_query_params(
             {
                 "read_only": "true",
-                "confirm_destructive": "true",
+                "exclude_money_movement": "true",
+                "exclude_destructive": "true",
                 "toolsets": "companies",
                 "tools": "list_companies",
                 "exclude_tools": "delete_company",
             }
         )
         assert tf.read_only is True
-        assert tf.confirm_destructive is False
+        assert tf.exclude_money_movement is False
+        assert tf.exclude_destructive is False
         assert tf.toolsets is None
         assert tf.tools is None
         assert tf.exclude_tools == frozenset()
@@ -318,33 +321,146 @@ class TestIsDestructiveTool:
         assert not is_destructive_tool(name), f"{name} should NOT be destructive"
 
 
-# --- requires_confirmation ---
+# --- is_money_movement_tool ---
 
 
-class TestRequiresConfirmation:
-    def test_no_confirmation_by_default(self):
+class TestIsMoneyMovementTool:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "approve_payroll",
+            "retry_payment",
+            "refund_payment",
+            "cancel_payment",
+            "create_bank_account",
+            "update_bank_account",
+            "delete_bank_account",
+        ],
+    )
+    def test_money_movement_detected(self, name):
+        assert is_money_movement_tool(name), f"{name} should be money movement"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # Reads that would match a naive *payment* substring rule
+            "list_payments",
+            "get_payment",
+            "list_payment_attempts",
+            "diagnose_payment",
+            "list_bank_accounts",
+            "get_bank_account",
+            # Prefix lookalikes that move no money
+            "retry_webhook_delivery",
+            "cancel_implementation",
+            "approve_external_payroll",
+            # Amount-shaping tools that cannot disburse on their own
+            "create_payroll",
+            "create_payroll_item",
+            "create_contractor_payment",
+            "create_net_pay_split",
+        ],
+    )
+    def test_not_money_movement(self, name):
+        assert not is_money_movement_tool(name), f"{name} should NOT be money movement"
+
+
+# --- category exclusion flags ---
+
+
+class TestExcludeMoneyMovement:
+    def test_disabled_by_default(self):
         tf = ToolFilter()
-        assert tf.requires_confirmation("approve_payroll") is False
+        assert tf.is_tool_allowed("approve_payroll", "payrolls") is True
 
-    def test_confirmation_when_enabled(self):
-        tf = ToolFilter(confirm_destructive=True)
-        assert tf.requires_confirmation("approve_payroll") is True
-        assert tf.requires_confirmation("delete_payroll") is True
+    def test_hides_money_movement_tools(self):
+        tf = ToolFilter(exclude_money_movement=True)
+        assert tf.is_tool_allowed("approve_payroll", "payrolls") is False
+        assert tf.is_tool_allowed("create_bank_account", "bank_accounts") is False
 
-    def test_no_confirmation_for_safe_tools(self):
-        tf = ToolFilter(confirm_destructive=True)
-        assert tf.requires_confirmation("list_companies") is False
-        assert tf.requires_confirmation("create_company") is False
+    def test_leaves_other_tools_visible(self):
+        tf = ToolFilter(exclude_money_movement=True)
+        assert tf.is_tool_allowed("list_companies", "companies") is True
+        assert tf.is_tool_allowed("create_payroll", "payrolls") is True
+        assert tf.is_tool_allowed("delete_payroll", "payrolls") is True
 
-    def test_from_env_confirm_destructive(self):
-        with mock.patch.dict(os.environ, {"CHECK_CONFIRM_DESTRUCTIVE": "true"}):
+    def test_overrides_tools_allowlist(self):
+        """Category exclusion is a floor: it beats an explicit allowlist."""
+        tf = ToolFilter(
+            tools=frozenset({"approve_payroll"}), exclude_money_movement=True
+        )
+        assert tf.is_tool_allowed("approve_payroll", "payrolls") is False
+
+    def test_from_env(self):
+        with mock.patch.dict(os.environ, {"CHECK_EXCLUDE_MONEY_MOVEMENT": "true"}):
             tf = ToolFilter.from_env()
-        assert tf.confirm_destructive is True
+        assert tf.exclude_money_movement is True
 
-    def test_from_headers_confirm_destructive(self):
-        headers = {"x-mcp-confirm-destructive": "1"}
-        tf = ToolFilter.from_headers(headers)
-        assert tf.confirm_destructive is True
+    def test_from_headers(self):
+        tf = ToolFilter.from_headers({"x-mcp-exclude-money-movement": "1"})
+        assert tf.exclude_money_movement is True
+
+
+class TestExcludeDestructive:
+    def test_disabled_by_default(self):
+        tf = ToolFilter()
+        assert tf.is_tool_allowed("delete_payroll", "payrolls") is True
+
+    def test_hides_destructive_tools(self):
+        tf = ToolFilter(exclude_destructive=True)
+        assert tf.is_tool_allowed("delete_payroll", "payrolls") is False
+        assert tf.is_tool_allowed("bulk_delete_payroll_items", "payroll_items") is False
+        assert tf.is_tool_allowed("cancel_implementation", "companies") is False
+
+    def test_leaves_other_writes_visible(self):
+        tf = ToolFilter(exclude_destructive=True)
+        assert tf.is_tool_allowed("create_payroll", "payrolls") is True
+        assert tf.is_tool_allowed("update_employee", "employees") is True
+
+    def test_overrides_tools_allowlist(self):
+        tf = ToolFilter(tools=frozenset({"delete_payroll"}), exclude_destructive=True)
+        assert tf.is_tool_allowed("delete_payroll", "payrolls") is False
+
+    def test_from_env(self):
+        with mock.patch.dict(os.environ, {"CHECK_EXCLUDE_DESTRUCTIVE": "true"}):
+            tf = ToolFilter.from_env()
+        assert tf.exclude_destructive is True
+
+    def test_from_headers(self):
+        tf = ToolFilter.from_headers({"x-mcp-exclude-destructive": "1"})
+        assert tf.exclude_destructive is True
+
+
+class TestDirectorySafeProfile:
+    """Both flags together — the Anthropic directory deployment profile."""
+
+    def test_money_and_destructive_tools_hidden(self):
+        tf = ToolFilter(exclude_money_movement=True, exclude_destructive=True)
+        for name, toolset in [
+            ("approve_payroll", "payrolls"),
+            ("cancel_payment", "payments"),
+            ("refund_payment", "payments"),
+            ("retry_payment", "payments"),
+            ("create_bank_account", "bank_accounts"),
+            ("update_bank_account", "bank_accounts"),
+            ("delete_bank_account", "bank_accounts"),
+            ("delete_payroll", "payrolls"),
+            ("bulk_delete_payroll_items", "payroll_items"),
+        ]:
+            assert tf.is_tool_allowed(name, toolset) is False, name
+
+    def test_payroll_preparation_still_possible(self):
+        """Agents can still prepare a payroll run; they just cannot disburse it."""
+        tf = ToolFilter(exclude_money_movement=True, exclude_destructive=True)
+        for name, toolset in [
+            ("list_companies", "companies"),
+            ("create_payroll", "payrolls"),
+            ("create_payroll_item", "payroll_items"),
+            ("create_contractor_payment", "contractor_payments"),
+            ("create_net_pay_split", "compensation"),
+            ("preview_payroll", "payrolls"),
+        ]:
+            assert tf.is_tool_allowed(name, toolset) is True, name
 
 
 class TestMerge:
@@ -397,10 +513,24 @@ class TestMerge:
         merged = env.merge(header)
         assert merged.tools == frozenset({"list_companies"})
 
-    def test_merge_confirm_destructive_or(self):
-        env = ToolFilter(confirm_destructive=True)
-        header = ToolFilter(confirm_destructive=False)
-        assert env.merge(header).confirm_destructive is True
+    def test_merge_exclude_money_movement_or(self):
+        """A client cannot relax an exclusion the server set."""
+        env = ToolFilter(exclude_money_movement=True)
+        header = ToolFilter(exclude_money_movement=False)
+        assert env.merge(header).exclude_money_movement is True
+
+    def test_merge_exclude_destructive_or(self):
+        env = ToolFilter(exclude_destructive=True)
+        header = ToolFilter(exclude_destructive=False)
+        assert env.merge(header).exclude_destructive is True
+
+    def test_merge_header_can_add_exclusions(self):
+        """A client may tighten beyond the server policy."""
+        env = ToolFilter()
+        header = ToolFilter(exclude_money_movement=True, exclude_destructive=True)
+        merged = env.merge(header)
+        assert merged.exclude_money_movement is True
+        assert merged.exclude_destructive is True
 
     def test_merge_three_way_env_header_query(self):
         """Env, header, and query-param filters combine correctly."""


### PR DESCRIPTION
## Why

Anthropic's directory review blocked our connector on ungated money-movement (§4.A) and irreversible (§4.E) tools. Our first fix used MCP elicitation (#40) and was reverted (#42) after it broke a partner: the hosted Lambda is stateless, so the prompt round-trip hangs, and Cameron has since confirmed in writing that elicitation doesn't render outside Claude Code — plan as if it isn't available.

The agreed direction (Ian, #proj-check-mcp) is to split into two endpoints rather than gate: a directory endpoint with the dangerous tools **absent**, and the existing endpoint unchanged for direct/custom connectors like Miter. §4.A and §4.E are then satisfied by absence, and no written money-movement exception is needed for the listing.

This PR is the code half. The hosted repo gets a second Lambda from the same image with these env vars set (handoff spec going to Sam separately); `/check` is untouched.

## What

**Two flags** (default off — nothing changes for existing deployments):

- `CHECK_EXCLUDE_MONEY_MOVEMENT` → `approve_payroll`, `retry_payment`, `refund_payment`, `cancel_payment`, `create/update/delete_bank_account`
- `CHECK_EXCLUDE_DESTRUCTIVE` → irreversible tools via the existing `is_destructive_tool`

Design notes worth reviewing:

- **Exact names, not prefixes**, for money movement. A `retry_`/`cancel_` prefix rule would catch `retry_webhook_delivery` and read-only `list_payments` while missing that `approve_payroll` is the tool that actually disburses.
- **`is_destructive_tool` is reused unchanged**, not widened — it also feeds the `destructiveHint` annotation that Cameron already verified, so expanding it would silently change annotations.
- **Enforced in `ToolFilter.is_tool_allowed`**, the one predicate every path consults: excluded tools are hidden from `list_tools`/`search_tools` and rejected by `call_tool`/`run_tool` before any HTTP request.
- **Checked before the `tools` allowlist**, so they're a floor; `merge()` ORs them so a client header can tighten but never relax them.
- **Creates stay available** (`create_payroll`, `create_payroll_item`, `create_contractor_payment`, `create_net_pay_split`): with approve and bank tools gone, an agent can prepare a run but cannot disburse it or repoint a destination. This is deliberate — it preserves agent autonomy — and will be stated openly in the resubmission.

**Removes the `CHECK_CONFIRM_DESTRUCTIVE` tier and `run_tool`'s `confirm` param.** A model-set boolean is exactly the mechanism the review rejected; leaving it implies protection that isn't there. It was undocumented and unset in both deployed instances. Only externally visible change: `run_tool`'s schema loses `confirm`.

**Fixes `cli._build_filter`**, which rebuilt `ToolFilter` field-by-field and silently dropped unnamed fields — it was already dropping `confirm_destructive` and would have dropped these flags. Now uses `merge()`.

**Drift guard** (`tests/test_tool_drift.py`): reads each tool's API path from source (or its closure, for factory-generated tools) and fails if a tool mutates `/payments` or `/bank_accounts` without being classified; a companion test fails if a name in the exclusion set stops existing. Verified it actually fires by temporarily adding a fake `initiate_wire_transfer` tool.

## Verification

- 529 tests pass; ruff clean.
- End-to-end over streamable HTTP with both profiles: with the flags, money tools are absent from search and blocked before the HTTP layer while prep tools remain; without them, the same calls reach the API layer. Header cannot re-enable an env-set exclusion; a header-only exclusion does apply.

## Not in this PR

Hosted Terraform (`module "anthropic"`, `extra_env`, Console callback allowlist for the new URL) — handoff spec for Sam. Order matters: merge this, bump the hosted pin, then add the Terraform, so the new endpoint never exists with exclusions silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WF9DwqrNSeJJBRdQvdHFw