### PR TITLE
Remove create/update company group tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **Terms of Service** — By using this MCP server to access the Check API, you agree to the [MCP Usage Terms](TERMS_OF_SERVICE.md), which are in addition to your existing agreement with Check.
 
-An [MCP](https://modelcontextprotocol.io/) server that wraps the [Check Payroll API](https://docs.checkhq.com/), providing 263 tools for managing companies, employees, contractors, payrolls, tax configuration, embedded components, and more.
+An [MCP](https://modelcontextprotocol.io/) server that wraps the [Check Payroll API](https://docs.checkhq.com/), providing 261 tools for managing companies, employees, contractors, payrolls, tax configuration, embedded components, and more.
 
 ## Quickstart
 
@@ -141,7 +141,7 @@ Then set the `CHECK_API_KEY` environment variable in your shell before running C
 
 ## Available Tools
 
-263 tools organized across 17 categories. All list tools support `limit` and `cursor` parameters for cursor-based pagination — pass the `cursor` value from a previous response to fetch the next page.
+261 tools organized across 17 categories. All list tools support `limit` and `cursor` parameters for cursor-based pagination — pass the `cursor` value from a previous response to fetch the next page.
 
 ### Companies (26 tools)
 
@@ -457,7 +457,7 @@ The counterparties Check files and remits to (IRS, state revenue departments). G
 | `get_webhook_delivery` | GET | Get a webhook delivery |
 | `retry_webhook_delivery` | POST | Re-enqueue a webhook delivery (sandbox only) |
 
-### Platform (29 tools)
+### Platform (27 tools)
 
 Notifications, communications, usage, integrations, accounting, company groups, addresses, setups, and requirements.
 
@@ -490,8 +490,6 @@ Notifications, communications, usage, integrations, accounting, company groups, 
 | `list_accounting_sync_attempts` | GET | List accounting sync attempts |
 | **Company Groups** | | |
 | `list_company_groups` | GET | List company groups |
-| `create_company_group` | POST | Create a company group |
-| `update_company_group` | PATCH | Update a company group |
 | **Addresses** | | |
 | `validate_address` | POST | Validate an address |
 | **Setups** | | |

--- a/src/mcp_server_check/tools/platform.py
+++ b/src/mcp_server_check/tools/platform.py
@@ -418,42 +418,6 @@ async def list_company_groups(
     )
 
 
-async def create_company_group(
-    ctx: Ctx,
-    name: str | None = None,
-    companies: list[dict] | None = None,
-) -> dict:
-    """Create a new company group.
-
-    Args:
-        name: Name of the company group.
-        companies: List of company dicts, each with an "id" key (the company ID).
-    """
-    return await check_api_post(
-        ctx, "/company_groups", data=build_body({}, name=name, companies=companies)
-    )
-
-
-async def update_company_group(
-    ctx: Ctx,
-    group_id: str,
-    name: str | None = None,
-    companies: list[dict] | None = None,
-) -> dict:
-    """Update a company group.
-
-    Args:
-        group_id: The company group ID.
-        name: Name of the company group.
-        companies: List of company dicts, each with an "id" key (the company ID).
-    """
-    return await check_api_patch(
-        ctx,
-        f"/company_groups/{group_id}",
-        data=build_body({}, name=name, companies=companies),
-    )
-
-
 # --- Addresses ---
 
 
@@ -609,5 +573,3 @@ def register(mcp: FastMCP, *, read_only: bool = False) -> None:
         add_annotated_tool(mcp, update_accounting_mappings)
         add_annotated_tool(mcp, toggle_accounting_mappings)
         add_annotated_tool(mcp, sync_accounting)
-        add_annotated_tool(mcp, create_company_group)
-        add_annotated_tool(mcp, update_company_group)


### PR DESCRIPTION
## Summary
- Remove `create_company_group` and `update_company_group` tools — the POST/PATCH `/company_groups` endpoints are not part of Check's publicly documented API
- `list_company_groups` remains available
- Update README: drop the two table rows and decrement tool counts (263 → 261, Platform 29 → 27)

## Test plan
- `uv run pytest tests/` — 485 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)